### PR TITLE
refactor: rename template_uri metadata key to templateUri

### DIFF
--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/MetadataContent.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/MetadataContent.java
@@ -14,15 +14,15 @@ import java.util.Map;
 public record MetadataContent(String templateUri, String promptText, String extensionUri) {
 
     /** Metadata key carrying the template URI alongside the message itself. */
-    public static final String TEMPLATE_URI_METADATA_KEY = "template_uri";
+    public static final String TEMPLATE_URI_METADATA_KEY = "templateUri";
 
     /**
      * Builds the A2A-T metadata map for this generated message.
      *
      * <p>The returned map contains exactly two keys in a fixed order: the extension URI mapping to the rendered
-     * message, and {@code template_uri} mapping to the template URI. Repeated calls return equal maps.
+     * message, and {@code templateUri} mapping to the template URI. Repeated calls return equal maps.
      *
-     * @return newly built metadata map with exactly the extension URI and {@code template_uri} keys
+     * @return newly built metadata map with exactly the extension URI and {@code templateUri} keys
      */
     public Map<String, String> buildMetadataContent() {
         Map<String, String> metadata = new LinkedHashMap<>();

--- a/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/MetadataContentTest.java
+++ b/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/MetadataContentTest.java
@@ -67,6 +67,6 @@ class MetadataContentTest {
         Map<String, String> metadata = content.buildMetadataContent();
 
         assertEquals(2, metadata.size());
-        assertTrue(metadata.containsKey("template_uri"));
+        assertTrue(metadata.containsKey(MetadataContent.TEMPLATE_URI_METADATA_KEY));
     }
 }

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/golden/GoldenFixtureComparisonTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/golden/GoldenFixtureComparisonTest.java
@@ -13,9 +13,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
-import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestrator;
 import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestratorBuilder;
 import net.openan.a2at.sdk.negotiation.golden.GoldenInputs.GoldenCase;
@@ -38,7 +38,7 @@ class GoldenFixtureComparisonTest {
     private static final String EXTENSION_URI =
             "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1";
 
-    private static final String TEMPLATE_URI_METADATA_KEY = "template_uri";
+    private static final String TEMPLATE_URI_METADATA_KEY = MetadataContent.TEMPLATE_URI_METADATA_KEY;
 
     static Stream<Arguments> goldenCases() {
         List<Arguments> cases = new ArrayList<>();

--- a/docs/en/developer_guide.md
+++ b/docs/en/developer_guide.md
@@ -510,7 +510,7 @@ All types live in `net.openan.a2at.sdk.negotiation.content`.
 
 `NegotiationItem(name, value)` is one named entry of an item list. `NegotiationConclusion` carries `ACCEPT`, `REJECT`, and `ABORT`; only `Accept` and `Reject` are renderable — generation methods reject `ABORT` as a programming error. `NegotiationAction` (`REQUEST_FEASIBILITY_EVALUATION`, `PROPOSE_ALTERNATIVE_ON_FAILURE`) selects the conditional sections of the feasibility propose template.
 
-**MetadataContent** — the generation result: `record MetadataContent(String templateUri, String promptText, String extensionUri)`. `buildMetadataContent()` returns exactly two keys: the TMF extension URI (`https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1`) mapping to the rendered message, and `template_uri` mapping to the template URI. This map is what travels in the A2A message metadata.
+**MetadataContent** — the generation result: `record MetadataContent(String templateUri, String promptText, String extensionUri)`. `buildMetadataContent()` returns exactly two keys: the TMF extension URI (`https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1`) mapping to the rendered message, and `templateUri` mapping to the template URI. This map is what travels in the A2A message metadata.
 
 **FilledParamData** — the extraction result: `record FilledParamData(Map<String, Object> data)` holding the context parameters merged with the schema-extracted parameters.
 
@@ -576,7 +576,7 @@ MetadataContent propose = client.generateNegotiationProposePromptFromData(
 
 // This two-key map travels in the A2A message metadata.
 Map<String, String> metadata = propose.buildMetadataContent();
-// metadata.get("template_uri")  -> "Negotiation-T/v1/information-negotiation/propose"
+// metadata.get("templateUri")  -> "Negotiation-T/v1/information-negotiation/propose"
 // metadata.get(propose.extensionUri()) -> the rendered message text
 
 // --- Server side: validate the received message and extract parameters ---

--- a/docs/zh/开发指南.md
+++ b/docs/zh/开发指南.md
@@ -493,7 +493,7 @@ Negotiation-T/v1/{type}-negotiation/{phase}
 
 `NegotiationItem(name, value)` 表示条目列表中的一个命名条目。`NegotiationConclusion` 取值为 `ACCEPT`、`REJECT`、`ABORT`；只有 `Accept` 与 `Reject` 可被渲染 — 生成方法会把 `ABORT` 作为编程错误拒绝。`NegotiationAction`（`REQUEST_FEASIBILITY_EVALUATION`、`PROPOSE_ALTERNATIVE_ON_FAILURE`）决定可行性 propose 模板中渲染哪些条件章节。
 
-**MetadataContent** — 生成结果：`record MetadataContent(String templateUri, String promptText, String extensionUri)`。`buildMetadataContent()` 返回恰好两个键：TMF 扩展 URI（`https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1`）映射到渲染后的消息文本，`template_uri` 映射到模板 URI。这个映射即随 A2A 消息 metadata 传输的内容。
+**MetadataContent** — 生成结果：`record MetadataContent(String templateUri, String promptText, String extensionUri)`。`buildMetadataContent()` 返回恰好两个键：TMF 扩展 URI（`https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1`）映射到渲染后的消息文本，`templateUri` 映射到模板 URI。这个映射即随 A2A 消息 metadata 传输的内容。
 
 **FilledParamData** — 提取结果：`record FilledParamData(Map<String, Object> data)`，持有上下文参数与按 Schema 提取的参数合并后的结果。
 
@@ -559,7 +559,7 @@ MetadataContent propose = client.generateNegotiationProposePromptFromData(
 
 // 这个两键映射随 A2A 消息 metadata 传输。
 Map<String, String> metadata = propose.buildMetadataContent();
-// metadata.get("template_uri")  -> "Negotiation-T/v1/information-negotiation/propose"
+// metadata.get("templateUri")  -> "Negotiation-T/v1/information-negotiation/propose"
 // metadata.get(propose.extensionUri()) -> 渲染后的消息文本
 
 // --- 服务端：校验收到的消息并提取参数 ---


### PR DESCRIPTION
Rename TEMPLATE_URI_METADATA_KEY from template_uri to templateUri in MetadataContent and sync all references in docs and tests.