### PR TITLE
feat(sample): map registry cards

### DIFF
--- a/a2a-t-sample/pom.xml
+++ b/a2a-t-sample/pom.xml
@@ -16,6 +16,10 @@
     <description>Publishable Java sample module for a2a-t client and server demo flows.</description>
     <url>https://github.com/project-openan/a2a-t-sdk-java</url>
 
+    <properties>
+        <a2a.java.sdk.version>1.0.0.Beta1</a2a.java.sdk.version>
+    </properties>
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -31,5 +35,102 @@
     </scm>
 
     <dependencies>
+        <dependency>
+            <groupId>net.openan.a2a-t.sdk</groupId>
+            <artifactId>a2a-t-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.openan.a2a-t.sdk</groupId>
+            <artifactId>a2a-t-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client</artifactId>
+            <version>${a2a.java.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
+            <version>${a2a.java.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-server-common</artifactId>
+            <version>${a2a.java.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-transport-rest</artifactId>
+            <version>${a2a.java.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>write-runtime-classpath</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputFile>${project.build.directory}/sample-runtime-classpath.txt</outputFile>
+                            <pathSeparator>${path.separator}</pathSeparator>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>write-sample-java-argfiles</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <loadfile
+                                        property="sample.runtime.classpath"
+                                        srcFile="${project.build.directory}/sample-runtime-classpath.txt" />
+                                <property
+                                        name="sample.jar.path"
+                                        value="${project.build.directory}${file.separator}${project.build.finalName}.jar" />
+                                <echo file="${project.build.directory}/server.javaargs.txt">-cp
+${sample.jar.path}${path.separator}${sample.runtime.classpath}
+net.openan.a2at.sample.server.ServerSampleMain
+server.env
+</echo>
+                                <echo file="${project.build.directory}/client.javaargs.txt">-cp
+${sample.jar.path}${path.separator}${sample.runtime.classpath}
+net.openan.a2at.sample.client.ClientSampleMain
+client.env
+</echo>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/package-info.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Publishable sample module for a2a-t Java client and server demo flows.
+ *
+ * @since 2026-05
+ */
+package net.openan.a2at.sample;
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/SharedSampleMarker.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/SharedSampleMarker.java
@@ -1,0 +1,13 @@
+package net.openan.a2at.sample.shared;
+
+/**
+ * Marker type for shared sample support code.
+ *
+ * @since 2026-05
+ */
+public final class SharedSampleMarker {
+
+    private SharedSampleMarker() {
+    }
+}
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/endpoint/AgentEndpointCache.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/endpoint/AgentEndpointCache.java
@@ -1,0 +1,25 @@
+package net.openan.a2at.sample.shared.endpoint;
+
+import net.openan.a2at.sample.shared.error.ValueErrorException;
+
+/**
+ * Keeps the current resolved endpoint for the active sample run.
+ *
+ * @since 2026-05
+ */
+public final class AgentEndpointCache {
+    private ResolvedAgentEndpoint current;
+
+    public void setResolved(ResolvedAgentEndpoint endpoint) {
+        this.current = endpoint;
+    }
+
+    public ResolvedAgentEndpoint getCurrent() {
+        if (current == null) {
+            throw new ValueErrorException("Agent endpoint cache is empty");
+        }
+        return current;
+    }
+}
+
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/endpoint/AgentEndpointResolver.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/endpoint/AgentEndpointResolver.java
@@ -1,0 +1,56 @@
+package net.openan.a2at.sample.shared.endpoint;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import net.openan.a2at.sample.shared.error.ValueErrorException;
+
+/**
+ * Resolves the preferred HTTP endpoint from a registry AgentCard payload.
+ *
+ * @since 2026-05
+ */
+public final class AgentEndpointResolver {
+
+    private AgentEndpointResolver() {
+    }
+
+    public static ResolvedAgentEndpoint resolvePreferredInterface(Map<String, Object> agentCard) {
+        Object supportedInterfacesValue = agentCard.get("supportedInterfaces");
+        if (!(supportedInterfacesValue instanceof List<?> supportedInterfaces)) {
+            throw new ValueErrorException("AgentCard.supportedInterfaces is required");
+        }
+
+        for (Object item : supportedInterfaces) {
+            if (!(item instanceof Map<?, ?> interfaceMap)) {
+                continue;
+            }
+            String url = stringValue(interfaceMap.get("url"));
+            if (!isValidHttpUrl(url)) {
+                throw new ValueErrorException("Invalid supportedInterfaces url: " + url);
+            }
+            return new ResolvedAgentEndpoint(
+                    stringValue(agentCard.get("name")),
+                    stringValue(interfaceMap.get("protocolBinding")),
+                    stringValue(interfaceMap.get("protocolVersion")),
+                    url);
+        }
+
+        throw new ValueErrorException("No supported HTTP interface found in AgentCard.supportedInterfaces");
+    }
+
+    private static boolean isValidHttpUrl(String url) {
+        try {
+            URI uri = URI.create(url);
+            return ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme())) && uri.getHost() != null;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+}
+
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/endpoint/ResolvedAgentEndpoint.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/endpoint/ResolvedAgentEndpoint.java
@@ -1,0 +1,12 @@
+package net.openan.a2at.sample.shared.endpoint;
+
+/**
+ * Resolved A2A endpoint details extracted from a registry AgentCard payload.
+ *
+ * @since 2026-05
+ */
+public record ResolvedAgentEndpoint(
+        String agentName, String protocolBinding, String protocolVersion, String url) {
+}
+
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/env/SampleEnvironmentPathResolver.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/env/SampleEnvironmentPathResolver.java
@@ -1,0 +1,30 @@
+package net.openan.a2at.sample.shared.env;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Resolves sample environment files using the same primary-then-fallback behavior as the Python samples.
+ *
+ * @since 2026-05
+ */
+public final class SampleEnvironmentPathResolver {
+
+    private SampleEnvironmentPathResolver() {
+    }
+
+    public static Path resolve(Path directory, String primaryFileName, String fallbackFileName) {
+        Path primary = directory.resolve(primaryFileName);
+        if (Files.exists(primary)) {
+            return primary;
+        }
+
+        Path fallback = directory.resolve(fallbackFileName);
+        if (Files.exists(fallback)) {
+            return fallback;
+        }
+        return primary;
+    }
+}
+
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/error/ValueErrorException.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/error/ValueErrorException.java
@@ -1,0 +1,15 @@
+package net.openan.a2at.sample.shared.error;
+
+/**
+ * Stable runtime exception used by the sample support layer for invalid sample inputs.
+ *
+ * @since 2026-05
+ */
+public final class ValueErrorException extends RuntimeException {
+
+    public ValueErrorException(String message) {
+        super(message);
+    }
+}
+
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/logging/SampleLoggingFormatter.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/logging/SampleLoggingFormatter.java
@@ -1,0 +1,112 @@
+package net.openan.a2at.sample.shared.logging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.lang.reflect.Array;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Formatting helpers for sample logs.
+ *
+ * @since 2026-05
+ */
+public final class SampleLoggingFormatter {
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private static final List<String> SECRET_KEYWORDS =
+            List.of("api_key", "authorization", "token", "secret", "password");
+
+    private SampleLoggingFormatter() {
+    }
+
+    public static String formatStageLog(String actor, String stage, String detail) {
+        return timestamp() + " [" + actor + "] " + stage + ": " + detail;
+    }
+
+    public static String formatPayloadLog(String actor, String stage, Object payload) {
+        try {
+            Object normalized = normalizePayload(payload, null);
+            return timestamp() + " [" + actor + "] " + stage + ": " + OBJECT_MAPPER.writeValueAsString(normalized);
+        } catch (Exception exception) {
+            return timestamp() + " [" + actor + "] " + stage + ": <payload-format-error: " + exception.getMessage()
+                    + ">";
+        }
+    }
+
+    private static String timestamp() {
+        return LocalDateTime.now().format(TIMESTAMP_FORMATTER);
+    }
+
+    private static Object normalizePayload(Object value, String keyName) throws Exception {
+        if (keyName != null && isSecretKey(keyName)) {
+            return "***";
+        }
+        if (value == null || value instanceof Boolean || value instanceof Number || value instanceof String) {
+            return value;
+        }
+        if (value instanceof Map<?, ?> mapValue) {
+            Map<String, Object> normalized = new TreeMap<>();
+            for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
+                String childKey = String.valueOf(entry.getKey());
+                normalized.put(childKey, normalizePayload(entry.getValue(), childKey));
+            }
+            return normalized;
+        }
+        if (value instanceof Collection<?> collection) {
+            List<Object> normalized = new ArrayList<>();
+            for (Object item : collection) {
+                normalized.add(normalizePayload(item, null));
+            }
+            return normalized;
+        }
+        if (value.getClass().isArray()) {
+            List<Object> normalized = new ArrayList<>();
+            int length = Array.getLength(value);
+            for (int index = 0; index < length; index++) {
+                normalized.add(normalizePayload(Array.get(value, index), null));
+            }
+            return normalized;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            List<Object> normalized = new ArrayList<>();
+            for (Object item : iterable) {
+                normalized.add(normalizePayload(item, null));
+            }
+            return normalized;
+        }
+        if (value instanceof java.util.Set<?> setValue) {
+            TreeSet<String> normalized = new TreeSet<>();
+            for (Object item : setValue) {
+                normalized.add(String.valueOf(normalizePayload(item, null)));
+            }
+            return normalized;
+        }
+
+        return OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsBytes(value), Object.class);
+    }
+
+    private static boolean isSecretKey(String keyName) {
+        String normalizedKeyName = keyName.toLowerCase(Locale.ROOT);
+        for (String keyword : SECRET_KEYWORDS) {
+            if (normalizedKeyName.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/package-info.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Shared support code for the publishable a2a-t sample module.
+ *
+ * @since 2026-05
+ */
+package net.openan.a2at.sample.shared;
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/registry/RegistryAgentCardMapper.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/registry/RegistryAgentCardMapper.java
@@ -1,0 +1,126 @@
+package net.openan.a2at.sample.shared.registry;
+
+import java.util.List;
+import java.util.Map;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentCapabilities;
+import org.a2aproject.sdk.spec.AgentExtension;
+import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.AgentProvider;
+import org.a2aproject.sdk.spec.AgentSkill;
+
+/**
+ * Maps registry-center AgentCard payloads to and from real a2a-java models.
+ *
+ * @since 2026-05
+ */
+public final class RegistryAgentCardMapper {
+
+    private RegistryAgentCardMapper() {
+    }
+
+    public static AgentCard toA2AJavaAgentCard(Map<String, Object> registryAgentCard) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> provider = (Map<String, Object>) registryAgentCard.get("provider");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> capabilities = (Map<String, Object>) registryAgentCard.get("capabilities");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> extensionMaps = (List<Map<String, Object>>) capabilities.getOrDefault("extensions", List.of());
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> skillMaps = (List<Map<String, Object>>) registryAgentCard.getOrDefault("skills", List.of());
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> interfaceMaps =
+                (List<Map<String, Object>>) registryAgentCard.getOrDefault("supportedInterfaces", List.of());
+        return new AgentCard(
+                stringValue(registryAgentCard.get("name")),
+                stringValue(registryAgentCard.get("description")),
+                provider == null ? null : new AgentProvider(stringValue(provider.get("organization")), stringValue(provider.get("url"))),
+                stringValue(registryAgentCard.get("version")),
+                null,
+                new AgentCapabilities(
+                        Boolean.TRUE.equals(capabilities.get("streaming")),
+                        Boolean.TRUE.equals(capabilities.get("pushNotifications")),
+                        Boolean.TRUE.equals(capabilities.get("extendedAgentCard")),
+                        extensionMaps.stream()
+                                .map(extension -> new AgentExtension(
+                                        stringValue(extension.get("description")),
+                                        Map.of(),
+                                        false,
+                                        stringValue(extension.get("uri"))))
+                                .toList()),
+                stringList(registryAgentCard.get("defaultInputModes")),
+                stringList(registryAgentCard.get("defaultOutputModes")),
+                skillMaps.stream()
+                        .map(skill -> new AgentSkill(
+                                stringValue(skill.get("id")),
+                                stringValue(skill.get("name")),
+                                stringValue(skill.get("description")),
+                                stringList(skill.get("tags")),
+                                List.of(),
+                                List.of(),
+                                List.of(),
+                                List.of()))
+                        .toList(),
+                Map.of(),
+                List.of(),
+                null,
+                interfaceMaps.stream()
+                        .map(serverInterface -> new AgentInterface(
+                                stringValue(serverInterface.get("protocolBinding")),
+                                stringValue(serverInterface.get("url")),
+                                "",
+                                stringValue(serverInterface.get("protocolVersion"))))
+                        .toList(),
+                List.of());
+    }
+
+    public static Map<String, Object> toRegistryRegistrationPayload(AgentCard agentCard) {
+        return Map.of("agentCards", List.of(toRegistryAgentCard(agentCard)));
+    }
+
+    public static Map<String, Object> toRegistryAgentCard(AgentCard agentCard) {
+        return Map.of(
+                "name", agentCard.name(),
+                "description", agentCard.description(),
+                "version", agentCard.version(),
+                "defaultInputModes", agentCard.defaultInputModes(),
+                "defaultOutputModes", agentCard.defaultOutputModes(),
+                "provider", Map.of(
+                        "organization", agentCard.provider().organization(),
+                        "url", agentCard.provider().url()),
+                "skills", agentCard.skills().stream()
+                        .map(skill -> Map.of(
+                                "id", skill.id(),
+                                "name", skill.name(),
+                                "description", skill.description(),
+                                "tags", skill.tags()))
+                        .toList(),
+                "capabilities", Map.of(
+                        "streaming", agentCard.capabilities().streaming(),
+                        "pushNotifications", agentCard.capabilities().pushNotifications(),
+                        "extensions", agentCard.capabilities().extensions().stream()
+                                .map(extension -> Map.of(
+                                        "uri", extension.uri(),
+                                        "description", extension.description()))
+                                .toList()),
+                "supportedInterfaces", agentCard.supportedInterfaces().stream()
+                        .map(agentInterface -> Map.of(
+                                "protocolBinding", agentInterface.protocolBinding(),
+                                "protocolVersion", agentInterface.protocolVersion(),
+                                "url", agentInterface.url()))
+                        .toList());
+    }
+
+    private static List<String> stringList(Object value) {
+        if (value instanceof List<?> values) {
+            return values.stream().map(String::valueOf).toList();
+        }
+        return List.of();
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+}
+
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/scenario/SampleScenarioLoader.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/scenario/SampleScenarioLoader.java
@@ -1,0 +1,34 @@
+package net.openan.a2at.sample.shared.scenario;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import net.openan.a2at.sample.shared.error.ValueErrorException;
+
+/**
+ * Loads static sample scenarios from classpath resources.
+ *
+ * @since 2026-05
+ */
+public final class SampleScenarioLoader {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private SampleScenarioLoader() {
+    }
+
+    public static Map<String, Object> loadClasspathScenario(String resourcePath) {
+        try (InputStream inputStream = SampleScenarioLoader.class.getClassLoader().getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new ValueErrorException("Scenario resource not found: " + resourcePath);
+            }
+            return OBJECT_MAPPER.readValue(inputStream, new TypeReference<>() {
+            });
+        } catch (IOException exception) {
+            throw new ValueErrorException("Unable to load scenario resource: " + resourcePath);
+        }
+    }
+}
+
+

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/stream/SampleStreamEventNormalizer.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/shared/stream/SampleStreamEventNormalizer.java
@@ -1,0 +1,48 @@
+package net.openan.a2at.sample.shared.stream;
+
+import java.util.List;
+import java.util.Map;
+import net.openan.a2at.sample.shared.error.ValueErrorException;
+
+/**
+ * Normalizes raw stream payload fragments into stable sample event shapes.
+ *
+ * @since 2026-05
+ */
+public final class SampleStreamEventNormalizer {
+
+    private SampleStreamEventNormalizer() {
+    }
+
+    public static Map<String, Object> normalize(Map<String, Object> payload) {
+        if (payload == null || payload.isEmpty()) {
+            throw new ValueErrorException("Unsupported SSE payload: " + payload);
+        }
+
+        Object statusValue = payload.get("status");
+        if (statusValue instanceof Map<?, ?> status) {
+            return Map.of("kind", "status", "state", status.get("state"));
+        }
+
+        Object messageValue = payload.get("message");
+        if (messageValue instanceof Map<?, ?> message) {
+            Object partsValue = message.get("parts");
+            if (partsValue instanceof List<?> parts) {
+                for (Object part : parts) {
+                    if (part instanceof Map<?, ?> partMap && partMap.containsKey("text")) {
+                        return Map.of("kind", "message", "text", String.valueOf(partMap.get("text")));
+                    }
+                }
+            }
+            return Map.of("kind", "message", "text", "");
+        }
+
+        if (payload.containsKey("artifact")) {
+            return Map.of("kind", "artifact", "artifact", payload.get("artifact"));
+        }
+
+        throw new ValueErrorException("Unsupported SSE payload: " + payload);
+    }
+}
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${org.apache.version}</version>


### PR DESCRIPTION
## Description

Adds registry card mapping helpers for the a2a-t sample so server metadata can be converted into runtime-friendly agent card data.

## Related Issue(s)

Relates to the a2a-t sample implementation split.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here. -->
