### PR TITLE
feat(a2a-t-prompt): discover classpath template and slot types by dir…

### DIFF
--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
@@ -94,9 +94,9 @@ public final class A2ATClient {
      * Generates an authorization prompt with metadata from natural-language input using the template identified by the
      * authorization type, bypassing scenario recognition.
      *
-     * <p><b>Experimental:</b> the SDK does not yet bundle Authorization-T template resources, so this method answers
-     * {@code template_not_found} under the classpath source until Authorization-T templates are added or provided
-     * through the local resource root.
+     * <p><b>Experimental:</b> Authorization-T template resources (such as {@code authz-policy-mgr}) are bundled and
+     * discovered automatically, but Authorization-T slot schemas are not yet bundled, so template-driven slot
+     * extraction fails until Authorization-T slot resources are added or provided through the local resource root.
      *
      * @param text natural-language authorization input
      * @param authorizationType authorization type used as the template identifier
@@ -111,9 +111,9 @@ public final class A2ATClient {
      * Generates an authorization prompt with metadata from structured input and an optional data schema using the
      * template identified by the authorization type, bypassing scenario recognition.
      *
-     * <p><b>Experimental:</b> the SDK does not yet bundle Authorization-T template resources, so this method answers
-     * {@code template_not_found} under the classpath source until Authorization-T templates are added or provided
-     * through the local resource root.
+     * <p><b>Experimental:</b> Authorization-T template resources (such as {@code authz-policy-mgr}) are bundled and
+     * discovered automatically, but Authorization-T slot schemas are not yet bundled, so template-driven slot
+     * extraction fails until Authorization-T slot resources are added or provided through the local resource root.
      *
      * @param data structured authorization input as a string-to-object map
      * @param schema optional data schema map for schema-guided extraction

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/resources/ClasspathResourceDirectories.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/resources/ClasspathResourceDirectories.java
@@ -1,0 +1,87 @@
+package net.openan.a2at.sdk.core.resources;
+
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+/**
+ * Lists the first-level directory names of a classpath resource directory.
+ *
+ * <p>The enumeration covers every classpath root carrying the directory, both {@code file://} roots and {@code jar://}
+ * entries, so extension directories bundled in any jar on the classpath are discovered. Callers use this to avoid
+ * hardcoding resource-type lists that drift from the packaged resource tree.
+ *
+ * @since 2026-08
+ */
+public final class ClasspathResourceDirectories {
+
+    private ClasspathResourceDirectories() {
+        throw new UnsupportedOperationException("Utility class - do not instantiate");
+    }
+
+    /**
+     * Lists the distinct first-level directory names of one classpath resource directory.
+     *
+     * @param resourceDirectory classpath directory path such as {@code prompt_resources/templates/}
+     * @return distinct directory names in encounter order; empty when the directory exists on no classpath root
+     * @throws IOException when a classpath root cannot be read
+     */
+    public static List<String> list(String resourceDirectory) throws IOException {
+        Set<String> names = new LinkedHashSet<>();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = ClasspathResourceDirectories.class.getClassLoader();
+        }
+        Enumeration<URL> roots = classLoader.getResources(resourceDirectory);
+        while (roots.hasMoreElements()) {
+            URL root = roots.nextElement();
+            if ("file".equals(root.getProtocol())) {
+                collectFilesystemNames(root, names);
+            } else if ("jar".equals(root.getProtocol())) {
+                collectJarNames((JarURLConnection) root.openConnection(), resourceDirectory, names);
+            }
+        }
+        return List.copyOf(names);
+    }
+
+    private static void collectFilesystemNames(URL root, Set<String> names) throws IOException {
+        Path rootDirectory;
+        try {
+            rootDirectory = Path.of(root.toURI());
+        } catch (URISyntaxException exception) {
+            throw new IOException("Malformed classpath root URL: " + root, exception);
+        }
+        try (var entries = Files.list(rootDirectory)) {
+            entries.filter(Files::isDirectory).forEach(path -> names.add(path.getFileName().toString()));
+        }
+    }
+
+    private static void collectJarNames(JarURLConnection connection, String resourceDirectory, Set<String> names)
+            throws IOException {
+        String prefix = resourceDirectory.endsWith("/") ? resourceDirectory : resourceDirectory + "/";
+        try (JarFile jarFile = connection.getJarFile()) {
+            jarFile.stream()
+                    .filter(entry -> !entry.isDirectory())
+                    .map(entry -> firstSegmentAfter(entry.getName(), prefix))
+                    .filter(name -> !name.isEmpty())
+                    .forEach(names::add);
+        }
+    }
+
+    private static String firstSegmentAfter(String entryName, String prefix) {
+        if (!entryName.startsWith(prefix)) {
+            return "";
+        }
+        String remainder = entryName.substring(prefix.length());
+        int slash = remainder.indexOf('/');
+        return slash < 0 ? remainder : remainder.substring(0, slash);
+    }
+}

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptSlotSchemaLoader.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptSlotSchemaLoader.java
@@ -1,9 +1,12 @@
 package net.openan.a2at.sdk.prompt.resources.loader;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.exception.SdkException;
+import net.openan.a2at.sdk.core.resources.ClasspathResourceDirectories;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotJsonSchema;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotSchema;
 import net.openan.a2at.sdk.resources.ClasspathPromptResourceLoader;
@@ -12,11 +15,17 @@ import net.openan.a2at.sdk.resources.PromptResourceKey;
 /**
  * Loads shared slot schemas from packaged classpath prompt resources.
  *
+ * <p>The slot types are probed in a fixed order first and then in the order the extension directories appear under
+ * {@code prompt_resources/slots/} on the classpath, so extensions bundled later are loadable without extending a
+ * hardcoded list.
+ *
  * @since 2026-06
  */
 public final class ClasspathPromptSlotSchemaLoader implements PromptSlotSchemaLoader {
 
-    private static final List<String> SLOT_TYPES = List.of("Task-T", "Notification-T");
+    private static final List<String> KNOWN_SLOT_TYPES = List.of("Task-T", "Notification-T");
+
+    private static final List<String> SLOT_TYPES = discoverSlotTypes();
 
     private final ClasspathPromptResourceLoader resourceLoader;
 
@@ -41,5 +50,15 @@ public final class ClasspathPromptSlotSchemaLoader implements PromptSlotSchemaLo
         throw new ResourceNotFoundException(
                 "Prompt resource file does not exist.",
                 "prompt_resources/slots/*/v1/" + scenarioCode + "/" + language + "/slot.json");
+    }
+
+    private static List<String> discoverSlotTypes() {
+        Set<String> types = new LinkedHashSet<>(KNOWN_SLOT_TYPES);
+        try {
+            types.addAll(ClasspathResourceDirectories.list("prompt_resources/slots/"));
+        } catch (Exception ignored) {
+            // classpath enumeration is unavailable; fall back to the known types only
+        }
+        return List.copyOf(types);
     }
 }

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptTemplateLoader.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptTemplateLoader.java
@@ -1,18 +1,27 @@
 package net.openan.a2at.sdk.prompt.resources.loader;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
+import net.openan.a2at.sdk.core.resources.ClasspathResourceDirectories;
 import net.openan.a2at.sdk.resources.ClasspathPromptResourceLoader;
 import net.openan.a2at.sdk.resources.PromptResourceKey;
 
 /**
  * Loads shared prompt templates from packaged classpath prompt resources.
  *
+ * <p>The template types are probed in a fixed order first and then in the order the extension directories appear
+ * under {@code prompt_resources/templates/} on the classpath, so extensions bundled later — such as Authorization-T —
+ * are loadable without extending a hardcoded list.
+ *
  * @since 2026-06
  */
 public final class ClasspathPromptTemplateLoader implements PromptTemplateTextLoader {
 
-    private static final List<String> TEMPLATE_TYPES = List.of("Task-T", "Notification-T", "Negotiation-T");
+    private static final List<String> KNOWN_TEMPLATE_TYPES = List.of("Task-T", "Notification-T", "Negotiation-T");
+
+    private static final List<String> TEMPLATE_TYPES = discoverTemplateTypes();
 
     private final ClasspathPromptResourceLoader resourceLoader;
 
@@ -33,5 +42,15 @@ public final class ClasspathPromptTemplateLoader implements PromptTemplateTextLo
         throw new ResourceNotFoundException(
                 "Prompt resource file does not exist.",
                 "prompt_resources/templates/*/v1/" + scenarioCode + "/" + language + "/template.md");
+    }
+
+    private static List<String> discoverTemplateTypes() {
+        Set<String> types = new LinkedHashSet<>(KNOWN_TEMPLATE_TYPES);
+        try {
+            types.addAll(ClasspathResourceDirectories.list("prompt_resources/templates/"));
+        } catch (Exception ignored) {
+            // classpath enumeration is unavailable; fall back to the known types only
+        }
+        return List.copyOf(types);
     }
 }


### PR DESCRIPTION
# PR: Discover classpath template and slot types by directory

## Description

Remove the hardcoded extension type lists (`Task-T`/`Notification-T`/`Negotiation-T`) from the classpath template and slot-schema loaders. Extension directories are now discovered from the resource tree itself via a new `ClasspathResourceDirectories` utility (file:// and jar:// protocols), matching the existing directory-driven behavior of the local-file loaders and `PromptTemplateCatalog`.

- Known types keep their current probe order; newly discovered extensions (e.g. Authorization-T, whose templates were recently bundled) are appended — zero behavior change for existing extensions.
- Updates the `generateAuthPrompt*` experimental javadoc: Authorization-T templates are now bundled and discoverable; slot schemas are not yet bundled, so template-driven slot extraction still fails until slot resources are added.

## Related Issue(s)

Follow-up to the Negotiation-T content layer (#89) and the Authorization-T template resources added upstream.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally (`mvn test` full reactor green)
- [ ] I have added tests that prove my fix is effective or my feature works (deferred; covered by existing loader tests for not-found paths)
- [x] I have added or updated documentation as needed (experimental javadoc updated)
- [x] New source files include the SPDX license header (N/A — repo has no SPDX header convention)

## Additional Context

When Authorization-T slot resources are later bundled under `prompt_resources/slots/Authorization-T/`, `generateAuthPrompt*` works end-to-end without further code changes.
