### PR TITLE
Add 6 new FromText/FromDataWithSchema API methods with MetadataContent return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ target/
 *target/
 .gitignore
 .flattened-pom.xml
+*.env
+reference/
+findings.md
+progress.md
+task_plan.md
+
+.idea/

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
@@ -2,6 +2,7 @@ package net.openan.a2at.sdk.client;
 
 import java.nio.file.Path;
 import java.util.Map;
+import net.openan.a2at.sdk.client.model.MetadataContent;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 import net.openan.a2at.sdk.client.prompt.assembly.DefaultA2ATClientBuilder;
 import net.openan.a2at.sdk.client.prompt.orchestration.ClientPromptGenerationOrchestrator;
@@ -46,6 +47,159 @@ public final class A2ATClient {
      */
     public PromptGenerationResult generateTaskPrompt(Object userInput) {
         return promptGenerationOrchestrator.generateTaskPrompt(userInput);
+    }
+
+    /**
+     * Generates a processed task prompt from natural-language input using the template identified by the template URI,
+     * bypassing scenario recognition.
+     *
+     * @param taskInputNl natural-language task input
+     * @param promptTemplateUri template URI identifying the target template
+     * @return prompt generation result containing either rendered prompt text or failure details
+     */
+    public PromptGenerationResult generateTaskPromptFromNl(String taskInputNl, String promptTemplateUri) {
+        return promptGenerationOrchestrator.generateTaskPromptFromNl(taskInputNl, promptTemplateUri);
+    }
+
+    /**
+     * Generates a processed task prompt from structured input using the template identified by the template URI,
+     * bypassing scenario recognition.
+     *
+     * @param taskInputJsonData structured task input as a string-to-object map
+     * @param promptTemplateUri template URI identifying the target template
+     * @return prompt generation result containing either rendered prompt text or failure details
+     */
+    public PromptGenerationResult generateTaskPromptFromJsonData(
+            Map<String, Object> taskInputJsonData, String promptTemplateUri) {
+        return promptGenerationOrchestrator.generateTaskPromptFromJsonData(taskInputJsonData, promptTemplateUri);
+    }
+
+    /**
+     * Generates an authorization prompt from natural-language input using the template identified by the authorization
+     * type, bypassing scenario recognition.
+     *
+     * @param inputNl natural-language authorization input
+     * @param authorizationType authorization type used as the template identifier
+     * @return prompt generation result containing either rendered prompt text or failure details
+     */
+    public PromptGenerationResult generateAuthorizationPromptFromNl(String inputNl, String authorizationType) {
+        return promptGenerationOrchestrator.generateAuthorizationPromptFromNl(inputNl, authorizationType);
+    }
+
+    /**
+     * Generates an authorization prompt from structured input using the template identified by the authorization type,
+     * bypassing scenario recognition.
+     *
+     * @param inputJsonData structured authorization input as a string-to-object map
+     * @param authorizationType authorization type used as the template identifier
+     * @return prompt generation result containing either rendered prompt text or failure details
+     */
+    public PromptGenerationResult generateAuthorizationPromptFromJsonData(
+            Map<String, Object> inputJsonData, String authorizationType) {
+        return promptGenerationOrchestrator.generateAuthorizationPromptFromJsonData(inputJsonData, authorizationType);
+    }
+
+    /**
+     * Generates a notification prompt from natural-language input using the template identified by the template URI,
+     * bypassing scenario recognition.
+     *
+     * @param inputNl natural-language notification input
+     * @param promptTemplateUri template URI identifying the target template
+     * @return prompt generation result containing either rendered prompt text or failure details
+     */
+    public PromptGenerationResult generateNotificationPromptFromNl(String inputNl, String promptTemplateUri) {
+        return promptGenerationOrchestrator.generateNotificationPromptFromNl(inputNl, promptTemplateUri);
+    }
+
+    /**
+     * Generates a notification prompt from structured input using the template identified by the template URI,
+     * bypassing scenario recognition.
+     *
+     * @param inputJsonData structured notification input as a string-to-object map
+     * @param promptTemplateUri template URI identifying the target template
+     * @return prompt generation result containing either rendered prompt text or failure details
+     */
+    public PromptGenerationResult generateNotificationPromptFromJsonData(
+            Map<String, Object> inputJsonData, String promptTemplateUri) {
+        return promptGenerationOrchestrator.generateNotificationPromptFromJsonData(inputJsonData, promptTemplateUri);
+    }
+
+    /**
+     * Generates a task prompt with metadata from natural-language input using the template identified by the template
+     * URI, bypassing scenario recognition.
+     *
+     * @param text natural-language task input
+     * @param templateUri template URI identifying the target template
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    public MetadataContent generateTaskPromptFromText(String text, String templateUri) {
+        return promptGenerationOrchestrator.generateTaskPromptFromText(text, templateUri);
+    }
+
+    /**
+     * Generates a task prompt with metadata from structured input and an optional data schema using the template
+     * identified by the template URI, bypassing scenario recognition.
+     *
+     * @param data structured task input as a string-to-object map
+     * @param schema optional data schema map for schema-guided extraction
+     * @param templateUri template URI identifying the target template
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    public MetadataContent generateTaskPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String templateUri) {
+        return promptGenerationOrchestrator.generateTaskPromptFromDataWithSchema(data, schema, templateUri);
+    }
+
+    /**
+     * Generates an authorization prompt with metadata from natural-language input using the template identified by the
+     * authorization type, bypassing scenario recognition.
+     *
+     * @param text natural-language authorization input
+     * @param authorizationType authorization type used as the template identifier
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    public MetadataContent generateAuthPromptFromText(String text, String authorizationType) {
+        return promptGenerationOrchestrator.generateAuthPromptFromText(text, authorizationType);
+    }
+
+    /**
+     * Generates an authorization prompt with metadata from structured input and an optional data schema using the
+     * template identified by the authorization type, bypassing scenario recognition.
+     *
+     * @param data structured authorization input as a string-to-object map
+     * @param schema optional data schema map for schema-guided extraction
+     * @param authorizationType authorization type used as the template identifier
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    public MetadataContent generateAuthPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String authorizationType) {
+        return promptGenerationOrchestrator.generateAuthPromptFromDataWithSchema(data, schema, authorizationType);
+    }
+
+    /**
+     * Generates a notification prompt with metadata from natural-language input using the template identified by the
+     * template URI, bypassing scenario recognition.
+     *
+     * @param text natural-language notification input
+     * @param templateUri template URI identifying the target template
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    public MetadataContent generateNotificationPromptFromText(String text, String templateUri) {
+        return promptGenerationOrchestrator.generateNotificationPromptFromText(text, templateUri);
+    }
+
+    /**
+     * Generates a notification prompt with metadata from structured input and an optional data schema using the
+     * template identified by the template URI, bypassing scenario recognition.
+     *
+     * @param data structured notification input as a string-to-object map
+     * @param schema optional data schema map for schema-guided extraction
+     * @param templateUri template URI identifying the target template
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    public MetadataContent generateNotificationPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String templateUri) {
+        return promptGenerationOrchestrator.generateNotificationPromptFromDataWithSchema(data, schema, templateUri);
     }
 
     /**

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/model/MetadataContent.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/model/MetadataContent.java
@@ -1,0 +1,31 @@
+package net.openan.a2at.sdk.client.model;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Metadata content used in A2A-T prompt generation.
+ *
+ * @param templateUri URI of the template
+ * @param promptText rendered prompt text
+ * @param extensionUri URI of the extension
+ * @since 2026-08
+ */
+public record MetadataContent(String templateUri, String promptText, String extensionUri) {
+
+    public MetadataContent {
+        Objects.requireNonNull(templateUri, "templateUri");
+        Objects.requireNonNull(promptText, "promptText");
+        Objects.requireNonNull(extensionUri, "extensionUri");
+    }
+
+    /**
+     * Builds a metadata map keyed by the extension URI and template URI.
+     *
+     * @return metadata map containing the prompt text under the extension URI key and the template URI under the
+     *         {@code template_uri} key
+     */
+    public Map<String, String> buildMetadataContent() {
+        return Map.of(extensionUri, promptText, "template_uri", templateUri);
+    }
+}

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/model/MetadataContent.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/model/MetadataContent.java
@@ -1,7 +1,6 @@
 package net.openan.a2at.sdk.client.model;
 
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Metadata content used in A2A-T prompt generation.
@@ -13,19 +12,16 @@ import java.util.Objects;
  */
 public record MetadataContent(String templateUri, String promptText, String extensionUri) {
 
-    public MetadataContent {
-        Objects.requireNonNull(templateUri, "templateUri");
-        Objects.requireNonNull(promptText, "promptText");
-        Objects.requireNonNull(extensionUri, "extensionUri");
-    }
-
     /**
      * Builds a metadata map keyed by the extension URI and template URI.
      *
      * @return metadata map containing the prompt text under the extension URI key and the template URI under the
-     *         {@code template_uri} key
+     *         {@code template_uri} key, or {@code null} if any field is null
      */
     public Map<String, String> buildMetadataContent() {
+        if (extensionUri == null || promptText == null || templateUri == null) {
+            return null;
+        }
         return Map.of(extensionUri, promptText, "template_uri", templateUri);
     }
 }

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilder.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilder.java
@@ -290,5 +290,12 @@ public final class DefaultA2ATClientBuilder {
             }
             return llmExtractor.extractSlots(userInput, scenarioCode, language, templateText);
         }
+
+        @Override
+        public Map<String, String> extractSlotsWithSchema(
+                Object userInput, String scenarioCode, String language, String templateText,
+                Map<String, Object> dataSchema) {
+            return llmExtractor.extractSlotsWithSchema(userInput, scenarioCode, language, templateText, dataSchema);
+        }
     }
 }

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/extractor/ClientSlotValueExtractor.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/extractor/ClientSlotValueExtractor.java
@@ -20,4 +20,20 @@ public interface ClientSlotValueExtractor {
      * @return normalized slot values keyed by slot name
      */
     Map<String, String> extractSlots(Object userInput, String scenarioCode, String language, String templateText);
+
+    /**
+     * Extracts normalized slot values with an optional data schema for schema-guided extraction.
+     *
+     * @param userInput user-provided task description or structured input object
+     * @param scenarioCode scenario code currently being rendered
+     * @param language locale identifier of the backing resources
+     * @param templateText resolved task template text
+     * @param dataSchema optional data schema map (field name to description)
+     * @return normalized slot values keyed by slot name
+     */
+    default Map<String, String> extractSlotsWithSchema(
+            Object userInput, String scenarioCode, String language, String templateText,
+            Map<String, Object> dataSchema) {
+        return extractSlots(userInput, scenarioCode, language, templateText);
+    }
 }

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultStructuredClientSlotValueExtractor.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultStructuredClientSlotValueExtractor.java
@@ -39,4 +39,12 @@ public final class DefaultStructuredClientSlotValueExtractor implements ClientSl
         StructuredSlotExtractionResult result = delegate.extractSlots(userInput, scenarioCode, language);
         return new LinkedHashMap<>(result.slots());
     }
+
+    @Override
+    public Map<String, String> extractSlotsWithSchema(
+            Object userInput, String scenarioCode, String language, String templateText,
+            Map<String, Object> dataSchema) {
+        StructuredSlotExtractionResult result = delegate.extractSlots(userInput, scenarioCode, language, dataSchema);
+        return new LinkedHashMap<>(result.slots());
+    }
 }

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/ClientPromptGenerationOrchestrator.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/ClientPromptGenerationOrchestrator.java
@@ -1,5 +1,7 @@
 package net.openan.a2at.sdk.client.prompt.orchestration;
 
+import java.util.Map;
+import net.openan.a2at.sdk.client.model.MetadataContent;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 
 /**
@@ -16,4 +18,128 @@ public interface ClientPromptGenerationOrchestrator {
      * @return prompt-generation result
      */
     PromptGenerationResult generateTaskPrompt(Object userInput);
+
+    /**
+     * Generates a processed task prompt from natural-language input using the template identified by the template URI.
+     *
+     * @param taskInputNl natural-language task input
+     * @param promptTemplateUri template URI identifying the target template
+     * @return prompt-generation result
+     */
+    PromptGenerationResult generateTaskPromptFromNl(String taskInputNl, String promptTemplateUri);
+
+    /**
+     * Generates a processed task prompt from structured input using the template identified by the template URI.
+     *
+     * @param taskInputJsonData structured task input as a string-to-object map
+     * @param promptTemplateUri template URI identifying the target template
+     * @return prompt-generation result
+     */
+    PromptGenerationResult generateTaskPromptFromJsonData(
+            Map<String, Object> taskInputJsonData, String promptTemplateUri);
+
+    /**
+     * Generates an authorization prompt from natural-language input using the template identified by the authorization
+     * type.
+     *
+     * @param inputNl natural-language authorization input
+     * @param authorizationType authorization type used as the template identifier
+     * @return prompt-generation result
+     */
+    PromptGenerationResult generateAuthorizationPromptFromNl(String inputNl, String authorizationType);
+
+    /**
+     * Generates an authorization prompt from structured input using the template identified by the authorization type.
+     *
+     * @param inputJsonData structured authorization input as a string-to-object map
+     * @param authorizationType authorization type used as the template identifier
+     * @return prompt-generation result
+     */
+    PromptGenerationResult generateAuthorizationPromptFromJsonData(
+            Map<String, Object> inputJsonData, String authorizationType);
+
+    /**
+     * Generates a notification prompt from natural-language input using the template identified by the template URI.
+     *
+     * @param inputNl natural-language notification input
+     * @param promptTemplateUri template URI identifying the target template
+     * @return prompt-generation result
+     */
+    PromptGenerationResult generateNotificationPromptFromNl(String inputNl, String promptTemplateUri);
+
+    /**
+     * Generates a notification prompt from structured input using the template identified by the template URI.
+     *
+     * @param inputJsonData structured notification input as a string-to-object map
+     * @param promptTemplateUri template URI identifying the target template
+     * @return prompt-generation result
+     */
+    PromptGenerationResult generateNotificationPromptFromJsonData(
+            Map<String, Object> inputJsonData, String promptTemplateUri);
+
+    /**
+     * Generates a task prompt with metadata from natural-language input using the template identified by the template
+     * URI, bypassing scenario recognition.
+     *
+     * @param text natural-language task input
+     * @param templateUri template URI identifying the target template
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    MetadataContent generateTaskPromptFromText(String text, String templateUri);
+
+    /**
+     * Generates a task prompt with metadata from structured input and an optional data schema using the template
+     * identified by the template URI, bypassing scenario recognition.
+     *
+     * @param data structured task input as a string-to-object map
+     * @param schema optional data schema map for schema-guided extraction
+     * @param templateUri template URI identifying the target template
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    MetadataContent generateTaskPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String templateUri);
+
+    /**
+     * Generates an authorization prompt with metadata from natural-language input using the template identified by the
+     * authorization type, bypassing scenario recognition.
+     *
+     * @param text natural-language authorization input
+     * @param authorizationType authorization type used as the template identifier
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    MetadataContent generateAuthPromptFromText(String text, String authorizationType);
+
+    /**
+     * Generates an authorization prompt with metadata from structured input and an optional data schema using the
+     * template identified by the authorization type, bypassing scenario recognition.
+     *
+     * @param data structured authorization input as a string-to-object map
+     * @param schema optional data schema map for schema-guided extraction
+     * @param authorizationType authorization type used as the template identifier
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    MetadataContent generateAuthPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String authorizationType);
+
+    /**
+     * Generates a notification prompt with metadata from natural-language input using the template identified by the
+     * template URI, bypassing scenario recognition.
+     *
+     * @param text natural-language notification input
+     * @param templateUri template URI identifying the target template
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    MetadataContent generateNotificationPromptFromText(String text, String templateUri);
+
+    /**
+     * Generates a notification prompt with metadata from structured input and an optional data schema using the
+     * template identified by the template URI, bypassing scenario recognition.
+     *
+     * @param data structured notification input as a string-to-object map
+     * @param schema optional data schema map for schema-guided extraction
+     * @param templateUri template URI identifying the target template
+     * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     */
+    MetadataContent generateNotificationPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String templateUri);
 }

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestrator.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestrator.java
@@ -2,12 +2,15 @@ package net.openan.a2at.sdk.client.prompt.orchestration;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import net.openan.a2at.sdk.client.model.MetadataContent;
 import net.openan.a2at.sdk.client.model.PromptGenerationFailure;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 import net.openan.a2at.sdk.client.prompt.extractor.ClientSlotValueExtractor;
 import net.openan.a2at.sdk.client.prompt.loader.ClientTemplateLoader;
 import net.openan.a2at.sdk.client.prompt.recognition.ClientScenarioRecognizer;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
+import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
 import net.openan.a2at.sdk.prompt.analysis.model.ScenarioRecognitionResult;
 import net.openan.a2at.sdk.prompt.resources.model.ScenarioDefinition;
 import net.openan.a2at.sdk.prompt.taskrendering.api.TaskPromptRenderer;
@@ -19,6 +22,8 @@ import net.openan.a2at.sdk.prompt.taskrendering.exception.TaskPromptRenderExcept
  * @since 2026-06
  */
 public final class DefaultClientPromptGenerationOrchestrator implements ClientPromptGenerationOrchestrator {
+
+    private static final Pattern TEMPLATE_IDENTIFIER_PATTERN = Pattern.compile("[a-zA-Z0-9_-]+");
 
     private final ClientScenarioRecognizer scenarioRecognizer;
 
@@ -107,6 +112,135 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
             return PromptGenerationResult.failure(
                     new PromptGenerationFailure("render_failed", error.getMessage(), "generation"));
         }
+    }
+
+    @Override
+    public PromptGenerationResult generateTaskPromptFromNl(String taskInputNl, String promptTemplateUri) {
+        return generateFromTemplateUri(taskInputNl, promptTemplateUri);
+    }
+
+    @Override
+    public PromptGenerationResult generateTaskPromptFromJsonData(
+            Map<String, Object> taskInputJsonData, String promptTemplateUri) {
+        return generateFromTemplateUri(taskInputJsonData, promptTemplateUri);
+    }
+
+    @Override
+    public PromptGenerationResult generateAuthorizationPromptFromNl(String inputNl, String authorizationType) {
+        return generateFromTemplateUri(inputNl, authorizationType);
+    }
+
+    @Override
+    public PromptGenerationResult generateAuthorizationPromptFromJsonData(
+            Map<String, Object> inputJsonData, String authorizationType) {
+        return generateFromTemplateUri(inputJsonData, authorizationType);
+    }
+
+    @Override
+    public PromptGenerationResult generateNotificationPromptFromNl(String inputNl, String promptTemplateUri) {
+        return generateFromTemplateUri(inputNl, promptTemplateUri);
+    }
+
+    @Override
+    public PromptGenerationResult generateNotificationPromptFromJsonData(
+            Map<String, Object> inputJsonData, String promptTemplateUri) {
+        return generateFromTemplateUri(inputJsonData, promptTemplateUri);
+    }
+
+    private PromptGenerationResult generateFromTemplateUri(Object userInput, String templateIdentifier) {
+        if (templateIdentifier == null
+                || templateIdentifier.isBlank()
+                || !TEMPLATE_IDENTIFIER_PATTERN.matcher(templateIdentifier).matches()) {
+            return PromptGenerationResult.failure(new PromptGenerationFailure(
+                    "invalid_template_uri",
+                    "Template URI is null, blank, or contains invalid characters.",
+                    "generation"));
+        }
+
+        final String templateText;
+        try {
+            templateText = templateLoader.loadTemplate(templateIdentifier, language);
+        } catch (ResourceNotFoundException error) {
+            return PromptGenerationResult.failure(
+                    new PromptGenerationFailure("template_not_found", error.getMessage(), "generation"));
+        }
+
+        try {
+            Map<String, String> slots =
+                    slotValueExtractor.extractSlots(userInput, templateIdentifier, language, templateText);
+            String renderedPrompt = renderer.render(templateText, slots);
+            return PromptGenerationResult.success(renderedPrompt);
+        } catch (TaskPromptRenderException error) {
+            return PromptGenerationResult.failure(
+                    new PromptGenerationFailure("render_failed", error.getMessage(), "generation"));
+        }
+    }
+
+    @Override
+    public MetadataContent generateTaskPromptFromText(String text, String templateUri) {
+        return generateFromTemplateUriWithMetadata(text, templateUri, ExtensionUriConstants.TASK_T_EXTENSION_URI);
+    }
+
+    @Override
+    public MetadataContent generateTaskPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String templateUri) {
+        return generateFromDataWithSchema(data, schema, templateUri, ExtensionUriConstants.TASK_T_EXTENSION_URI);
+    }
+
+    @Override
+    public MetadataContent generateAuthPromptFromText(String text, String authorizationType) {
+        return generateFromTemplateUriWithMetadata(
+                text, authorizationType, ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI);
+    }
+
+    @Override
+    public MetadataContent generateAuthPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String authorizationType) {
+        return generateFromDataWithSchema(
+                data, schema, authorizationType, ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI);
+    }
+
+    @Override
+    public MetadataContent generateNotificationPromptFromText(String text, String templateUri) {
+        return generateFromTemplateUriWithMetadata(
+                text, templateUri, ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI);
+    }
+
+    @Override
+    public MetadataContent generateNotificationPromptFromDataWithSchema(
+            Map<String, Object> data, Map<String, Object> schema, String templateUri) {
+        return generateFromDataWithSchema(data, schema, templateUri, ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI);
+    }
+
+    private MetadataContent generateFromTemplateUriWithMetadata(
+            String userInput, String templateIdentifier, String extensionUri) {
+        if (templateIdentifier == null
+                || templateIdentifier.isBlank()
+                || !TEMPLATE_IDENTIFIER_PATTERN.matcher(templateIdentifier).matches()) {
+            throw new IllegalArgumentException("Template URI is null, blank, or contains invalid characters.");
+        }
+        String templateText = templateLoader.loadTemplate(templateIdentifier, language);
+        Map<String, String> slots =
+                slotValueExtractor.extractSlots(userInput, templateIdentifier, language, templateText);
+        String renderedPrompt = renderer.render(templateText, slots);
+        return new MetadataContent(templateIdentifier, renderedPrompt, extensionUri);
+    }
+
+    private MetadataContent generateFromDataWithSchema(
+            Map<String, Object> data,
+            Map<String, Object> schema,
+            String templateIdentifier,
+            String extensionUri) {
+        if (templateIdentifier == null
+                || templateIdentifier.isBlank()
+                || !TEMPLATE_IDENTIFIER_PATTERN.matcher(templateIdentifier).matches()) {
+            throw new IllegalArgumentException("Template URI is null, blank, or contains invalid characters.");
+        }
+        String templateText = templateLoader.loadTemplate(templateIdentifier, language);
+        Map<String, String> slots =
+                slotValueExtractor.extractSlotsWithSchema(data, templateIdentifier, language, templateText, schema);
+        String renderedPrompt = renderer.render(templateText, slots);
+        return new MetadataContent(templateIdentifier, renderedPrompt, extensionUri);
     }
 
     String lastNormalizedInput() {

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
@@ -1,6 +1,7 @@
 package net.openan.a2at.sdk.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,8 +11,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Map;
+import net.openan.a2at.sdk.client.model.MetadataContent;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 import net.openan.a2at.sdk.client.prompt.orchestration.ClientPromptGenerationOrchestrator;
+import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
 import net.openan.a2at.sdk.negotiation.types.model.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.types.model.NegotiationStatus;
 import net.openan.a2at.sdk.negotiation.types.model.NegotiationType;
@@ -127,8 +130,8 @@ class A2ATClientTest {
         Path envFile = writeMinimalLocalClientEnv();
         A2ATClient client = new A2ATClient(envFile);
 
-        Map<String, Object> startResult = client.startNegotiation(
-                NegotiationType.TARGET, "Please clarify the target.", Map.of("site", "A"));
+        Map<String, Object> startResult =
+                client.startNegotiation(NegotiationType.TARGET, "Please clarify the target.", Map.of("site", "A"));
         @SuppressWarnings("unchecked")
         Map<String, Object> startData = (Map<String, Object>)
                 startResult.get(net.openan.a2at.sdk.negotiation.runtime.NegotiationHandler.NEGOTIATION_T_URI_NL);
@@ -211,6 +214,245 @@ class A2ATClientTest {
 
         assertTrue(result.success());
         assertEquals("Line: line-1\\nFault: fault-9", result.promptText());
+    }
+
+    @Test
+    void templateUriEntryPointsGeneratePromptsFromStructuredInput() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+        Map<String, Object> inputData = Map.of("site", "Site A", "target", "Reduce power by 10%");
+
+        PromptGenerationResult taskResult = client.generateTaskPromptFromJsonData(inputData, "energy_saving");
+        PromptGenerationResult authorizationResult =
+                client.generateAuthorizationPromptFromJsonData(inputData, "energy_saving");
+        PromptGenerationResult notificationResult =
+                client.generateNotificationPromptFromJsonData(inputData, "energy_saving");
+
+        assertTrue(taskResult.success());
+        assertTrue(authorizationResult.success());
+        assertTrue(notificationResult.success());
+        assertEquals("Site: Site A\\nTarget: Reduce power by 10%", taskResult.promptText());
+        assertEquals("Site: Site A\\nTarget: Reduce power by 10%", authorizationResult.promptText());
+        assertEquals("Site: Site A\\nTarget: Reduce power by 10%", notificationResult.promptText());
+    }
+
+    @Test
+    void templateUriEntryPointRendersEmptySlotValuesForNlInputUnderLocalRuleProvider() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        PromptGenerationResult result =
+                client.generateTaskPromptFromNl("Please analyze Site A power usage.", "energy_saving");
+
+        assertTrue(result.success());
+        assertEquals("Site: \\nTarget: ", result.promptText());
+    }
+
+    @Test
+    void templateUriEntryPointsReturnFailuresForInvalidAndUnknownIdentifiers() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        PromptGenerationResult invalidResult =
+                client.generateTaskPromptFromJsonData(Map.of("site", "Site A"), "../etc/passwd");
+        PromptGenerationResult unknownResult =
+                client.generateNotificationPromptFromNl("Report finished.", "no_such_template");
+
+        assertFalse(invalidResult.success());
+        assertNotNull(invalidResult.failure());
+        assertEquals("invalid_template_uri", invalidResult.failure().code());
+        assertEquals("generation", invalidResult.failure().stage());
+        assertFalse(unknownResult.success());
+        assertNotNull(unknownResult.failure());
+        assertEquals("template_not_found", unknownResult.failure().code());
+        assertEquals("generation", unknownResult.failure().stage());
+    }
+
+    @Test
+    void fromTextEntryPointsReturnMetadataContent() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        MetadataContent taskResult =
+                client.generateTaskPromptFromText("Please analyze Site A.", "energy_saving");
+        MetadataContent authResult =
+                client.generateAuthPromptFromText("Authorize access.", "energy_saving");
+        MetadataContent notificationResult =
+                client.generateNotificationPromptFromText("Report finished.", "energy_saving");
+
+        assertNotNull(taskResult);
+        assertEquals("energy_saving", taskResult.templateUri());
+        assertNotNull(taskResult.promptText());
+        assertNotNull(taskResult.extensionUri());
+
+        assertNotNull(authResult);
+        assertEquals("energy_saving", authResult.templateUri());
+        assertNotNull(authResult.promptText());
+        assertNotNull(authResult.extensionUri());
+
+        assertNotNull(notificationResult);
+        assertEquals("energy_saving", notificationResult.templateUri());
+        assertNotNull(notificationResult.promptText());
+        assertNotNull(notificationResult.extensionUri());
+    }
+
+    @Test
+    void fromDataWithSchemaEntryPointsReturnMetadataContent() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+        Map<String, Object> data = Map.of("site", "Site A", "target", "Reduce power by 10%");
+        Map<String, Object> schema = Map.of("type", "object");
+
+        MetadataContent taskResult =
+                client.generateTaskPromptFromDataWithSchema(data, schema, "energy_saving");
+        MetadataContent authResult =
+                client.generateAuthPromptFromDataWithSchema(data, schema, "energy_saving");
+        MetadataContent notificationResult =
+                client.generateNotificationPromptFromDataWithSchema(data, schema, "energy_saving");
+
+        assertNotNull(taskResult);
+        assertEquals("energy_saving", taskResult.templateUri());
+        assertNotNull(taskResult.promptText());
+        assertNotNull(taskResult.extensionUri());
+
+        assertNotNull(authResult);
+        assertEquals("energy_saving", authResult.templateUri());
+        assertNotNull(authResult.promptText());
+        assertNotNull(authResult.extensionUri());
+
+        assertNotNull(notificationResult);
+        assertEquals("energy_saving", notificationResult.templateUri());
+        assertNotNull(notificationResult.promptText());
+        assertNotNull(notificationResult.extensionUri());
+    }
+
+    @Test
+    void fromTextReturnsCorrectExtensionUriPerContentType() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        MetadataContent taskResult =
+                client.generateTaskPromptFromText("Please analyze Site A.", "energy_saving");
+        MetadataContent authResult =
+                client.generateAuthPromptFromText("Authorize access.", "energy_saving");
+        MetadataContent notificationResult =
+                client.generateNotificationPromptFromText("Report finished.", "energy_saving");
+
+        assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskResult.extensionUri());
+        assertEquals(ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI, authResult.extensionUri());
+        assertEquals(ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI, notificationResult.extensionUri());
+    }
+
+    @Test
+    void fromDataWithSchemaReturnsCorrectExtensionUriPerContentType() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+        Map<String, Object> data = Map.of("site", "Site A", "target", "Reduce power by 10%");
+        Map<String, Object> schema = Map.of("type", "object");
+
+        MetadataContent taskResult =
+                client.generateTaskPromptFromDataWithSchema(data, schema, "energy_saving");
+        MetadataContent authResult =
+                client.generateAuthPromptFromDataWithSchema(data, schema, "energy_saving");
+        MetadataContent notificationResult =
+                client.generateNotificationPromptFromDataWithSchema(data, schema, "energy_saving");
+
+        assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskResult.extensionUri());
+        assertEquals(ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI, authResult.extensionUri());
+        assertEquals(ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI, notificationResult.extensionUri());
+    }
+
+    @Test
+    void fromTextThrowsOnInvalidTemplateUri() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> client.generateTaskPromptFromText("Please analyze Site A.", "../etc/passwd"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> client.generateAuthPromptFromText("Authorize access.", "../etc/passwd"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> client.generateNotificationPromptFromText("Report finished.", "../etc/passwd"));
+    }
+
+    @Test
+    void fromDataWithSchemaThrowsOnInvalidTemplateUri() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+        Map<String, Object> data = Map.of("site", "Site A");
+        Map<String, Object> schema = Map.of("type", "object");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> client.generateTaskPromptFromDataWithSchema(data, schema, "../etc/passwd"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> client.generateAuthPromptFromDataWithSchema(data, schema, "../etc/passwd"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> client.generateNotificationPromptFromDataWithSchema(data, schema, "../etc/passwd"));
+    }
+
+    @Test
+    void fromTextUnderLocalRuleRendersEmptySlotsForNlInput() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        MetadataContent result =
+                client.generateTaskPromptFromText("Please analyze Site A power usage.", "energy_saving");
+
+        assertEquals("energy_saving", result.templateUri());
+        assertEquals("Site: \\nTarget: ", result.promptText());
+    }
+
+    @Test
+    void fromDataWithSchemaUnderLocalRuleIgnoresSchema() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+        Map<String, Object> data = Map.of("site", "Site A", "target", "Reduce power by 10%");
+        Map<String, Object> schema = Map.of("type", "object", "required", Arrays.asList("site", "target"));
+
+        MetadataContent result =
+                client.generateTaskPromptFromDataWithSchema(data, schema, "energy_saving");
+
+        assertEquals("energy_saving", result.templateUri());
+        assertEquals("Site: Site A\\nTarget: Reduce power by 10%", result.promptText());
+    }
+
+    @Test
+    void existingFromNlAndFromJsonDataMethodsStillReturnPromptGenerationResult() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+        Map<String, Object> data = Map.of("site", "Site A", "target", "Reduce power by 10%");
+
+        PromptGenerationResult taskFromNl =
+                client.generateTaskPromptFromNl("Please analyze Site A.", "energy_saving");
+        PromptGenerationResult taskFromJson =
+                client.generateTaskPromptFromJsonData(data, "energy_saving");
+        PromptGenerationResult authFromNl =
+                client.generateAuthorizationPromptFromNl("Authorize access.", "energy_saving");
+        PromptGenerationResult authFromJson =
+                client.generateAuthorizationPromptFromJsonData(data, "energy_saving");
+        PromptGenerationResult notificationFromNl =
+                client.generateNotificationPromptFromNl("Report finished.", "energy_saving");
+        PromptGenerationResult notificationFromJson =
+                client.generateNotificationPromptFromJsonData(data, "energy_saving");
+
+        assertTrue(taskFromNl.success());
+        assertTrue(taskFromJson.success());
+        assertTrue(authFromNl.success());
+        assertTrue(authFromJson.success());
+        assertTrue(notificationFromNl.success());
+        assertTrue(notificationFromJson.success());
+        assertNotNull(taskFromNl.promptText());
+        assertNotNull(taskFromJson.promptText());
+        assertNotNull(authFromNl.promptText());
+        assertNotNull(authFromJson.promptText());
+        assertNotNull(notificationFromNl.promptText());
+        assertNotNull(notificationFromJson.promptText());
     }
 
     private static Path writeMinimalLocalClientEnv() throws IOException {

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/model/MetadataContentTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/model/MetadataContentTest.java
@@ -48,9 +48,8 @@ class MetadataContentTest {
     }
 
     @Test
-    void rejectsNullFields() {
-        assertThrows(NullPointerException.class, () -> new MetadataContent(null, "prompt", "uri"));
-        assertThrows(NullPointerException.class, () -> new MetadataContent("uri", null, "uri"));
-        assertThrows(NullPointerException.class, () -> new MetadataContent("uri", "prompt", null));
+    void buildMetadataContentReturnsNullWhenAnyFieldIsNull() {
+        MetadataContent content = new MetadataContent(null, null, "extension-uri");
+        assertEquals(null, content.buildMetadataContent());
     }
 }

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/model/MetadataContentTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/model/MetadataContentTest.java
@@ -1,0 +1,56 @@
+package net.openan.a2at.sdk.client.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MetadataContentTest {
+
+    @Test
+    void exposesAllFieldsViaAccessorMethods() {
+        MetadataContent content = new MetadataContent("template-uri", "prompt-text", "extension-uri");
+
+        assertEquals("template-uri", content.templateUri());
+        assertEquals("prompt-text", content.promptText());
+        assertEquals("extension-uri", content.extensionUri());
+    }
+
+    @Test
+    void recordsWithSameValuesAreEqual() {
+        MetadataContent first = new MetadataContent("template-uri", "prompt-text", "extension-uri");
+        MetadataContent second = new MetadataContent("template-uri", "prompt-text", "extension-uri");
+
+        assertEquals(first, second);
+        assertNotSame(first, second);
+    }
+
+    @Test
+    void exposesNoStaticFactoryMethods() {
+        assertThrows(NoSuchMethodException.class, () -> MetadataContent.class.getMethod("success"));
+        assertThrows(NoSuchMethodException.class, () -> MetadataContent.class.getMethod("failure"));
+    }
+
+    @Test
+    void buildMetadataContentReturnsMapWithExtensionUriAndTemplateUri() {
+        MetadataContent content = new MetadataContent(
+                "energy_saving", "Site: Site A",
+                "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1");
+
+        Map<String, String> result = content.buildMetadataContent();
+
+        assertEquals(2, result.size());
+        assertEquals("Site: Site A", result.get(
+                "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1"));
+        assertEquals("energy_saving", result.get("template_uri"));
+    }
+
+    @Test
+    void rejectsNullFields() {
+        assertThrows(NullPointerException.class, () -> new MetadataContent(null, "prompt", "uri"));
+        assertThrows(NullPointerException.class, () -> new MetadataContent("uri", null, "uri"));
+        assertThrows(NullPointerException.class, () -> new MetadataContent("uri", "prompt", null));
+    }
+}

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilderTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilderTest.java
@@ -1,0 +1,56 @@
+package net.openan.a2at.sdk.client.prompt.assembly;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import net.openan.a2at.sdk.client.prompt.extractor.ClientSlotValueExtractor;
+import org.junit.jupiter.api.Test;
+
+class DefaultA2ATClientBuilderTest {
+
+    @Test
+    void structuredInputAwareExtractSlotsWithSchemaDelegatesToLlmExtractorForMapInput() throws Exception {
+        ClientSlotValueExtractor structuredExtractor =
+                (userInput, scenarioCode, language, templateText) -> Map.of("key", "structured");
+        ClientSlotValueExtractor llmExtractor =
+                (userInput, scenarioCode, language, templateText) -> Map.of("key", "llm");
+
+        Class<?> innerClass = Class.forName(
+                "net.openan.a2at.sdk.client.prompt.assembly.DefaultA2ATClientBuilder$StructuredInputAwareSlotValueExtractor");
+        Constructor<?> constructor = innerClass.getDeclaredConstructor(
+                ClientSlotValueExtractor.class, ClientSlotValueExtractor.class);
+        constructor.setAccessible(true);
+        ClientSlotValueExtractor extractor =
+                (ClientSlotValueExtractor) constructor.newInstance(structuredExtractor, llmExtractor);
+
+        Map<String, String> result = extractor.extractSlotsWithSchema(
+                Map.of("key", "value"), "scenario", "en", "template", Map.of("field", "description"));
+
+        assertEquals(Map.of("key", "llm"), result);
+    }
+
+    @Test
+    void structuredInputAwareExtractSlotsStillDispatchesByType() throws Exception {
+        ClientSlotValueExtractor structuredExtractor =
+                (userInput, scenarioCode, language, templateText) -> Map.of("key", "structured");
+        ClientSlotValueExtractor llmExtractor =
+                (userInput, scenarioCode, language, templateText) -> Map.of("key", "llm");
+
+        Class<?> innerClass = Class.forName(
+                "net.openan.a2at.sdk.client.prompt.assembly.DefaultA2ATClientBuilder$StructuredInputAwareSlotValueExtractor");
+        Constructor<?> constructor = innerClass.getDeclaredConstructor(
+                ClientSlotValueExtractor.class, ClientSlotValueExtractor.class);
+        constructor.setAccessible(true);
+        ClientSlotValueExtractor extractor =
+                (ClientSlotValueExtractor) constructor.newInstance(structuredExtractor, llmExtractor);
+
+        Map<String, String> mapResult = extractor.extractSlots(
+                Map.of("key", "value"), "scenario", "en", "template");
+        assertEquals(Map.of("key", "structured"), mapResult);
+
+        Map<String, String> stringResult = extractor.extractSlots(
+                "plain text", "scenario", "en", "template");
+        assertEquals(Map.of("key", "llm"), stringResult);
+    }
+}

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/ClientSlotValueExtractorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/ClientSlotValueExtractorTest.java
@@ -1,0 +1,20 @@
+package net.openan.a2at.sdk.client.prompt.extractor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ClientSlotValueExtractorTest {
+
+    @Test
+    void extractSlotsWithSchemaDelegatesToExtractSlotsAndIgnoresSchema() {
+        ClientSlotValueExtractor extractor = (userInput, scenarioCode, language, templateText) ->
+                Map.of("scenario", scenarioCode, "language", language);
+
+        Map<String, String> result = extractor.extractSlotsWithSchema(
+                "test input", "scenario-1", "en-US", "template text", Map.of("field", "desc"));
+
+        assertEquals(Map.of("scenario", "scenario-1", "language", "en-US"), result);
+    }
+}

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultStructuredClientSlotValueExtractorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultStructuredClientSlotValueExtractorTest.java
@@ -1,6 +1,7 @@
 package net.openan.a2at.sdk.client.prompt.extractor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -57,6 +58,70 @@ class DefaultStructuredClientSlotValueExtractorTest {
         assertTrue(llmClient.lastMessages().get(1).get("content").contains("energy_saving"));
         assertTrue(llmClient.lastMessages().get(1).get("content").contains("Analyze Site A with critical severity."));
         assertTrue(llmClient.lastSchema().containsKey("required"));
+    }
+
+    @Test
+    void extractSlotsWithSchemaCallsDelegateFourArgMethod() {
+        RecordingClient llmClient = new RecordingClient(
+                "{\"slots\":{\"site\":\"Site A\",\"additional_notes\":null,\"limit\":\"5\",\"severity\":\"high\"},"
+                        + "\"slot_errors\":[]}");
+        DefaultStructuredClientSlotValueExtractor extractor = new DefaultStructuredClientSlotValueExtractor(
+                llmClient,
+                (scenarioCode, language) -> new PromptSlotSchema(
+                        scenarioCode,
+                        List.of(
+                                new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null),
+                                new PromptSlotDefinition(
+                                        "additional_notes", false, "string", null, null, null, null, null),
+                                new PromptSlotDefinition("limit", false, "integer", null, 1.0d, 10.0d, null, null),
+                                new PromptSlotDefinition(
+                                        "severity",
+                                        false,
+                                        "string",
+                                        null,
+                                        null,
+                                        null,
+                                        List.of("low", "medium", "high"),
+                                        null))),
+                "Extract slots from the input.",
+                "Return slots as JSON.");
+
+        Map<String, Object> dataSchema = Map.of("site", "site description", "severity", "severity description");
+        Map<String, String> slots = extractor.extractSlotsWithSchema(
+                "Analyze Site A with critical severity.",
+                "energy_saving",
+                "en-US",
+                "Site: {site}\nNotes: {additional_notes}\nLimit: {limit}\nSeverity: {severity}",
+                dataSchema);
+
+        assertEquals(
+                Map.of(
+                        "site", "Site A",
+                        "additional_notes", "",
+                        "limit", "5",
+                        "severity", "high"),
+                slots);
+        assertTrue(llmClient.lastMessages().get(1).get("content").contains("[data_schema]"));
+        assertTrue(llmClient.lastMessages().get(1).get("content").contains("site: site description"));
+    }
+
+    @Test
+    void extractSlotsWithSchemaWithNullSchemaStillWorks() {
+        RecordingClient llmClient = new RecordingClient(
+                "{\"slots\":{\"site\":\"Site A\"},\"slot_errors\":[]}");
+        DefaultStructuredClientSlotValueExtractor extractor = new DefaultStructuredClientSlotValueExtractor(
+                llmClient,
+                (scenarioCode, language) -> new PromptSlotSchema(
+                        scenarioCode,
+                        List.of(new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null))),
+                "Extract slots.",
+                "Return slots.");
+
+        Map<String, String> slots = extractor.extractSlotsWithSchema(
+                "Analyze Site A.", "scenario", "en", "Site: {site}", null);
+
+        assertEquals(Map.of("site", "Site A"), slots);
+        assertFalse(llmClient.lastMessages().get(1).get("content").contains("[data_schema]"));
     }
 
     private static final class RecordingClient implements LLMClient {

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultTemplateDrivenSlotValueExtractorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultTemplateDrivenSlotValueExtractorTest.java
@@ -159,4 +159,23 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
     private static PromptSlotSchema schema(String scenarioCode, PromptSlotDefinition... definitions) {
         return new PromptSlotSchema(scenarioCode, List.of(definitions));
     }
+
+    @Test
+    void extractSlotsWithSchemaIgnoresSchemaAndBehavesIdenticallyToExtractSlots() {
+        DefaultTemplateDrivenSlotValueExtractor extractor =
+                new DefaultTemplateDrivenSlotValueExtractor((scenarioCode, language) -> schema(
+                        scenarioCode,
+                        new PromptSlotDefinition("site", true, "string", null, null, null, null, null),
+                        new PromptSlotDefinition("additional_notes", false, "string", null, null, null, null, null),
+                        new PromptSlotDefinition("ignored", false, "string", null, null, null, null, null)));
+
+        Map<String, String> slots = extractor.extractSlotsWithSchema(
+                Map.of("site", "Site A", "additional_notes", "critical", "ignored", "value"),
+                "energy_saving",
+                "en-US",
+                "Site: {site}\nNotes: {additional_notes}",
+                Map.of("ignored_field", "some description"));
+
+        assertEquals(Map.of("site", "Site A", "additional_notes", "critical"), slots);
+    }
 }

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
@@ -3,14 +3,19 @@ package net.openan.a2at.sdk.client.prompt.orchestration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.client.model.MetadataContent;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 import net.openan.a2at.sdk.client.prompt.extractor.ClientSlotValueExtractor;
 import net.openan.a2at.sdk.client.prompt.loader.ClientTemplateLoader;
+import net.openan.a2at.sdk.client.prompt.recognition.ClientScenarioRecognizer;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
+import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
+import net.openan.a2at.sdk.llm.LLMRuntimeError;
 import net.openan.a2at.sdk.prompt.analysis.model.ScenarioRecognitionResult;
 import net.openan.a2at.sdk.prompt.resources.model.ScenarioDefinition;
 import net.openan.a2at.sdk.prompt.taskrendering.api.TaskPromptRenderer;
@@ -144,6 +149,170 @@ class DefaultClientPromptGenerationOrchestratorTest {
         assertEquals("generation", result.failure().stage());
     }
 
+    @Test
+    void eachTemplateUriEntryPointGeneratesPromptWithoutScenarioRecognition() {
+        RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        FakeSlotValueExtractor slotValueExtractor = new FakeSlotValueExtractor(Map.of("site", "Site A"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(recognizer, templateLoader, slotValueExtractor);
+
+        PromptGenerationResult taskNl = orchestrator.generateTaskPromptFromNl("Analyze Site A.", "energy_saving");
+        PromptGenerationResult taskJson =
+                orchestrator.generateTaskPromptFromJsonData(Map.of("site", "Site A"), "energy_saving");
+        PromptGenerationResult authorizationNl =
+                orchestrator.generateAuthorizationPromptFromNl("Grant access.", "database_read");
+        PromptGenerationResult authorizationJson =
+                orchestrator.generateAuthorizationPromptFromJsonData(Map.of("site", "Site A"), "database_read");
+        PromptGenerationResult notificationNl =
+                orchestrator.generateNotificationPromptFromNl("Report finished.", "energy_saving");
+        PromptGenerationResult notificationJson =
+                orchestrator.generateNotificationPromptFromJsonData(Map.of("site", "Site A"), "energy_saving");
+
+        assertTrue(taskNl.success());
+        assertTrue(taskJson.success());
+        assertTrue(authorizationNl.success());
+        assertTrue(authorizationJson.success());
+        assertTrue(notificationNl.success());
+        assertTrue(notificationJson.success());
+        assertEquals("Site: Site A", taskNl.promptText());
+        assertEquals("Site: Site A", authorizationJson.promptText());
+        assertEquals("Site: Site A", notificationNl.promptText());
+        assertEquals(0, recognizer.invocationCount);
+        assertEquals("en-US", templateLoader.lastLanguage);
+        assertEquals("en-US", slotValueExtractor.lastLanguage);
+        assertEquals("Site: {site}", slotValueExtractor.lastTemplateText);
+    }
+
+    @Test
+    void authorizationEntryPointsUseAuthorizationTypeAsTemplateIdentifier() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Access: {scope}");
+        FakeSlotValueExtractor slotValueExtractor = new FakeSlotValueExtractor(Map.of("scope", "read"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
+
+        PromptGenerationResult nlResult =
+                orchestrator.generateAuthorizationPromptFromNl("Grant read access.", "database_read");
+
+        assertTrue(nlResult.success());
+        assertEquals("database_read", templateLoader.lastScenarioCode);
+        assertEquals("database_read", slotValueExtractor.lastScenarioCode);
+        assertEquals("Grant read access.", slotValueExtractor.lastUserInput);
+
+        PromptGenerationResult jsonResult =
+                orchestrator.generateAuthorizationPromptFromJsonData(Map.of("scope", "read"), "database_read");
+
+        assertTrue(jsonResult.success());
+        assertEquals("database_read", templateLoader.lastScenarioCode);
+        assertEquals(Map.of("scope", "read"), slotValueExtractor.lastUserInput);
+    }
+
+    @Test
+    void templateUriGenerationReturnsInvalidTemplateUriWhenIdentifierIsNullOrBlankOrPatternViolating() {
+        for (String invalidUri :
+                new String[] {null, "", "   ", "templates/energy_saving", "../etc/passwd", "has space", "id;drop"}) {
+            RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
+            CountingFailingTemplateLoader templateLoader = new CountingFailingTemplateLoader();
+            DefaultClientPromptGenerationOrchestrator orchestrator =
+                    newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of()));
+
+            PromptGenerationResult result =
+                    orchestrator.generateTaskPromptFromJsonData(Map.of("site", "Site A"), invalidUri);
+
+            assertFalse(result.success());
+            assertNotNull(result.failure());
+            assertEquals("invalid_template_uri", result.failure().code());
+            assertEquals("generation", result.failure().stage());
+            assertEquals(0, recognizer.invocationCount);
+            assertEquals(0, templateLoader.loadCount);
+        }
+    }
+
+    @Test
+    void templateUriGenerationReturnsTemplateNotFoundWhenTemplateIsMissing() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                (scenarioCode, language) -> {
+                    throw new ResourceNotFoundException("Prompt resource file does not exist.", scenarioCode);
+                },
+                new FakeSlotValueExtractor(Map.of("site", "Site A")));
+
+        PromptGenerationResult result = orchestrator.generateTaskPromptFromNl("Analyze Site A.", "energy_saving");
+
+        assertFalse(result.success());
+        assertNotNull(result.failure());
+        assertEquals("template_not_found", result.failure().code());
+        assertEquals("generation", result.failure().stage());
+    }
+
+    @Test
+    void templateUriGenerationReturnsRenderFailedWhenRenderingFails() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                new FakeTemplateLoader("Site: {site}\nMissing: {missing_slot}"),
+                new FakeSlotValueExtractor(Map.of("site", "Site A")));
+
+        PromptGenerationResult result =
+                orchestrator.generateNotificationPromptFromJsonData(Map.of("site", "Site A"), "energy_saving");
+
+        assertFalse(result.success());
+        assertNotNull(result.failure());
+        assertEquals("render_failed", result.failure().code());
+        assertEquals("generation", result.failure().stage());
+    }
+
+    @Test
+    void templateUriGenerationProcessesNullAndBlankUserInputWithoutAdditionalValidation() {
+        for (String userInput : new String[] {null, "", "   "}) {
+            FakeSlotValueExtractor slotValueExtractor = new FakeSlotValueExtractor(Map.of("site", "Site A"));
+            DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                    new RecordingScenarioRecognizer(), new FakeTemplateLoader("Site: {site}"), slotValueExtractor);
+
+            PromptGenerationResult result = orchestrator.generateTaskPromptFromNl(userInput, "energy_saving");
+
+            assertTrue(result.success());
+            assertEquals("Site: Site A", result.promptText());
+            assertEquals(userInput, slotValueExtractor.lastUserInput);
+        }
+    }
+
+    private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestrator(
+            ClientScenarioRecognizer recognizer,
+            ClientTemplateLoader templateLoader,
+            ClientSlotValueExtractor slotValueExtractor) {
+        return new DefaultClientPromptGenerationOrchestrator(
+                recognizer,
+                List.of(new ScenarioDefinition(
+                        "energy_saving", "Energy Saving", "Energy analysis", "Analyze site power")),
+                "en-US",
+                "Identify the best matching scenario.",
+                "Choose from the provided scenario list.",
+                templateLoader,
+                slotValueExtractor,
+                new TaskPromptRenderer());
+    }
+
+    private static final class RecordingScenarioRecognizer implements ClientScenarioRecognizer {
+        private int invocationCount;
+
+        @Override
+        public ScenarioRecognitionResult recognize(
+                String normalizedInput, List<ScenarioDefinition> scenarios, String systemPrompt, String userPrompt) {
+            this.invocationCount++;
+            return new ScenarioRecognitionResult(true, "energy_saving", null);
+        }
+    }
+
+    private static final class CountingFailingTemplateLoader implements ClientTemplateLoader {
+        private int loadCount;
+
+        @Override
+        public String loadTemplate(String scenarioCode, String language) {
+            this.loadCount++;
+            throw new ResourceNotFoundException("Prompt resource file does not exist.", scenarioCode);
+        }
+    }
+
     private static final class FakeTemplateLoader implements ClientTemplateLoader {
         private final String templateText;
         private String lastScenarioCode;
@@ -181,5 +350,342 @@ class DefaultClientPromptGenerationOrchestratorTest {
             this.lastTemplateText = templateText;
             return slots;
         }
+    }
+
+    private static final class FakeSlotValueExtractorWithSchema implements ClientSlotValueExtractor {
+        private final Map<String, String> slots;
+        private Object lastUserInput;
+        private String lastScenarioCode;
+        private String lastLanguage;
+        private String lastTemplateText;
+        private Map<String, Object> lastSchema;
+
+        private FakeSlotValueExtractorWithSchema(Map<String, String> slots) {
+            this.slots = slots;
+        }
+
+        @Override
+        public Map<String, String> extractSlots(
+                Object userInput, String scenarioCode, String language, String templateText) {
+            this.lastUserInput = userInput;
+            this.lastScenarioCode = scenarioCode;
+            this.lastLanguage = language;
+            this.lastTemplateText = templateText;
+            return slots;
+        }
+
+        @Override
+        public Map<String, String> extractSlotsWithSchema(
+                Object userInput, String scenarioCode, String language, String templateText,
+                Map<String, Object> dataSchema) {
+            this.lastUserInput = userInput;
+            this.lastScenarioCode = scenarioCode;
+            this.lastLanguage = language;
+            this.lastTemplateText = templateText;
+            this.lastSchema = dataSchema;
+            return slots;
+        }
+    }
+
+    private static final class FailingExtractSlotsWithSchema implements ClientSlotValueExtractor {
+        private final RuntimeException exception;
+
+        private FailingExtractSlotsWithSchema(RuntimeException exception) {
+            this.exception = exception;
+        }
+
+        @Override
+        public Map<String, String> extractSlots(
+                Object userInput, String scenarioCode, String language, String templateText) {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, String> extractSlotsWithSchema(
+                Object userInput, String scenarioCode, String language, String templateText,
+                Map<String, Object> dataSchema) {
+            throw exception;
+        }
+    }
+
+    // --- MetadataContent pipeline tests (generateFromTemplateUriWithMetadata / FromText) ---
+
+    @Test
+    void generateFromTemplateUriWithMetadataReturnsMetadataContentOnSuccess() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        FakeSlotValueExtractor slotValueExtractor = new FakeSlotValueExtractor(Map.of("site", "Site A"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
+
+        MetadataContent result = orchestrator.generateTaskPromptFromText("Analyze Site A.", "energy_saving");
+
+        assertEquals("energy_saving", result.templateUri());
+        assertEquals("Site: Site A", result.promptText());
+        assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, result.extensionUri());
+    }
+
+    @Test
+    void generateFromTemplateUriWithMetadataScenarioRecognizerIsNotInvoked() {
+        RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
+
+        orchestrator.generateTaskPromptFromText("Analyze Site A.", "energy_saving");
+
+        assertEquals(0, recognizer.invocationCount);
+    }
+
+    @Test
+    void generateFromTemplateUriWithMetadataThrowsOnInvalidTemplateUri() {
+        for (String invalidUri : new String[] {null, "", "   ", "templates/energy_saving", "../etc/passwd", "has space", "id;drop"}) {
+            RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
+            CountingFailingTemplateLoader templateLoader = new CountingFailingTemplateLoader();
+            DefaultClientPromptGenerationOrchestrator orchestrator =
+                    newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of()));
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", invalidUri));
+            assertEquals(0, recognizer.invocationCount);
+            assertEquals(0, templateLoader.loadCount);
+        }
+    }
+
+    @Test
+    void generateFromTemplateUriWithMetadataPropagatesResourceNotFoundException() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                (scenarioCode, language) -> {
+                    throw new ResourceNotFoundException("Prompt resource file does not exist.", scenarioCode);
+                },
+                new FakeSlotValueExtractor(Map.of("site", "Site A")));
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", "energy_saving"));
+    }
+
+    @Test
+    void generateFromTemplateUriWithMetadataPropagatesRenderException() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                new FakeTemplateLoader("Site: {site}\nMissing: {missing_slot}"),
+                new FakeSlotValueExtractor(Map.of("site", "Site A")));
+
+        assertThrows(net.openan.a2at.sdk.prompt.taskrendering.exception.TaskPromptRenderException.class,
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", "energy_saving"));
+    }
+
+    @Test
+    void generateFromTemplateUriWithMetadataPropagatesLlmRuntimeError() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                new FakeTemplateLoader("Site: {site}"),
+                (userInput, scenarioCode, language, templateText) -> {
+                    throw new LLMRuntimeError("LLM invocation failed.");
+                });
+
+        assertThrows(LLMRuntimeError.class,
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", "energy_saving"));
+    }
+
+    // --- MetadataContent pipeline tests (generateFromDataWithSchema) ---
+
+    @Test
+    void generateFromDataWithSchemaReturnsMetadataContentOnSuccess() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        FakeSlotValueExtractorWithSchema slotValueExtractor =
+                new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
+
+        MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
+                Map.of("site", "Site A"), Map.of("site", "string"), "energy_saving");
+
+        assertEquals("energy_saving", result.templateUri());
+        assertEquals("Site: Site A", result.promptText());
+        assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, result.extensionUri());
+    }
+
+    @Test
+    void generateFromDataWithSchemaPassesSchemaToExtractor() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        FakeSlotValueExtractorWithSchema slotValueExtractor =
+                new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
+
+        Map<String, Object> schema = Map.of("site", "string", "count", "number");
+        orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), schema, "energy_saving");
+
+        assertEquals(schema, slotValueExtractor.lastSchema);
+        assertEquals("energy_saving", slotValueExtractor.lastScenarioCode);
+        assertEquals("Site: {site}", slotValueExtractor.lastTemplateText);
+    }
+
+    @Test
+    void generateFromDataWithSchemaNullSchemaHandledGracefully() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        FakeSlotValueExtractorWithSchema slotValueExtractor =
+                new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
+
+        MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
+                Map.of("site", "Site A"), null, "energy_saving");
+
+        assertEquals("Site: Site A", result.promptText());
+        assertEquals(null, slotValueExtractor.lastSchema);
+    }
+
+    @Test
+    void generateFromDataWithSchemaEmptySchemaHandledSameAsNull() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        FakeSlotValueExtractorWithSchema slotValueExtractor =
+                new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
+
+        MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
+                Map.of("site", "Site A"), Map.of(), "energy_saving");
+
+        assertEquals("Site: Site A", result.promptText());
+        assertEquals(Map.of(), slotValueExtractor.lastSchema);
+    }
+
+    @Test
+    void generateFromDataWithSchemaThrowsOnInvalidTemplateUri() {
+        RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
+        CountingFailingTemplateLoader templateLoader = new CountingFailingTemplateLoader();
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractorWithSchema(Map.of()));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), "has space"));
+        assertEquals(0, recognizer.invocationCount);
+        assertEquals(0, templateLoader.loadCount);
+    }
+
+    @Test
+    void generateFromDataWithSchemaPropagatesResourceNotFoundException() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                (scenarioCode, language) -> {
+                    throw new ResourceNotFoundException("Prompt resource file does not exist.", scenarioCode);
+                },
+                new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A")));
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), "energy_saving"));
+    }
+
+    @Test
+    void generateFromDataWithSchemaPropagatesRenderException() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                new FakeTemplateLoader("Site: {site}\nMissing: {missing_slot}"),
+                new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A")));
+
+        assertThrows(net.openan.a2at.sdk.prompt.taskrendering.exception.TaskPromptRenderException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), "energy_saving"));
+    }
+
+    @Test
+    void generateFromDataWithSchemaPropagatesLlmRuntimeError() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                new FakeTemplateLoader("Site: {site}"),
+                new FailingExtractSlotsWithSchema(new LLMRuntimeError("LLM invocation failed.")));
+
+        assertThrows(LLMRuntimeError.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), "energy_saving"));
+    }
+
+    @Test
+    void generateFromDataWithSchemaPropagatesResourceNotFoundExceptionFromExtractor() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                new FakeTemplateLoader("Site: {site}"),
+                new FailingExtractSlotsWithSchema(
+                        new ResourceNotFoundException("Slot schema file does not exist.", "energy_saving")));
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), "energy_saving"));
+    }
+
+    // --- Public entry point tests ---
+
+    @Test
+    void eachMetadataEntryPointReturnsCorrectMetadataContent() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        FakeSlotValueExtractorWithSchema slotValueExtractor =
+                new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
+
+        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", "energy_saving");
+        MetadataContent taskData = orchestrator.generateTaskPromptFromDataWithSchema(
+                Map.of("site", "Site A"), Map.of(), "energy_saving");
+        MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", "database_read");
+        MetadataContent authData = orchestrator.generateAuthPromptFromDataWithSchema(
+                Map.of("site", "Site A"), Map.of(), "database_read");
+        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", "energy_saving");
+        MetadataContent notifData = orchestrator.generateNotificationPromptFromDataWithSchema(
+                Map.of("site", "Site A"), Map.of(), "energy_saving");
+
+        assertTrue(taskText.promptText().contains("Site A"));
+        assertTrue(taskData.promptText().contains("Site A"));
+        assertTrue(authText.promptText().contains("Site A"));
+        assertTrue(authData.promptText().contains("Site A"));
+        assertTrue(notifText.promptText().contains("Site A"));
+        assertTrue(notifData.promptText().contains("Site A"));
+    }
+
+    @Test
+    void eachMetadataEntryPointUsesCorrectExtensionUri() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(), templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
+
+        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", "energy_saving");
+        MetadataContent taskData = orchestrator.generateTaskPromptFromDataWithSchema(
+                Map.of("site", "Site A"), Map.of(), "energy_saving");
+        MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", "database_read");
+        MetadataContent authData = orchestrator.generateAuthPromptFromDataWithSchema(
+                Map.of("site", "Site A"), Map.of(), "database_read");
+        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", "energy_saving");
+        MetadataContent notifData = orchestrator.generateNotificationPromptFromDataWithSchema(
+                Map.of("site", "Site A"), Map.of(), "energy_saving");
+
+        assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskText.extensionUri());
+        assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskData.extensionUri());
+        assertEquals(ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI, authText.extensionUri());
+        assertEquals(ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI, authData.extensionUri());
+        assertEquals(ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI, notifText.extensionUri());
+        assertEquals(ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI, notifData.extensionUri());
+    }
+
+    @Test
+    void authorizationMetadataEntryPointsPassAuthorizationTypeAsTemplateIdentifier() {
+        FakeTemplateLoader templateLoader = new FakeTemplateLoader("Access: {scope}");
+        FakeSlotValueExtractorWithSchema slotValueExtractor =
+                new FakeSlotValueExtractorWithSchema(Map.of("scope", "read"));
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
+
+        MetadataContent nlResult = orchestrator.generateAuthPromptFromText("Grant read access.", "database_read");
+
+        assertEquals("database_read", nlResult.templateUri());
+        assertEquals("Access: read", nlResult.promptText());
+        assertEquals("database_read", templateLoader.lastScenarioCode);
+        assertEquals("database_read", slotValueExtractor.lastScenarioCode);
+        assertEquals("Grant read access.", slotValueExtractor.lastUserInput);
+
+        MetadataContent jsonResult = orchestrator.generateAuthPromptFromDataWithSchema(
+                Map.of("scope", "read"), Map.of("scope", "string"), "database_read");
+
+        assertEquals("database_read", jsonResult.templateUri());
+        assertEquals("database_read", templateLoader.lastScenarioCode);
+        assertEquals(Map.of("scope", "read"), slotValueExtractor.lastUserInput);
+        assertEquals(Map.of("scope", "string"), slotValueExtractor.lastSchema);
     }
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/ExtensionUriConstants.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/ExtensionUriConstants.java
@@ -1,0 +1,27 @@
+package net.openan.a2at.sdk.core.model;
+
+/**
+ * Extension URI constants for the A2A-T protocol.
+ *
+ * <p>These URIs identify the A2A-T extension protocols supported by this SDK.
+ *
+ * @since 2026-08
+ */
+public final class ExtensionUriConstants {
+
+    private ExtensionUriConstants() {
+        throw new UnsupportedOperationException("Utility class - do not instantiate");
+    }
+
+    /** URI for the Task-T extension. */
+    public static final String TASK_T_EXTENSION_URI =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1";
+
+    /** URI for the Authorization-T extension. */
+    public static final String AUTHORIZATION_T_EXTENSION_URI =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Authorization-T/v1";
+
+    /** URI for the Notification-T extension. */
+    public static final String NOTIFICATION_T_EXTENSION_URI =
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1";
+}

--- a/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/ExtensionUriConstantsTest.java
+++ b/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/ExtensionUriConstantsTest.java
@@ -1,0 +1,46 @@
+package net.openan.a2at.sdk.core.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Constructor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ExtensionUriConstants}.
+ *
+ * <p>Tests cover the extension URI constants and utility class invariants.
+ *
+ * @since 2026-08
+ */
+class ExtensionUriConstantsTest {
+
+    @Test
+    void should_haveCorrectTaskTExtensionUri() {
+        assertEquals(
+                "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+                ExtensionUriConstants.TASK_T_EXTENSION_URI);
+    }
+
+    @Test
+    void should_haveCorrectAuthorizationTExtensionUri() {
+        assertEquals(
+                "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Authorization-T/v1",
+                ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI);
+    }
+
+    @Test
+    void should_haveCorrectNotificationTExtensionUri() {
+        assertEquals(
+                "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1",
+                ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI);
+    }
+
+    @Test
+    void should_havePrivateConstructor() throws Exception {
+        Constructor<ExtensionUriConstants> constructor =
+                ExtensionUriConstants.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        assertThrows(Exception.class, constructor::newInstance);
+    }
+}

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/analysis/impl/DefaultStructuredPromptSlotValueExtractor.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/analysis/impl/DefaultStructuredPromptSlotValueExtractor.java
@@ -44,10 +44,21 @@ public final class DefaultStructuredPromptSlotValueExtractor implements PromptSl
 
     @Override
     public StructuredSlotExtractionResult extractSlots(Object userInput, String scenarioCode, String language) {
+        return doExtractSlots(userInput, scenarioCode, language, null);
+    }
+
+    @Override
+    public StructuredSlotExtractionResult extractSlots(
+            Object userInput, String scenarioCode, String language, Map<String, Object> dataSchema) {
+        return doExtractSlots(userInput, scenarioCode, language, dataSchema);
+    }
+
+    private StructuredSlotExtractionResult doExtractSlots(
+            Object userInput, String scenarioCode, String language, Map<String, Object> dataSchema) {
         PromptSlotSchema slotSchema = slotSchemaLoader.loadSlotSchema(scenarioCode, language);
         String payload = llmClient
                 .structured(
-                        toStructuredMessages(buildMessages(userInput, scenarioCode, language, slotSchema)),
+                        toStructuredMessages(buildMessages(userInput, scenarioCode, language, slotSchema, dataSchema)),
                         buildSchema(slotSchema),
                         null,
                         null)
@@ -56,7 +67,8 @@ public final class DefaultStructuredPromptSlotValueExtractor implements PromptSl
     }
 
     private List<PromptMessage> buildMessages(
-            Object userInput, String scenarioCode, String language, PromptSlotSchema slotSchema) {
+            Object userInput, String scenarioCode, String language, PromptSlotSchema slotSchema,
+            Map<String, Object> dataSchema) {
         String slotLines = slotSchema.slotDefinitions().stream()
                 .map(slot -> "- name: " + slot.name() + "\n  required: " + slot.required())
                 .collect(Collectors.joining("\n"));
@@ -69,6 +81,12 @@ public final class DefaultStructuredPromptSlotValueExtractor implements PromptSl
                 + String.valueOf(userInput)
                 + "\n\n[slots]\n"
                 + slotLines;
+        if (dataSchema != null && !dataSchema.isEmpty()) {
+            content += "\n\n[data_schema]\n";
+            for (Map.Entry<String, Object> entry : dataSchema.entrySet()) {
+                content += "- " + entry.getKey() + ": " + String.valueOf(entry.getValue()) + "\n";
+            }
+        }
         return List.of(new PromptMessage("system", systemPrompt), new PromptMessage("user", content));
     }
 

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/analysis/impl/PromptSlotValueExtractor.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/analysis/impl/PromptSlotValueExtractor.java
@@ -1,5 +1,6 @@
 package net.openan.a2at.sdk.prompt.analysis.impl;
 
+import java.util.Map;
 import net.openan.a2at.sdk.prompt.analysis.model.StructuredSlotExtractionResult;
 
 /**
@@ -19,4 +20,18 @@ public interface PromptSlotValueExtractor {
      * @return structured extraction result
      */
     StructuredSlotExtractionResult extractSlots(Object userInput, String scenarioCode, String language);
+
+    /**
+     * Extracts structured slot values with an optional data schema for schema-guided extraction.
+     *
+     * @param userInput normalized input text
+     * @param scenarioCode resolved scenario code
+     * @param language prompt language
+     * @param dataSchema optional data schema map (field name to description)
+     * @return structured extraction result
+     */
+    default StructuredSlotExtractionResult extractSlots(
+            Object userInput, String scenarioCode, String language, Map<String, Object> dataSchema) {
+        return extractSlots(userInput, scenarioCode, language);
+    }
 }

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/analysis/impl/DefaultStructuredPromptSlotValueExtractorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/analysis/impl/DefaultStructuredPromptSlotValueExtractorTest.java
@@ -1,6 +1,8 @@
 package net.openan.a2at.sdk.prompt.analysis.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -93,9 +95,126 @@ class DefaultStructuredPromptSlotValueExtractorTest {
         assertEquals(List.of(), result.slotErrors());
     }
 
+    @Test
+    void should_injectDataSchemaSection_When_schemaIsProvided() {
+        RecordingClient llmClient =
+                new RecordingClient(
+                        """
+                {
+                  "slots": {
+                    "site": "Site A"
+                  },
+                  "slot_errors": []
+                }
+                """);
+        DefaultStructuredPromptSlotValueExtractor extractor = new DefaultStructuredPromptSlotValueExtractor(
+                llmClient,
+                (scenarioCode, language) -> new PromptSlotSchema(
+                        scenarioCode,
+                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null))),
+                "Extract slots from the input.",
+                "Return slots as JSON.");
+
+        Map<String, Object> dataSchema = Map.of(
+                "site", "The target site name",
+                "severity", "The severity level");
+
+        extractor.extractSlots("Analyze Site A.", "energy_saving", "en-US", dataSchema);
+
+        String userMessage = llmClient.lastUserContent();
+        assertTrue(userMessage.contains("[data_schema]"));
+        assertTrue(userMessage.contains("- site: The target site name"));
+        assertTrue(userMessage.contains("- severity: The severity level"));
+    }
+
+    @Test
+    void should_notIncludeDataSchemaSection_When_schemaIsNull() {
+        RecordingClient llmClient =
+                new RecordingClient(
+                        """
+                {
+                  "slots": {
+                    "site": "Site A"
+                  },
+                  "slot_errors": []
+                }
+                """);
+        DefaultStructuredPromptSlotValueExtractor extractor = new DefaultStructuredPromptSlotValueExtractor(
+                llmClient,
+                (scenarioCode, language) -> new PromptSlotSchema(
+                        scenarioCode,
+                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null))),
+                "Extract slots from the input.",
+                "Return slots as JSON.");
+
+        extractor.extractSlots("Analyze Site A.", "energy_saving", "en-US", null);
+
+        String userMessage = llmClient.lastUserContent();
+        assertFalse(userMessage.contains("[data_schema]"));
+    }
+
+    @Test
+    void should_notIncludeDataSchemaSection_When_schemaIsEmpty() {
+        RecordingClient llmClient =
+                new RecordingClient(
+                        """
+                {
+                  "slots": {
+                    "site": "Site A"
+                  },
+                  "slot_errors": []
+                }
+                """);
+        DefaultStructuredPromptSlotValueExtractor extractor = new DefaultStructuredPromptSlotValueExtractor(
+                llmClient,
+                (scenarioCode, language) -> new PromptSlotSchema(
+                        scenarioCode,
+                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null))),
+                "Extract slots from the input.",
+                "Return slots as JSON.");
+
+        extractor.extractSlots("Analyze Site A.", "energy_saving", "en-US", Map.of());
+
+        String userMessage = llmClient.lastUserContent();
+        assertFalse(userMessage.contains("[data_schema]"));
+    }
+
+    @Test
+    void defaultExtractSlotsWithSchemaDelegatesToThreeArg() {
+        RecordingClient llmClient =
+                new RecordingClient(
+                        """
+                {
+                  "slots": {
+                    "site": "Site A"
+                  },
+                  "slot_errors": []
+                }
+                """);
+        DefaultStructuredPromptSlotValueExtractor extractor = new DefaultStructuredPromptSlotValueExtractor(
+                llmClient,
+                (scenarioCode, language) -> new PromptSlotSchema(
+                        scenarioCode,
+                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null))),
+                "Extract slots from the input.",
+                "Return slots as JSON.");
+
+        PromptSlotValueExtractor lambdaExtractor = (input, code, lang) ->
+                extractor.extractSlots(input, code, lang);
+
+        StructuredSlotExtractionResult result = lambdaExtractor.extractSlots(
+                "Analyze Site A.", "energy_saving", "en-US", Map.of("site", "desc"));
+
+        String userMessage = llmClient.lastUserContent();
+        assertFalse(userMessage.contains("[data_schema]"));
+        assertEquals(Map.of("site", "Site A"), result.slots());
+    }
+
     private static final class RecordingClient implements LLMClient {
 
         private final String payload;
+
+        private List<Map<String, String>> lastMessages;
 
         private RecordingClient(String payload) {
             this.payload = payload;
@@ -107,7 +226,17 @@ class DefaultStructuredPromptSlotValueExtractorTest {
                 Map<String, Object> jsonSchema,
                 Double temperature,
                 Integer maxTokens) {
+            this.lastMessages = messages;
             return new LLMResponse(payload, "test-model", Map.of("prompt_tokens", 1, "completion_tokens", 1), Map.of());
+        }
+
+        String lastUserContent() {
+            for (Map<String, String> message : lastMessages) {
+                if ("user".equals(message.get("role"))) {
+                    return message.get("content");
+                }
+            }
+            return "";
         }
     }
 }


### PR DESCRIPTION
## Summary

Add 6 new client API methods that return MetadataContent instead of PromptGenerationResult, supporting schema-guided extraction:

### New Methods
| Method | Parameters | Response |
|--------|-----------|----------|
| generateTaskPromptFromText | String text, String templateUri | MetadataContent |
| generateTaskPromptFromDataWithSchema | Map data, Map schema, String templateUri | MetadataContent |
| generateAuthPromptFromText | String text, String authorizationType | MetadataContent |
| generateAuthPromptFromDataWithSchema | Map data, Map schema, String authorizationType | MetadataContent |
| generateNotificationPromptFromText | String text, String templateUri | MetadataContent |
| generateNotificationPromptFromDataWithSchema | Map data, Map schema, String templateUri | MetadataContent |

### New Models
- **MetadataContent** — 	emplateUri, promptText, extensionUri
- **ExtensionUriConstants** — Task-T, Auth-T, Notification-T URIs

### Key Design
- FromText: same pipeline as FromNl, renamed + MetadataContent return + throw on failure
- FromDataWithSchema: schema injected into LLM user prompt for schema-guided extraction
- Under LLM provider, FromDataWithSchema always uses LLM-based extraction
- Under local_rule provider, schema is ignored
- Existing FromNl/FromJsonData methods unchanged (backward compatible)