### PR TITLE
fix(profile): include JDK 17 in old_jdk_support activation for error-prone compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
             -->
             <id>old_jdk_support</id>
             <activation>
-                <jdk>(17, 21]</jdk>
+                <jdk>[17, 21]</jdk>
             </activation>
             <properties>
                 <error-prone.version>2.42.0</error-prone.version>


### PR DESCRIPTION
Closes #99

## Problem

Building the SDK with **JDK 17 + Maven 3** fails during compilation with a stack trace rooted at ClassLoader.defineClass1, with no clear compiler error message.

## Root Cause

The old_jdk_support profile lowers error-prone to 2.42.0 and 
ullaway to .12.10 for older JDKs, but its activation boundary was written as the open interval (17, 21], which **excludes JDK 17 itself**. As a result, JDK 17 fell back to the default error-prone 2.50.0, whose class files target Java 21 (class file version 65), and javac failed to load the annotation-processor plugin via ServiceLoader.

## Fix

Change the activation boundary to the closed interval [17, 21] so JDK 17 activates the downgrade.

pom.xml:
`diff
-<jdk>(17, 21]</jdk>
+<jdk>[17, 21]</jdk>
`

## Verification

mvn clean install passes on JDK 17 + Maven 3.9; all 10 reactor modules install to the local repository.