### PR TITLE
refactor: align extension URIs with IG1453 and unify negotiation payload structure

### DIFF
--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
@@ -130,24 +130,23 @@ class A2ATClientTest {
         Map<String, Object> startResult = client.startNegotiation(
                 NegotiationType.CLARIFICATION, "Please clarify the target.", Map.of("site", "A"));
         @SuppressWarnings("unchecked")
-        Map<String, Object> context = (Map<String, Object>)
-                startResult.get(net.openan.a2at.sdk.negotiation.runtime.NegotiationHandler.NEGOTIATION_CONTEXT_KEY);
+        Map<String, Object> startData = (Map<String, Object>)
+                startResult.get(net.openan.a2at.sdk.negotiation.runtime.NegotiationHandler.NEGOTIATION_T_URI_NL);
 
         Map<String, Object> continueResult = client.continueNegotiation(
                 new NegotiationContext(
                         NegotiationType.CLARIFICATION,
-                        String.valueOf(context.get("negotiationId")),
+                        String.valueOf(startData.get("negotiationId")),
                         1,
                         NegotiationStatus.IN_PROGRESS),
                 NegotiationStatus.IN_PROGRESS,
                 "Site A");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> continueData = (Map<String, Object>)
+                continueResult.get(net.openan.a2at.sdk.negotiation.runtime.NegotiationHandler.NEGOTIATION_T_URI_NL);
 
-        assertEquals(
-                "Please clarify the target.",
-                startResult.get(net.openan.a2at.sdk.negotiation.runtime.NegotiationHandler.NEGOTIATION_TEXT_KEY));
-        assertEquals(
-                "Site A",
-                continueResult.get(net.openan.a2at.sdk.negotiation.runtime.NegotiationHandler.NEGOTIATION_TEXT_KEY));
+        assertEquals("Please clarify the target.", startData.get("message"));
+        assertEquals("Site A", continueData.get("message"));
     }
 
     @Test

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/runtime/NegotiationHandler.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/runtime/NegotiationHandler.java
@@ -17,11 +17,17 @@ import net.openan.a2at.sdk.negotiation.types.model.*;
  */
 public final class NegotiationHandler {
 
-    public static final String NEGOTIATION_CONTEXT_KEY =
-            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1";
+    public static final String NEGOTIATION_T_URI_NL =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/NL/v1";
 
-    public static final String NEGOTIATION_TEXT_KEY =
-            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T";
+    public static final String NEGOTIATION_T_URI =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1";
+
+    /**
+     * @deprecated Use {@link #NEGOTIATION_T_URI_NL} instead.
+     */
+    @Deprecated
+    public static final String NEGOTIATION_TEXT_KEY = NEGOTIATION_T_URI_NL;
 
     private final NegotiationRuntime runtime;
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/runtime/helper/NegotiationPayloadMapper.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/runtime/helper/NegotiationPayloadMapper.java
@@ -17,9 +17,12 @@ public final class NegotiationPayloadMapper {
 
     public static Map<String, Object> payload(
             NegotiationContext context, String contentText, Map<String, Object> facts) {
+        Map<String, Object> negotiationData = new LinkedHashMap<>();
+        negotiationData.put("message", contentText);
+        negotiationData.putAll(contextPayload(context));
+
         Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put(NegotiationHandler.NEGOTIATION_TEXT_KEY, contentText);
-        payload.put(NegotiationHandler.NEGOTIATION_CONTEXT_KEY, contextPayload(context));
+        payload.put(NegotiationHandler.NEGOTIATION_T_URI_NL, negotiationData);
         if (!facts.isEmpty()) {
             payload.put("facts", facts);
         }
@@ -36,6 +39,19 @@ public final class NegotiationPayloadMapper {
         payload.put("status", context.status().name().toLowerCase().replace('_', '-'));
         payload.put("extra", Map.of());
         return payload;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> extractContextMap(Map<String, Object> payload) {
+        Object primary = payload.get(NegotiationHandler.NEGOTIATION_T_URI_NL);
+        if (primary instanceof Map<?, ?> data) {
+            return (Map<String, Object>) data;
+        }
+        Object legacy = payload.get(NegotiationHandler.NEGOTIATION_T_URI);
+        if (legacy instanceof Map<?, ?> data) {
+            return (Map<String, Object>) data;
+        }
+        throw new NegotiationStateException("Negotiation-T extension key not found in payload.");
     }
 
     public static NegotiationContext contextFromMap(Map<String, Object> contextMap) {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/runtime/NegotiationHandlerBuilderTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/runtime/NegotiationHandlerBuilderTest.java
@@ -23,7 +23,7 @@ class NegotiationHandlerBuilderTest {
                 .build();
 
         Map<String, Object> startPayload = handler.start(NegotiationType.INFORMATION, "latest prompt", Map.of());
-        Map<String, Object> context = castStringObjectMap(startPayload.get(NegotiationHandler.NEGOTIATION_CONTEXT_KEY));
+        Map<String, Object> context = castStringObjectMap(startPayload.get(NegotiationHandler.NEGOTIATION_T_URI_NL));
         Map<String, Object> result = handler.receive("latest prompt", context);
 
         assertTrue(booleanValue(result.get("needResponse")));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/runtime/NegotiationHandlerTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/runtime/NegotiationHandlerTest.java
@@ -25,10 +25,10 @@ class NegotiationHandlerTest {
                 "Please clarify the request.",
                 Map.of("clarificationItems", new Object[] {"intent"}));
 
-        assertEquals("Please clarify the request.", payload.get(NegotiationHandler.NEGOTIATION_TEXT_KEY));
-        Map<String, Object> context = cast(payload.get(NegotiationHandler.NEGOTIATION_CONTEXT_KEY));
-        assertNotNull(context.get("negotiationId"));
-        assertNotNull(store.get(stringValue(context.get("negotiationId"))));
+        Map<String, Object> negotiationData = cast(payload.get(NegotiationHandler.NEGOTIATION_T_URI_NL));
+        assertEquals("Please clarify the request.", negotiationData.get("message"));
+        assertNotNull(negotiationData.get("negotiationId"));
+        assertNotNull(store.get(stringValue(negotiationData.get("negotiationId"))));
     }
 
     @Test
@@ -38,19 +38,19 @@ class NegotiationHandlerTest {
                 new NegotiationHandler(Map.of(NegotiationType.CLARIFICATION, new ClarificationNegotiation()), store);
         Map<String, Object> startPayload =
                 handler.start(NegotiationType.CLARIFICATION, "Please clarify the request.", Map.of());
-        Map<String, Object> contextMap = cast(startPayload.get(NegotiationHandler.NEGOTIATION_CONTEXT_KEY));
+        Map<String, Object> startData = cast(startPayload.get(NegotiationHandler.NEGOTIATION_T_URI_NL));
         NegotiationContext context = new NegotiationContext(
                 NegotiationType.CLARIFICATION,
-                stringValue(contextMap.get("negotiationId")),
-                numberValue(contextMap.get("round")).intValue(),
+                stringValue(startData.get("negotiationId")),
+                numberValue(startData.get("round")).intValue(),
                 NegotiationStatus.IN_PROGRESS);
 
         Map<String, Object> payload =
                 handler.continueMessage(context, NegotiationStatus.IN_PROGRESS, "Here is the clarification.");
 
-        Map<String, Object> nextContext = cast(payload.get(NegotiationHandler.NEGOTIATION_CONTEXT_KEY));
-        assertEquals(2, numberValue(nextContext.get("round")).intValue());
-        assertEquals("Here is the clarification.", payload.get(NegotiationHandler.NEGOTIATION_TEXT_KEY));
+        Map<String, Object> nextData = cast(payload.get(NegotiationHandler.NEGOTIATION_T_URI_NL));
+        assertEquals(2, numberValue(nextData.get("round")).intValue());
+        assertEquals("Here is the clarification.", nextData.get("message"));
     }
 
     @Test
@@ -59,7 +59,7 @@ class NegotiationHandlerTest {
         NegotiationHandler handler =
                 new NegotiationHandler(Map.of(NegotiationType.CLARIFICATION, new ClarificationNegotiation()), store);
         Map<String, Object> startPayload = handler.start(NegotiationType.CLARIFICATION, "Please clarify", Map.of());
-        Map<String, Object> context = cast(startPayload.get(NegotiationHandler.NEGOTIATION_CONTEXT_KEY));
+        Map<String, Object> context = cast(startPayload.get(NegotiationHandler.NEGOTIATION_T_URI_NL));
 
         Map<String, Object> result = handler.receive("Clarify intent", context);
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/runtime/NegotiationPayloadMapperTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/runtime/NegotiationPayloadMapperTest.java
@@ -30,7 +30,9 @@ class NegotiationPayloadMapperTest {
         Map<String, Object> payload =
                 NegotiationPayloadMapper.payload(context, "latest prompt", Map.of("source", "server"));
 
-        assertEquals("latest prompt", payload.get(NegotiationHandler.NEGOTIATION_TEXT_KEY));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> negotiationData = (Map<String, Object>) payload.get(NegotiationHandler.NEGOTIATION_T_URI_NL);
+        assertEquals("latest prompt", negotiationData.get("message"));
         assertEquals("server", ((Map<?, ?>) payload.get("facts")).get("source"));
     }
 }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/client/flow/ClientSampleFlow.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/client/flow/ClientSampleFlow.java
@@ -25,8 +25,8 @@ import org.a2aproject.sdk.client.ClientEvent;
  * @since 2026-05
  */
 public final class ClientSampleFlow {
-    static final String NOTIFICATION_T_EXTENSION_URI =
-            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1";
+    static final String NOTIFICATION_T_EXTENSION_URI_NL =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/NL/v1";
 
     static final String NATURAL_LANGUAGE_PROMPT_INPUT =
             "通知主题为Incident的，订阅条件为：订阅级别为critical的ETH-LOS的故障，上报通知数据格式为：DataPart";
@@ -59,7 +59,7 @@ public final class ClientSampleFlow {
         String promptText = requirePromptText(promptResult);
 
         BuiltA2AJavaRequest builtRequest = A2AJavaRequestBuilder.buildStreamRequest(
-                promptText, NOTIFICATION_T_EXTENSION_URI, buildRequestMetadata(scenarioPayload));
+                promptText, NOTIFICATION_T_EXTENSION_URI_NL, buildRequestMetadata(scenarioPayload));
         emit(logSink, SampleLoggingFormatter.formatPayloadLog("client", "a2a-request-body", builtRequest.request()));
         emit(logSink, SampleLoggingFormatter.formatPayloadLog("client", "request-headers", builtRequest.callContext().getHeaders()));
         emit(logSink, SampleLoggingFormatter.formatStageLog(

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/server/agentcard/ServerSampleAgentCardBuilder.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/server/agentcard/ServerSampleAgentCardBuilder.java
@@ -9,11 +9,11 @@ import java.util.Map;
  * @since 2026-05
  */
 public final class ServerSampleAgentCardBuilder {
-    static final String TASK_T_EXTENSION_URI =
-            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1";
+    static final String TASK_T_EXTENSION_URI_NL =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/NL/v1";
 
-    static final String NOTIFICATION_T_EXTENSION_URI =
-            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1";
+    static final String NOTIFICATION_T_EXTENSION_URI_NL =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/NL/v1";
 
     private ServerSampleAgentCardBuilder() {
     }
@@ -38,10 +38,10 @@ public final class ServerSampleAgentCardBuilder {
                         "pushNotifications", false,
                         "extensions", List.of(
                                 Map.of(
-                                        "uri", TASK_T_EXTENSION_URI,
+                                        "uri", TASK_T_EXTENSION_URI_NL,
                                         "description", "Extension of structured prompt Task-T requests."),
                                 Map.of(
-                                        "uri", NOTIFICATION_T_EXTENSION_URI,
+                                        "uri", NOTIFICATION_T_EXTENSION_URI_NL,
                                         "description", "Extension of structured prompt Notification-T requests."))),
                 "supportedInterfaces", List.of(Map.of(
                         "protocolBinding", "HTTP+JSON",

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/server/flow/ServerSampleFlow.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/server/flow/ServerSampleFlow.java
@@ -21,6 +21,9 @@ import org.a2aproject.sdk.spec.Part;
  * @since 2026-05
  */
 public final class ServerSampleFlow {
+    static final String NOTIFICATION_T_EXTENSION_URI_NL =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/NL/v1";
+
     static final String NOTIFICATION_T_EXTENSION_URI =
             "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1";
 
@@ -108,7 +111,9 @@ public final class ServerSampleFlow {
         Map<String, String> headers = extractHeaders(callContext);
         String modernValue = headers.get("A2A-Extensions");
         String legacyValue = headers.get("X-A2A-Extensions");
-        if (!NOTIFICATION_T_EXTENSION_URI.equals(modernValue) && !NOTIFICATION_T_EXTENSION_URI.equals(legacyValue)) {
+        String extensionValue = modernValue != null ? modernValue : legacyValue;
+        if (!NOTIFICATION_T_EXTENSION_URI_NL.equals(extensionValue)
+                && !NOTIFICATION_T_EXTENSION_URI.equals(extensionValue)) {
             throw new ValueErrorException("a2a client extensions is not exist.");
         }
     }
@@ -118,7 +123,11 @@ public final class ServerSampleFlow {
         if (message == null || message.metadata() == null) {
             throw new ValueErrorException("Expected message metadata for Notification-T prompt");
         }
-        return stringValue(message.metadata().get(NOTIFICATION_T_EXTENSION_URI));
+        String promptText = stringValue(message.metadata().get(NOTIFICATION_T_EXTENSION_URI_NL));
+        if (promptText.isEmpty()) {
+            promptText = stringValue(message.metadata().get(NOTIFICATION_T_EXTENSION_URI));
+        }
+        return promptText;
     }
 
     @SuppressWarnings("unchecked")

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/assembly/ServerNegotiationOrchestratorBuilderTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/assembly/ServerNegotiationOrchestratorBuilderTest.java
@@ -30,7 +30,7 @@ class ServerNegotiationOrchestratorBuilderTest {
 
         Map<String, Object> started =
                 orchestrator.startNegotiation(NegotiationType.INFORMATION, "Need full task prompt.", Map.of());
-        Map<String, Object> context = cast(started.get(NegotiationHandler.NEGOTIATION_CONTEXT_KEY));
+        Map<String, Object> context = cast(started.get(NegotiationHandler.NEGOTIATION_T_URI_NL));
 
         Map<String, Object> received = orchestrator.receiveNegotiation("latest full task prompt", context);
 
@@ -48,7 +48,7 @@ class ServerNegotiationOrchestratorBuilderTest {
 
         Map<String, Object> result = orchestrator.startNegotiation(
                 NegotiationType.CLARIFICATION, "Please clarify the target.", Map.of("site", "A"));
-        Map<String, Object> context = cast(result.get(NegotiationHandler.NEGOTIATION_CONTEXT_KEY));
+        Map<String, Object> context = cast(result.get(NegotiationHandler.NEGOTIATION_T_URI_NL));
 
         assertEquals("clarification", context.get("negotiationType"));
         assertEquals("in-progress", context.get("status"));


### PR DESCRIPTION
Closes #75

Align extension URIs with IG1453 specification and restructure negotiation payload.

## Changes
- Remove DATA-NEGOTIATION-T extension (not in IG1453 spec)
- URI alignment: Negotiation-T/NL/v1, Task-T/NL/v1, Notification-T/NL/v1
- Add backward-compatible non-NL URI constants
- Merge negotiation context into single Negotiation-T payload key
- Update all tests to use new payload structure