### PR TITLE
Refactor/standard template uri

### DIFF
--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationApiTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationApiTest.java
@@ -20,6 +20,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +37,7 @@ class A2ATClientNegotiationApiTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     @Test
     void generatesInformationProposeFromDataWithBuiltinChineseTemplates() throws IOException {
@@ -87,7 +88,7 @@ class A2ATClientNegotiationApiTest {
         A2ATClient client = new A2ATClient(writeEnv("zh-CN"));
 
         assertTrue(client.getNegotiationPrompt(INFORMATION_PROPOSE_URI).isPresent());
-        assertTrue(client.getNegotiationPrompt("Negotiation-T/v1/feasibility-negotiation/accept-reject")
+        assertTrue(client.getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
                 .isPresent());
         assertFalse(client.getNegotiationPrompt("not-a-template-uri").isPresent());
         PromptTemplate template =

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationEnvConfigTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationEnvConfigTest.java
@@ -29,6 +29,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +57,7 @@ class A2ATClientNegotiationEnvConfigTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private static final String CUSTOM_TEMPLATE_MARKER = "CUSTOM-TEMPLATE-MARKER-7d31";
 

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
@@ -17,6 +17,7 @@ import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 import net.openan.a2at.sdk.client.prompt.orchestration.ClientPromptGenerationOrchestrator;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMClientConfig;
 import net.openan.a2at.sdk.llm.LLMClientFactory;
@@ -282,24 +283,24 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
         Map<String, Object> schema = Map.of("type", "object");
 
         MetadataContent taskResult =
-                client.generateTaskPromptFromDataWithSchema(data, schema, "Task-T/v1/energy-saving");
+                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent authResult =
-                client.generateAuthPromptFromDataWithSchema(data, schema, "Task-T/v1/energy-saving");
+                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent notificationResult =
-                client.generateNotificationPromptFromDataWithSchema(data, schema, "Task-T/v1/energy-saving");
+                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
 
         assertNotNull(taskResult);
-        assertEquals("Task-T/v1/energy-saving", taskResult.templateUri());
+        assertEquals(StandardTemplates.ENERGY_SAVING.uri(), taskResult.templateUri());
         assertNotNull(taskResult.promptText());
         assertNotNull(taskResult.extensionUri());
 
         assertNotNull(authResult);
-        assertEquals("Task-T/v1/energy-saving", authResult.templateUri());
+        assertEquals(StandardTemplates.ENERGY_SAVING.uri(), authResult.templateUri());
         assertNotNull(authResult.promptText());
         assertNotNull(authResult.extensionUri());
 
         assertNotNull(notificationResult);
-        assertEquals("Task-T/v1/energy-saving", notificationResult.templateUri());
+        assertEquals(StandardTemplates.ENERGY_SAVING.uri(), notificationResult.templateUri());
         assertNotNull(notificationResult.promptText());
         assertNotNull(notificationResult.extensionUri());
     }
@@ -329,11 +330,11 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
         Map<String, Object> schema = Map.of("type", "object");
 
         MetadataContent taskResult =
-                client.generateTaskPromptFromDataWithSchema(data, schema, "Task-T/v1/energy-saving");
+                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent authResult =
-                client.generateAuthPromptFromDataWithSchema(data, schema, "Task-T/v1/energy-saving");
+                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent notificationResult =
-                client.generateNotificationPromptFromDataWithSchema(data, schema, "Task-T/v1/energy-saving");
+                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
 
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskResult.extensionUri());
         assertEquals(ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI, authResult.extensionUri());

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
@@ -19,6 +19,7 @@ import net.openan.a2at.sdk.core.exception.FailedParameter;
 import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.llm.LLMRuntimeError;
 import net.openan.a2at.sdk.prompt.analysis.model.ScenarioRecognitionResult;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotDefinition;
@@ -305,9 +306,9 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent result = orchestrator.generateTaskPromptFromText("Analyze Site A.", "Task-T/v1/energy-saving");
+        MetadataContent result = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri());
 
-        assertEquals("Task-T/v1/energy-saving", result.templateUri());
+        assertEquals(StandardTemplates.ENERGY_SAVING.uri(), result.templateUri());
         assertEquals("Site: Site A", result.promptText());
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, result.extensionUri());
     }
@@ -319,7 +320,7 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
-        orchestrator.generateTaskPromptFromText("Analyze Site A.", "Task-T/v1/energy-saving");
+        orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri());
 
         assertEquals(0, recognizer.invocationCount);
     }
@@ -409,9 +410,9 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of("site", "string"), "Task-T/v1/energy-saving");
+                Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING.uri());
 
-        assertEquals("Task-T/v1/energy-saving", result.templateUri());
+        assertEquals(StandardTemplates.ENERGY_SAVING.uri(), result.templateUri());
         assertEquals("Site: Site A", result.promptText());
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, result.extensionUri());
     }
@@ -425,10 +426,10 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         Map<String, Object> schema = Map.of("site", "string", "count", "number");
-        orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), schema, "Task-T/v1/energy-saving");
+        orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), schema, StandardTemplates.ENERGY_SAVING.uri());
 
         assertEquals(schema, slotValueExtractor.lastSchema);
-        assertEquals("Task-T/v1/energy-saving", slotValueExtractor.lastScenarioCode);
+        assertEquals(StandardTemplates.ENERGY_SAVING.uri(), slotValueExtractor.lastScenarioCode);
         assertEquals("Site: {site}", slotValueExtractor.lastTemplateText);
     }
 
@@ -441,7 +442,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), null, "Task-T/v1/energy-saving");
+                Map.of("site", "Site A"), null, StandardTemplates.ENERGY_SAVING.uri());
 
         assertEquals("Site: Site A", result.promptText());
         assertEquals(null, slotValueExtractor.lastSchema);
@@ -456,7 +457,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), "Task-T/v1/energy-saving");
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
 
         assertEquals("Site: Site A", result.promptText());
         assertEquals(Map.of(), slotValueExtractor.lastSchema);
@@ -541,15 +542,15 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", "Task-T/v1/energy-saving");
+        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent taskData = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), "Task-T/v1/energy-saving");
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", "Authorization-T/v1/database_read");
         MetadataContent authData = orchestrator.generateAuthPromptFromDataWithSchema(
                 Map.of("site", "Site A"), Map.of(), "Authorization-T/v1/database_read");
-        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", "Task-T/v1/energy-saving");
+        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent notifData = orchestrator.generateNotificationPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), "Task-T/v1/energy-saving");
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
 
         assertTrue(taskText.promptText().contains("Site A"));
         assertTrue(taskData.promptText().contains("Site A"));
@@ -565,15 +566,15 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
         DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
                 new RecordingScenarioRecognizer(), templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
-        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", "Task-T/v1/energy-saving");
+        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent taskData = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), "Task-T/v1/energy-saving");
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", "Authorization-T/v1/database_read");
         MetadataContent authData = orchestrator.generateAuthPromptFromDataWithSchema(
                 Map.of("site", "Site A"), Map.of(), "Authorization-T/v1/database_read");
-        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", "Task-T/v1/energy-saving");
+        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING.uri());
         MetadataContent notifData = orchestrator.generateNotificationPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), "Task-T/v1/energy-saving");
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
 
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskText.extensionUri());
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskData.extensionUri());

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/SimpleTemplateReference.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/SimpleTemplateReference.java
@@ -1,0 +1,13 @@
+package net.openan.a2at.sdk.core.validation;
+
+/**
+ * Plain data carrier implementing {@link TemplateReference} for templates that have no richer reference type of
+ * their own (Task-T, Notification-T, Authorization-T and language-bound {@link TemplateUri} values).
+ *
+ * @param uri template URI such as {@code Task-T/v1/energy-saving}
+ * @param language locale identifier such as {@code zh-CN} or {@code en-US}
+ * @param extensionName extension name identifying the template family, such as {@code Task-T}
+ * @since 2026-08
+ */
+public record SimpleTemplateReference(String uri, String language, String extensionName)
+        implements TemplateReference {}

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/StandardTemplates.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/StandardTemplates.java
@@ -20,45 +20,60 @@ public final class StandardTemplates {
         throw new UnsupportedOperationException("Utility class - do not instantiate");
     }
 
+    /** Extension name of the Task-T template family. */
+    public static final String TASK_EXTENSION_NAME = "Task-T";
+
+    /** Extension name of the Notification-T template family. */
+    public static final String NOTIFICATION_EXTENSION_NAME = "Notification-T";
+
+    /** Extension name of the Authorization-T template family. */
+    public static final String AUTHORIZATION_EXTENSION_NAME = "Authorization-T";
+
+    /** Extension name of the Negotiation-T template family. */
+    public static final String NEGOTIATION_EXTENSION_NAME = "Negotiation-T";
+
     /** Task-T template for the energy-saving scenario. */
-    public static final TemplateUri ENERGY_SAVING = TemplateUri.of("Task-T", "v1", "energy-saving");
+    public static final TemplateUri ENERGY_SAVING = TemplateUri.of(TASK_EXTENSION_NAME, "v1", "energy-saving");
 
     /** Task-T template for the private-line-complaint scenario. */
     public static final TemplateUri PRIVATE_LINE_COMPLAINT =
-            TemplateUri.of("Task-T", "v1", "private-line-complaint");
+            TemplateUri.of(TASK_EXTENSION_NAME, "v1", "private-line-complaint");
 
     /** Notification-T template for the subscribe-incident scenario. */
-    public static final TemplateUri SUBSCRIBE_INCIDENT = TemplateUri.of("Notification-T", "v1", "subscribe-incident");
+    public static final TemplateUri SUBSCRIBE_INCIDENT =
+            TemplateUri.of(NOTIFICATION_EXTENSION_NAME, "v1", "subscribe-incident");
 
     /** Notification-T template for the service-recovery scenario. */
-    public static final TemplateUri SERVICE_RECOVERY = TemplateUri.of("Notification-T", "v1", "service-recovery");
+    public static final TemplateUri SERVICE_RECOVERY =
+            TemplateUri.of(NOTIFICATION_EXTENSION_NAME, "v1", "service-recovery");
 
     /** Authorization-T template for the authz-policy-mgr scenario. */
-    public static final TemplateUri AUTHZ_POLICY_MGR = TemplateUri.of("Authorization-T", "v1", "authz-policy-mgr");
+    public static final TemplateUri AUTHZ_POLICY_MGR =
+            TemplateUri.of(AUTHORIZATION_EXTENSION_NAME, "v1", "authz-policy-mgr");
 
     /** Negotiation-T propose template for information negotiation. */
     public static final TemplateUri INFORMATION_NEGOTIATION_PROPOSE =
-            TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "propose");
+            TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "v1", "information-negotiation", "propose");
 
     /** Negotiation-T accept-reject template for information negotiation. */
     public static final TemplateUri INFORMATION_NEGOTIATION_ACCEPT_REJECT =
-            TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "accept-reject");
+            TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "v1", "information-negotiation", "accept-reject");
 
     /** Negotiation-T propose template for target negotiation. */
     public static final TemplateUri TARGET_NEGOTIATION_PROPOSE =
-            TemplateUri.of("Negotiation-T", "v1", "target-negotiation", "propose");
+            TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "v1", "target-negotiation", "propose");
 
     /** Negotiation-T accept-reject template for target negotiation. */
     public static final TemplateUri TARGET_NEGOTIATION_ACCEPT_REJECT =
-            TemplateUri.of("Negotiation-T", "v1", "target-negotiation", "accept-reject");
+            TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "v1", "target-negotiation", "accept-reject");
 
     /** Negotiation-T propose template for feasibility negotiation. */
     public static final TemplateUri FEASIBILITY_NEGOTIATION_PROPOSE =
-            TemplateUri.of("Negotiation-T", "v1", "feasibility-negotiation", "propose");
+            TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "v1", "feasibility-negotiation", "propose");
 
     /** Negotiation-T accept-reject template for feasibility negotiation. */
     public static final TemplateUri FEASIBILITY_NEGOTIATION_ACCEPT_REJECT =
-            TemplateUri.of("Negotiation-T", "v1", "feasibility-negotiation", "accept-reject");
+            TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "v1", "feasibility-negotiation", "accept-reject");
 
     /** All built-in Task-T templates. */
     public static final List<TemplateUri> TASK = List.of(ENERGY_SAVING, PRIVATE_LINE_COMPLAINT);

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/StandardTemplates.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/StandardTemplates.java
@@ -1,0 +1,80 @@
+package net.openan.a2at.sdk.core.validation;
+
+import java.util.List;
+
+/**
+ * Constants for the built-in content templates shipped with the SDK, in the spirit of
+ * {@code java.nio.charset.StandardCharsets}.
+ *
+ * <p>Each constant is a language-neutral {@link TemplateUri}; the language is global prompt runtime context and is
+ * bound by the SDK, not by the caller. Use these constants instead of hand-written URI strings to get compile-time
+ * safety against spelling drift.
+ *
+ * <p>Example: {@code StandardTemplates.ENERGY_SAVING.uri()} is {@code Task-T/v1/energy-saving}.
+ *
+ * @since 2026-08
+ */
+public final class StandardTemplates {
+
+    private StandardTemplates() {
+        throw new UnsupportedOperationException("Utility class - do not instantiate");
+    }
+
+    /** Task-T template for the energy-saving scenario. */
+    public static final TemplateUri ENERGY_SAVING = TemplateUri.of("Task-T", "v1", "energy-saving");
+
+    /** Task-T template for the private-line-complaint scenario. */
+    public static final TemplateUri PRIVATE_LINE_COMPLAINT =
+            TemplateUri.of("Task-T", "v1", "private-line-complaint");
+
+    /** Notification-T template for the subscribe-incident scenario. */
+    public static final TemplateUri SUBSCRIBE_INCIDENT = TemplateUri.of("Notification-T", "v1", "subscribe-incident");
+
+    /** Notification-T template for the service-recovery scenario. */
+    public static final TemplateUri SERVICE_RECOVERY = TemplateUri.of("Notification-T", "v1", "service-recovery");
+
+    /** Authorization-T template for the authz-policy-mgr scenario. */
+    public static final TemplateUri AUTHZ_POLICY_MGR = TemplateUri.of("Authorization-T", "v1", "authz-policy-mgr");
+
+    /** Negotiation-T propose template for information negotiation. */
+    public static final TemplateUri INFORMATION_NEGOTIATION_PROPOSE =
+            TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "propose");
+
+    /** Negotiation-T accept-reject template for information negotiation. */
+    public static final TemplateUri INFORMATION_NEGOTIATION_ACCEPT_REJECT =
+            TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "accept-reject");
+
+    /** Negotiation-T propose template for target negotiation. */
+    public static final TemplateUri TARGET_NEGOTIATION_PROPOSE =
+            TemplateUri.of("Negotiation-T", "v1", "target-negotiation", "propose");
+
+    /** Negotiation-T accept-reject template for target negotiation. */
+    public static final TemplateUri TARGET_NEGOTIATION_ACCEPT_REJECT =
+            TemplateUri.of("Negotiation-T", "v1", "target-negotiation", "accept-reject");
+
+    /** Negotiation-T propose template for feasibility negotiation. */
+    public static final TemplateUri FEASIBILITY_NEGOTIATION_PROPOSE =
+            TemplateUri.of("Negotiation-T", "v1", "feasibility-negotiation", "propose");
+
+    /** Negotiation-T accept-reject template for feasibility negotiation. */
+    public static final TemplateUri FEASIBILITY_NEGOTIATION_ACCEPT_REJECT =
+            TemplateUri.of("Negotiation-T", "v1", "feasibility-negotiation", "accept-reject");
+
+    /** All built-in Task-T templates. */
+    public static final List<TemplateUri> TASK = List.of(ENERGY_SAVING, PRIVATE_LINE_COMPLAINT);
+
+    /** All built-in Notification-T templates. */
+    public static final List<TemplateUri> NOTIFICATION = List.of(SUBSCRIBE_INCIDENT, SERVICE_RECOVERY);
+
+    /** All built-in Authorization-T templates. */
+    public static final List<TemplateUri> AUTHORIZATION = List.of(AUTHZ_POLICY_MGR);
+
+    /** All built-in Negotiation-T templates. */
+    public static final List<TemplateUri> NEGOTIATION = List.of(
+            INFORMATION_NEGOTIATION_PROPOSE,
+            INFORMATION_NEGOTIATION_ACCEPT_REJECT,
+            TARGET_NEGOTIATION_PROPOSE,
+            TARGET_NEGOTIATION_ACCEPT_REJECT,
+            FEASIBILITY_NEGOTIATION_PROPOSE,
+            FEASIBILITY_NEGOTIATION_ACCEPT_REJECT);
+}

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/TemplateReference.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/TemplateReference.java
@@ -22,9 +22,9 @@ public interface TemplateReference {
     String language();
 
     /**
-     * Returns the extension prefix identifying the template family.
+     * Returns the extension name identifying the template family — the first segment of the template URI.
      *
-     * @return extension prefix
+     * @return extension name such as {@code Task-T}
      */
-    String extensionPrefix();
+    String extensionName();
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/TemplateUri.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/TemplateUri.java
@@ -1,0 +1,125 @@
+package net.openan.a2at.sdk.core.validation;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.openan.a2at.sdk.core.resources.PathSegments;
+
+/**
+ * Structured, always-valid identifier of a content template.
+ *
+ * <p>A template URI is composed of an extension name ({@code Task-T}, {@code Notification-T}, {@code Negotiation-T},
+ * {@code Authorization-T}), a version segment and at least one trailing segment (a scenario code, or the type and
+ * phase segments of a negotiation template). Constructing a {@code TemplateUri} validates every segment, so a value
+ * of this type can never carry a malformed URI — the structural invariants that validators previously re-derived by
+ * splitting raw strings are encoded in the type itself.
+ *
+ * <p>The language is deliberately not part of the URI: it is runtime context resolved from the global prompt
+ * configuration, bound into a {@link TemplateReference} only when a concrete reference is needed.
+ *
+ * @param extensionName first URI segment identifying the template family, such as {@code Task-T}
+ * @param version second URI segment, such as {@code v1}
+ * @param segments trailing URI segments, such as {@code [energy-saving]} or {@code [information-negotiation, propose]}
+ * @since 2026-08
+ */
+public record TemplateUri(String extensionName, String version, List<String> segments) {
+
+    /**
+     * Validates the components and defensively copies the segment list.
+     *
+     * @throws NullPointerException if the extension name, version or segment list is null
+     * @throws IllegalArgumentException if any component is not a simple path segment or the segment list is empty
+     */
+    public TemplateUri {
+        validateSegment(extensionName, "Extension name");
+        validateSegment(version, "Version");
+        Objects.requireNonNull(segments, "Template URI segments must not be null.");
+        if (segments.isEmpty()) {
+            throw new IllegalArgumentException("Template URI must have at least one trailing segment.");
+        }
+        for (String segment : segments) {
+            validateSegment(segment, "Template URI segment");
+        }
+        segments = List.copyOf(segments);
+    }
+
+    /**
+     * Creates a template URI from its components.
+     *
+     * @param extensionName first URI segment identifying the template family, such as {@code Task-T}
+     * @param version second URI segment, such as {@code v1}
+     * @param segments trailing URI segments, such as {@code energy-saving}
+     * @return validated template URI
+     * @throws NullPointerException if any component is null
+     * @throws IllegalArgumentException if any component is not a simple path segment or no trailing segment is given
+     */
+    public static TemplateUri of(String extensionName, String version, String... segments) {
+        return new TemplateUri(extensionName, version, List.of(segments));
+    }
+
+    /**
+     * Tries to parse a raw template URI into its components.
+     *
+     * @param templateUri template URI such as {@code Task-T/v1/energy-saving}
+     * @return parsed template URI, or an empty result when the input is null, blank, has fewer than three segments or
+     *     contains a segment that is not a simple path segment
+     */
+    public static Optional<TemplateUri> parse(String templateUri) {
+        if (templateUri == null || templateUri.isBlank()) {
+            return Optional.empty();
+        }
+        String[] parts = templateUri.strip().split("/");
+        if (parts.length < 3) {
+            return Optional.empty();
+        }
+        for (String part : parts) {
+            if (!PathSegments.isSimpleSegment(part)) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(new TemplateUri(parts[0], parts[1], List.of(parts).subList(2, parts.length)));
+    }
+
+    /**
+     * Returns the raw template URI.
+     *
+     * @return template URI such as {@code Negotiation-T/v1/feasibility-negotiation/propose}
+     */
+    public String uri() {
+        return Stream.concat(Stream.of(extensionName, version), segments.stream())
+                .collect(Collectors.joining("/"));
+    }
+
+    /**
+     * Returns the extension prefix identifying the template family — the first URI segment, kept as a derived view for
+     * callers using the legacy term.
+     *
+     * @return extension prefix such as {@code Task-T}
+     */
+    public String extensionPrefix() {
+        return extensionName;
+    }
+
+    /**
+     * Binds the runtime language into a concrete template reference.
+     *
+     * <p>The language is global prompt runtime context, so callers normally pass this URI as-is; binding happens
+     * inside the SDK at the point where a language-carrying reference is required.
+     *
+     * @param language locale identifier such as {@code zh-CN} or {@code en-US}
+     * @return template reference carrying this URI and the given language
+     */
+    public TemplateReference withLanguage(String language) {
+        return new SimpleTemplateReference(uri(), language, extensionName);
+    }
+
+    private static void validateSegment(String value, String label) {
+        Objects.requireNonNull(value, label + " must not be null.");
+        if (!PathSegments.isSimpleSegment(value)) {
+            throw new IllegalArgumentException(
+                    label + " must be a non-blank simple path segment but was " + value + ".");
+        }
+    }
+}

--- a/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/MetadataContentTest.java
+++ b/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/MetadataContentTest.java
@@ -6,11 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import org.junit.jupiter.api.Test;
 
 class MetadataContentTest {
 
-    private static final String TEMPLATE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String TEMPLATE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     @Test
     void recordExposesAllThreeComponents() {

--- a/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/validation/TemplateUriTest.java
+++ b/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/validation/TemplateUriTest.java
@@ -1,0 +1,79 @@
+package net.openan.a2at.sdk.core.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class TemplateUriTest {
+
+    @Test
+    void composesUriFromComponents() {
+        TemplateUri uri = TemplateUri.of("Task-T", "v1", "energy-saving");
+        assertEquals("Task-T/v1/energy-saving", uri.uri());
+        assertEquals("Task-T", uri.extensionName());
+        assertEquals("v1", uri.version());
+        assertEquals(List.of("energy-saving"), uri.segments());
+    }
+
+    @Test
+    void extensionPrefixIsDerivedViewOfFirstSegment() {
+        TemplateUri uri = TemplateUri.of("Negotiation-T", "v1", "feasibility-negotiation", "propose");
+        assertEquals("Negotiation-T", uri.extensionPrefix());
+        assertEquals(uri.extensionName(), uri.extensionPrefix());
+    }
+
+    @Test
+    void parseRoundTripsSingleTrailingSegment() {
+        Optional<TemplateUri> parsed = TemplateUri.parse("Task-T/v1/energy-saving");
+        assertEquals(Optional.of(TemplateUri.of("Task-T", "v1", "energy-saving")), parsed);
+        assertEquals("Task-T/v1/energy-saving", parsed.orElseThrow().uri());
+    }
+
+    @Test
+    void parseRoundTripsTwoTrailingSegments() {
+        Optional<TemplateUri> parsed = TemplateUri.parse("Negotiation-T/v1/feasibility-negotiation/propose");
+        assertEquals(
+                Optional.of(TemplateUri.of("Negotiation-T", "v1", "feasibility-negotiation", "propose")), parsed);
+    }
+
+    @Test
+    void parseRejectsMalformedUris() {
+        assertEquals(Optional.empty(), TemplateUri.parse(null));
+        assertEquals(Optional.empty(), TemplateUri.parse("  "));
+        assertEquals(Optional.empty(), TemplateUri.parse("Task-T"));
+        assertEquals(Optional.empty(), TemplateUri.parse("Task-T/v1"));
+        assertEquals(Optional.empty(), TemplateUri.parse("Task-T/v1/energy-saving/../etc"));
+        assertEquals(Optional.empty(), TemplateUri.parse("Task-T/v1/energy\\saving"));
+        assertEquals(Optional.empty(), TemplateUri.parse("Task-T//energy-saving"));
+    }
+
+    @Test
+    void ofRejectsInvalidComponents() {
+        assertThrows(NullPointerException.class, () -> TemplateUri.of(null, "v1", "scenario"));
+        assertThrows(NullPointerException.class, () -> TemplateUri.of("Task-T", null, "scenario"));
+        assertThrows(IllegalArgumentException.class, () -> TemplateUri.of("Task-T", "v1"));
+        assertThrows(NullPointerException.class, () -> new TemplateUri("Task-T", "v1", (List<String>) null));
+        assertThrows(IllegalArgumentException.class, () -> TemplateUri.of("Task-T", "v1", "scen/ario"));
+        assertThrows(IllegalArgumentException.class, () -> TemplateUri.of("Task-T", "v1", "scen..ario/x"));
+        assertThrows(IllegalArgumentException.class, () -> TemplateUri.of("Task-T", "v1", "  "));
+    }
+
+    @Test
+    void withLanguageBindsRuntimeLanguage() {
+        TemplateReference reference = TemplateUri.of("Task-T", "v1", "energy-saving").withLanguage("zh-CN");
+        assertEquals("Task-T/v1/energy-saving", reference.uri());
+        assertEquals("zh-CN", reference.language());
+        assertEquals("Task-T", reference.extensionName());
+    }
+
+    @Test
+    void segmentsAreDefensivelyCopied() {
+        java.util.ArrayList<String> segments = new java.util.ArrayList<>(List.of("energy-saving"));
+        TemplateUri uri = new TemplateUri("Task-T", "v1", segments);
+        segments.add("tampered");
+        assertEquals(List.of("energy-saving"), uri.segments());
+    }
+}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReference.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReference.java
@@ -62,7 +62,7 @@ public record NegotiationReference(NegotiationType type, NegotiationPhase phase,
     }
 
     @Override
-    public String extensionPrefix() {
+    public String extensionName() {
         return URI_PREFIX;
     }
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReference.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReference.java
@@ -4,6 +4,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import net.openan.a2at.sdk.core.resources.PathSegments;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.validation.TemplateReference;
 import net.openan.a2at.sdk.negotiation.content.NegotiationPhase;
 import net.openan.a2at.sdk.negotiation.content.NegotiationType;
@@ -22,7 +23,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationType;
 public record NegotiationReference(NegotiationType type, NegotiationPhase phase, String language)
         implements TemplateReference {
 
-    private static final String URI_PREFIX = "Negotiation-T";
+    private static final String URI_PREFIX = StandardTemplates.NEGOTIATION_EXTENSION_NAME;
 
     private static final String URI_VERSION_SEGMENT = "v1";
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/concurrency/NegotiationConcurrentMixedLoadTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/concurrency/NegotiationConcurrentMixedLoadTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.core.model.FilledParamData;
@@ -35,7 +36,7 @@ class NegotiationConcurrentMixedLoadTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private static final int THREADS = 12;
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ConclusionLiteralAndExceptionSlotTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ConclusionLiteralAndExceptionSlotTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.stream.Stream;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityEndingContent;
 import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationConclusion;
@@ -46,7 +47,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 new InfoEndingContent(
                                         NegotiationConclusion.ACCEPT,
                                         List.of(new NegotiationItem("area information", "Songshan Lake")))),
-                        "Negotiation-T/v1/information-negotiation/accept-reject")
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
         String target = orchestrator
                 .generateAcceptFromData(
@@ -54,7 +55,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 context,
                                 new TargetEndingContent(
                                         NegotiationConclusion.ACCEPT, "The confirmed intent is recorded.", null)),
-                        "Negotiation-T/v1/target-negotiation/accept-reject")
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
         String feasibility = orchestrator
                 .generateAcceptFromData(
@@ -62,7 +63,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 context,
                                 new FeasibilityEndingContent(
                                         NegotiationConclusion.ACCEPT, "The target is achievable.")),
-                        "Negotiation-T/v1/feasibility-negotiation/accept-reject")
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
 
         assertTrue(information.contains(conclusionSection(language, "information") + "\nAccept"));
@@ -86,7 +87,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 new InfoEndingContent(
                                         NegotiationConclusion.REJECT,
                                         List.of(new NegotiationItem("area information", "not available")))),
-                        "Negotiation-T/v1/information-negotiation/accept-reject")
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
         String target = orchestrator
                 .generateRejectFromData(
@@ -94,7 +95,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 context,
                                 new TargetEndingContent(
                                         NegotiationConclusion.REJECT, null, "The intent cannot be clarified.")),
-                        "Negotiation-T/v1/target-negotiation/accept-reject")
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
         String feasibility = orchestrator
                 .generateRejectFromData(
@@ -102,7 +103,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 context,
                                 new FeasibilityEndingContent(
                                         NegotiationConclusion.REJECT, "The target is not achievable.")),
-                        "Negotiation-T/v1/feasibility-negotiation/accept-reject")
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
 
         assertTrue(information.contains(conclusionSection(language, "information") + "\nReject"));
@@ -125,14 +126,14 @@ class ConclusionLiteralAndExceptionSlotTest {
                         new NegotiationEndingData(
                                 new NegotiationContext(UUID, 2, 5),
                                 new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, summary)),
-                        "Negotiation-T/v1/feasibility-negotiation/accept-reject")
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
         String rejectText = orchestrator
                 .generateRejectFromData(
                         new NegotiationEndingData(
                                 new NegotiationContext(UUID, 2, 5),
                                 new FeasibilityEndingContent(NegotiationConclusion.REJECT, summary)),
-                        "Negotiation-T/v1/feasibility-negotiation/accept-reject")
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
 
         String sectionTitle =
@@ -156,7 +157,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                         new NegotiationEndingData(
                                 new NegotiationContext(UUID, 2, 5),
                                 new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, summary)),
-                        "Negotiation-T/v1/feasibility-negotiation/accept-reject")
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
                 .promptText();
 
         assertEquals(1, countOccurrences(promptText, summary));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ConditionalSectionRenderingTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ConditionalSectionRenderingTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.stream.Stream;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationAction;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
@@ -27,9 +28,9 @@ class ConditionalSectionRenderingTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String FEASIBILITY_PROPOSE_URI = "Negotiation-T/v1/feasibility-negotiation/propose";
+    private static final String FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri();
 
-    private static final String TARGET_PROPOSE_URI = "Negotiation-T/v1/target-negotiation/propose";
+    private static final String TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri();
 
     static Stream<Arguments> languages() {
         return Stream.of(Arguments.of("zh-CN"), Arguments.of("en-US"));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/FromDataProgrammingErrorMatrixTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/FromDataProgrammingErrorMatrixTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
@@ -38,17 +39,17 @@ class FromDataProgrammingErrorMatrixTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
-    private static final String INFORMATION_ACCEPT_URI = "Negotiation-T/v1/information-negotiation/accept-reject";
+    private static final String INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
 
-    private static final String TARGET_PROPOSE_URI = "Negotiation-T/v1/target-negotiation/propose";
+    private static final String TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri();
 
-    private static final String FEASIBILITY_PROPOSE_URI = "Negotiation-T/v1/feasibility-negotiation/propose";
+    private static final String FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri();
 
-    private static final String FEASIBILITY_ACCEPT_URI = "Negotiation-T/v1/feasibility-negotiation/accept-reject";
+    private static final String FEASIBILITY_ACCEPT_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri();
 
-    private static final String TARGET_ACCEPT_URI = "Negotiation-T/v1/target-negotiation/accept-reject";
+    private static final String TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri();
 
     private final CountingClient llm = new CountingClient();
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilderWiringTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilderWiringTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMError;
@@ -42,7 +43,7 @@ class NegotiationGenerationOrchestratorBuilderWiringTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private Logger rootLogger;
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -29,7 +30,7 @@ class NegotiationGenerationOrchestratorTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     @Test
     void generatesInformationProposeFromDataInChinese() {
@@ -128,7 +129,7 @@ class NegotiationGenerationOrchestratorTest {
         assertTrue(
                 zhOrchestrator().getNegotiationPrompt(INFORMATION_PROPOSE_URI).isPresent());
         assertTrue(zhOrchestrator()
-                .getNegotiationPrompt("Negotiation-T/v1/target-negotiation/accept-reject")
+                .getNegotiationPrompt(StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri())
                 .isPresent());
         assertFalse(zhOrchestrator()
                 .getNegotiationPrompt("Negotiation-T/v1/unknown-negotiation/propose")
@@ -242,7 +243,7 @@ class NegotiationGenerationOrchestratorTest {
                                 new NegotiationProposeData(
                                         new NegotiationContext(UUID, 1, 5),
                                         new InfoProposeContent(List.of(new NegotiationItem("区域", "松山湖")), null)),
-                                "Negotiation-T/v1/information-negotiation/accept-reject"));
+                                StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri()));
         assertTrue(phaseMismatchFailure
                 .getMessage()
                 .contains("Template URI is malformed or contradicts the expected phase PROPOSE (propose)"));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGeneratorsTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGeneratorsTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityEndingContent;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityProposeContent;
 import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
@@ -164,7 +165,7 @@ class NegotiationGeneratorsTest {
                 .generate(
                         context(1),
                         content,
-                        template("Negotiation-T/v1/feasibility-negotiation/propose", ZH_FEASIBILITY_PROPOSE_TEMPLATE),
+                        template(StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(), ZH_FEASIBILITY_PROPOSE_TEMPLATE),
                         zhVocabulary);
 
         assertTrue(rendered.contains("## 可行性协商\n请协助评估该节能目标能否达成。"));
@@ -187,7 +188,7 @@ class NegotiationGeneratorsTest {
                 .generate(
                         context(2),
                         content,
-                        template("Negotiation-T/v1/feasibility-negotiation/propose", ZH_FEASIBILITY_PROPOSE_TEMPLATE),
+                        template(StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(), ZH_FEASIBILITY_PROPOSE_TEMPLATE),
                         zhVocabulary);
 
         assertTrue(rendered.contains("## 可行性协商\n当前速率目标不可行，提出下调方案。"));
@@ -207,7 +208,7 @@ class NegotiationGeneratorsTest {
                                 context(1),
                                 nullAction,
                                 template(
-                                        "Negotiation-T/v1/feasibility-negotiation/propose",
+                                        StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
                                         ZH_FEASIBILITY_PROPOSE_TEMPLATE),
                                 zhVocabulary));
         assertTrue(nullActionError.getMessage().contains("action must not be null"));
@@ -221,7 +222,7 @@ class NegotiationGeneratorsTest {
                                 context(1),
                                 emptyEvaluation,
                                 template(
-                                        "Negotiation-T/v1/feasibility-negotiation/propose",
+                                        StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
                                         ZH_FEASIBILITY_PROPOSE_TEMPLATE),
                                 zhVocabulary));
         assertEquals(
@@ -237,7 +238,7 @@ class NegotiationGeneratorsTest {
                                 context(1),
                                 emptyAlternative,
                                 template(
-                                        "Negotiation-T/v1/feasibility-negotiation/propose",
+                                        StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
                                         ZH_FEASIBILITY_PROPOSE_TEMPLATE),
                                 zhVocabulary));
         assertEquals(
@@ -254,7 +255,7 @@ class NegotiationGeneratorsTest {
                                         context(1),
                                         blankDescription,
                                         template(
-                                                "Negotiation-T/v1/feasibility-negotiation/propose",
+                                                StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
                                                 ZH_FEASIBILITY_PROPOSE_TEMPLATE),
                                         zhVocabulary))
                         .getMessage());
@@ -272,7 +273,7 @@ class NegotiationGeneratorsTest {
                 .generate(
                         context(1),
                         content,
-                        template("Negotiation-T/v1/target-negotiation/propose", ZH_TARGET_PROPOSE_TEMPLATE),
+                        template(StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(), ZH_TARGET_PROPOSE_TEMPLATE),
                         zhVocabulary);
 
         assertTrue(rendered.contains("## 意图理解陈述\n1. 发起方理解：对方希望在体验无损的前提下降低节能力度"));
@@ -293,7 +294,7 @@ class NegotiationGeneratorsTest {
                 .generate(
                         context(3),
                         content,
-                        template("Negotiation-T/v1/target-negotiation/propose", ZH_TARGET_PROPOSE_TEMPLATE),
+                        template(StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(), ZH_TARGET_PROPOSE_TEMPLATE),
                         zhVocabulary);
 
         assertTrue(rendered.contains("## 理解对齐与疑问澄清\n1. 确认结果：节能时间范围确认为08:00~18:00"));
@@ -310,7 +311,7 @@ class NegotiationGeneratorsTest {
                         .generate(
                                 context(1),
                                 content,
-                                template("Negotiation-T/v1/target-negotiation/propose", ZH_TARGET_PROPOSE_TEMPLATE),
+                                template(StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(), ZH_TARGET_PROPOSE_TEMPLATE),
                                 zhVocabulary));
 
         assertEquals("Target negotiation description must not be blank.", exception.getMessage());
@@ -326,7 +327,7 @@ class NegotiationGeneratorsTest {
                 .generate(
                         context(1),
                         withRelationship,
-                        template("Negotiation-T/v1/information-negotiation/propose", ZH_INFO_PROPOSE_TEMPLATE),
+                        template(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(), ZH_INFO_PROPOSE_TEMPLATE),
                         zhVocabulary);
 
         assertTrue(renderedZh.contains("## 所需信息项\n1. 故障发生时间：精确到分钟的时间点\n2. 受影响小区标识：CGI 或小区名称"));
@@ -339,7 +340,7 @@ class NegotiationGeneratorsTest {
                 .generate(
                         context(1),
                         withoutRelationship,
-                        template("Negotiation-T/v1/information-negotiation/propose", ZH_INFO_PROPOSE_TEMPLATE),
+                        template(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(), ZH_INFO_PROPOSE_TEMPLATE),
                         zhVocabulary);
 
         assertFalse(renderedWithout.contains("缺失项之间的关系"));
@@ -352,7 +353,7 @@ class NegotiationGeneratorsTest {
                 "failure time and cell identity must correspond per cell");
 
         PromptTemplate enTemplate = template(
-                "Negotiation-T/v1/information-negotiation/propose",
+                StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(),
                 """
                 ## Negotiation Context
                 {{negotiation_context}} (required)
@@ -377,7 +378,7 @@ class NegotiationGeneratorsTest {
                         new InfoEndingContent(
                                 NegotiationConclusion.ACCEPT,
                                 List.of(new NegotiationItem("故障发生时间", "2026-08-19 10:30"))),
-                        template("Negotiation-T/v1/information-negotiation/accept-reject", ZH_INFO_ENDING_TEMPLATE),
+                        template(StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(), ZH_INFO_ENDING_TEMPLATE),
                         zhVocabulary);
 
         assertTrue(infoRendered.contains("## 信息协商结果\nAccept"));
@@ -387,7 +388,7 @@ class NegotiationGeneratorsTest {
                 .generate(
                         context(2),
                         new TargetEndingContent(NegotiationConclusion.REJECT, null, "双方未就速率保障下限达成一致。"),
-                        template("Negotiation-T/v1/target-negotiation/accept-reject", ZH_TARGET_ENDING_TEMPLATE),
+                        template(StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(), ZH_TARGET_ENDING_TEMPLATE),
                         zhVocabulary);
 
         assertTrue(targetRendered.contains("## 目标协商结果\nReject"));
@@ -398,7 +399,7 @@ class NegotiationGeneratorsTest {
                         context(2),
                         new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, "同意将速率保障目标由5Mbps下调至2Mbps。"),
                         template(
-                                "Negotiation-T/v1/feasibility-negotiation/accept-reject",
+                                StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
                                 ZH_FEASIBILITY_ENDING_TEMPLATE),
                         zhVocabulary);
 
@@ -412,20 +413,20 @@ class NegotiationGeneratorsTest {
                 .generate(
                         context(1),
                         new InfoEndingContent(NegotiationConclusion.ABORT, List.of()),
-                        template("Negotiation-T/v1/information-negotiation/accept-reject", ZH_INFO_ENDING_TEMPLATE),
+                        template(StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(), ZH_INFO_ENDING_TEMPLATE),
                         zhVocabulary));
         assertThrows(IllegalArgumentException.class, () -> new TargetEndingGenerator()
                 .generate(
                         context(1),
                         new TargetEndingContent(NegotiationConclusion.ABORT, "意图", null),
-                        template("Negotiation-T/v1/target-negotiation/accept-reject", ZH_TARGET_ENDING_TEMPLATE),
+                        template(StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(), ZH_TARGET_ENDING_TEMPLATE),
                         zhVocabulary));
         assertThrows(IllegalArgumentException.class, () -> new FeasibilityEndingGenerator()
                 .generate(
                         context(1),
                         new FeasibilityEndingContent(NegotiationConclusion.ABORT, "结论"),
                         template(
-                                "Negotiation-T/v1/feasibility-negotiation/accept-reject",
+                                StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
                                 ZH_FEASIBILITY_ENDING_TEMPLATE),
                         zhVocabulary));
     }
@@ -438,7 +439,7 @@ class NegotiationGeneratorsTest {
                                 context(1),
                                 new InfoEndingContent(null, List.of()),
                                 template(
-                                        "Negotiation-T/v1/information-negotiation/accept-reject",
+                                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(),
                                         ZH_INFO_ENDING_TEMPLATE),
                                 zhVocabulary));
 
@@ -453,7 +454,7 @@ class NegotiationGeneratorsTest {
                                 context(1),
                                 new TargetEndingContent(NegotiationConclusion.ACCEPT, null, "失败原因"),
                                 template(
-                                        "Negotiation-T/v1/target-negotiation/accept-reject", ZH_TARGET_ENDING_TEMPLATE),
+                                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(), ZH_TARGET_ENDING_TEMPLATE),
                                 zhVocabulary));
 
         assertEquals(
@@ -466,7 +467,7 @@ class NegotiationGeneratorsTest {
                                 context(1),
                                 new TargetEndingContent(NegotiationConclusion.REJECT, "  ", null),
                                 template(
-                                        "Negotiation-T/v1/target-negotiation/accept-reject", ZH_TARGET_ENDING_TEMPLATE),
+                                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(), ZH_TARGET_ENDING_TEMPLATE),
                                 zhVocabulary));
 
         assertEquals(
@@ -482,7 +483,7 @@ class NegotiationGeneratorsTest {
                                 context(1),
                                 new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, " "),
                                 template(
-                                        "Negotiation-T/v1/feasibility-negotiation/accept-reject",
+                                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
                                         ZH_FEASIBILITY_ENDING_TEMPLATE),
                                 zhVocabulary));
 
@@ -498,7 +499,7 @@ class NegotiationGeneratorsTest {
                         .generate(
                                 context(1),
                                 new TargetProposeContent("描述", null, null, null),
-                                template("Negotiation-T/v1/information-negotiation/propose", ZH_INFO_PROPOSE_TEMPLATE),
+                                template(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(), ZH_INFO_PROPOSE_TEMPLATE),
                                 zhVocabulary));
 
         assertTrue(exception.getMessage().contains("requires content of type InfoProposeContent"));
@@ -507,7 +508,7 @@ class NegotiationGeneratorsTest {
     @Test
     void generatorsRenderAgainstTheBundledTemplates() {
         NegotiationReference reference = NegotiationReference.tryParse(
-                        "Negotiation-T/v1/target-negotiation/propose", NegotiationPhase.PROPOSE, "zh-CN")
+                        StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(), NegotiationPhase.PROPOSE, "zh-CN")
                 .orElseThrow(() -> new AssertionError("expected the bundled target propose template to resolve"));
         PromptTemplate loaded = new DefaultNegotiationTemplateLoader("zh-CN", null).load(reference);
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationPromptResourceLoaderTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationPromptResourceLoaderTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.Test;
 
@@ -84,7 +85,7 @@ class NegotiationPromptResourceLoaderTest {
                         NegotiationMessageBuilder.TOKEN_NEGOTIATION_TYPE,
                         "information",
                         NegotiationMessageBuilder.TOKEN_TEMPLATE_URI,
-                        "Negotiation-T/v1/information-negotiation/propose",
+                        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(),
                         NegotiationMessageBuilder.TOKEN_SCHEMA,
                         "{\"type\":\"object\"}",
                         NegotiationMessageBuilder.TOKEN_INPUT,

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationTemplateQueryBoundaryTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationTemplateQueryBoundaryTest.java
@@ -11,6 +11,7 @@ import ch.qos.logback.core.read.ListAppender;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,12 +32,12 @@ import org.slf4j.LoggerFactory;
 class NegotiationTemplateQueryBoundaryTest {
 
     private static final List<String> EXPECTED_URI_ORDER = List.of(
-            "Negotiation-T/v1/information-negotiation/propose",
-            "Negotiation-T/v1/information-negotiation/accept-reject",
-            "Negotiation-T/v1/target-negotiation/propose",
-            "Negotiation-T/v1/target-negotiation/accept-reject",
-            "Negotiation-T/v1/feasibility-negotiation/propose",
-            "Negotiation-T/v1/feasibility-negotiation/accept-reject");
+            StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(),
+            StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(),
+            StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(),
+            StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(),
+            StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
+            StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri());
 
     private ListAppender<ILoggingEvent> logAppender;
 
@@ -85,11 +86,11 @@ class NegotiationTemplateQueryBoundaryTest {
         NegotiationGenerationOrchestrator orchestrator = orchestrator(language);
 
         Optional<PromptTemplate> template =
-                orchestrator.getNegotiationPrompt("Negotiation-T/v1/feasibility-negotiation/propose");
+                orchestrator.getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri());
 
         assertTrue(template.isPresent());
         assertEquals(
-                "Negotiation-T/v1/feasibility-negotiation/propose",
+                StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
                 template.orElseThrow().uri());
         String contextTitle = "zh-CN".equals(language) ? "## 协商上下文" : "## Negotiation Context";
         assertTrue(template.orElseThrow().content().contains(contextTitle));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/RelationshipLineRenderingTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/RelationshipLineRenderingTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.InfoProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
@@ -21,7 +22,7 @@ class RelationshipLineRenderingTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     @Test
     void chineseRelationshipIsAppendedWithTheChineseLabel() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/TemplateUriEntryMatrixTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/TemplateUriEntryMatrixTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -47,7 +48,7 @@ class TemplateUriEntryMatrixTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private static final String BUILTIN_INFORMATION_PROPOSE_TEMPLATE =
             "templates/Negotiation-T/v1/information-negotiation/propose/zh-CN/template.md";

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidateAndFillingDataPipelineTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidateAndFillingDataPipelineTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
@@ -41,12 +42,12 @@ class ValidateAndFillingDataPipelineTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private static final String INFORMATION_ACCEPT_REJECT_URI =
-            "Negotiation-T/v1/information-negotiation/accept-reject";
+            StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
 
-    private static final String TARGET_PROPOSE_URI = "Negotiation-T/v1/target-negotiation/propose";
+    private static final String TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri();
 
     private static final Map<String, Object> REGION_SCHEMA = Map.of(
             "type", "object", "properties", Map.of("region", Map.of("type", "string")), "required", List.of("region"));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/language/CustomRootPromptsIgnoredTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/language/CustomRootPromptsIgnoredTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.core.model.FilledParamData;
@@ -32,7 +33,7 @@ class CustomRootPromptsIgnoredTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private static final String FAKE_PROMPT_MARKER = "FAKE_PROMPT_MARKER_5b19";
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/language/NegotiationLanguageSwitchTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/language/NegotiationLanguageSwitchTest.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestrator;
 import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestratorBuilder;
@@ -30,7 +31,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 class NegotiationLanguageSwitchTest {
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     static Stream<GoldenCase> goldenCases() {
         return Stream.of(GoldenCase.values());

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationErrorCodeUsageMatrixTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationErrorCodeUsageMatrixTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
@@ -41,9 +42,9 @@ class NegotiationErrorCodeUsageMatrixTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
-    private static final String INFORMATION_ENDING_URI = "Negotiation-T/v1/information-negotiation/accept-reject";
+    private static final String INFORMATION_ENDING_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
 
     private static final String VALID_CONTEXT_PROMPT = "## 协商上下文\n- id: " + UUID + "\n- round: 1\n- maxRounds: 5";
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationExceptionTreeRootCatchTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationExceptionTreeRootCatchTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -35,7 +36,7 @@ class NegotiationExceptionTreeRootCatchTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     @Test
     void exhaustedGenerationLlmFailureIsCatchableThroughTheCommonRoot() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationLogEventContractTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationLogEventContractTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
@@ -48,7 +49,7 @@ class NegotiationLogEventContractTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private static final Map<String, Set<Level>> EXPECTED_EVENT_LEVELS = Map.ofEntries(
             Map.entry("negotiation_template_loaded", Set.of(Level.DEBUG)),

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationPublicExceptionSurfaceTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationPublicExceptionSurfaceTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.A2ATParamExtractionError;
@@ -33,7 +34,7 @@ class NegotiationPublicExceptionSurfaceTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private static final List<Class<?>> PUBLIC_EXCEPTION_TYPES = List.of(
             A2ATError.class,

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/resources/DefaultNegotiationTemplateLoaderTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/resources/DefaultNegotiationTemplateLoaderTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
 import net.openan.a2at.sdk.negotiation.content.NegotiationPhase;
@@ -18,12 +19,12 @@ import org.junit.jupiter.api.io.TempDir;
 class DefaultNegotiationTemplateLoaderTest {
 
     private static final List<String> EXPECTED_LOAD_ALL_URIS = List.of(
-            "Negotiation-T/v1/information-negotiation/propose",
-            "Negotiation-T/v1/information-negotiation/accept-reject",
-            "Negotiation-T/v1/target-negotiation/propose",
-            "Negotiation-T/v1/target-negotiation/accept-reject",
-            "Negotiation-T/v1/feasibility-negotiation/propose",
-            "Negotiation-T/v1/feasibility-negotiation/accept-reject");
+            StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(),
+            StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(),
+            StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(),
+            StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(),
+            StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
+            StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri());
 
     @TempDir
     Path customRootDir;
@@ -50,7 +51,7 @@ class DefaultNegotiationTemplateLoaderTest {
         PromptTemplate template =
                 loader.load(new NegotiationReference(NegotiationType.INFORMATION, NegotiationPhase.PROPOSE, "en-US"));
 
-        assertEquals("Negotiation-T/v1/information-negotiation/propose", template.uri());
+        assertEquals(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(), template.uri());
         assertTrue(template.content().startsWith("## Negotiation Context"));
     }
 
@@ -119,7 +120,7 @@ class DefaultNegotiationTemplateLoaderTest {
 
         assertEquals(EXPECTED_LOAD_ALL_URIS, urisOf(templates));
         PromptTemplate overriddenTemplate = templates.get(2);
-        assertEquals("Negotiation-T/v1/target-negotiation/propose", overriddenTemplate.uri());
+        assertEquals(StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(), overriddenTemplate.uri());
         assertTrue(overriddenTemplate.content().contains("自定义目标内容"));
     }
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReferenceTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReferenceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.NegotiationPhase;
 import net.openan.a2at.sdk.negotiation.content.NegotiationType;
 import org.junit.jupiter.api.Test;
@@ -21,13 +22,13 @@ class NegotiationReferenceTest {
     @Test
     void uriComposesPrefixVersionTypeSegmentAndPhaseSegment() {
         assertEquals(
-                "Negotiation-T/v1/information-negotiation/propose",
+                StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(),
                 new NegotiationReference(NegotiationType.INFORMATION, NegotiationPhase.PROPOSE, "en-US").uri());
         assertEquals(
-                "Negotiation-T/v1/target-negotiation/accept-reject",
+                StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(),
                 new NegotiationReference(NegotiationType.TARGET, NegotiationPhase.ACCEPT, "zh-CN").uri());
         assertEquals(
-                "Negotiation-T/v1/feasibility-negotiation/accept-reject",
+                StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
                 new NegotiationReference(NegotiationType.FEASIBILITY, NegotiationPhase.REJECT, "zh-CN").uri());
     }
 
@@ -103,7 +104,7 @@ class NegotiationReferenceTest {
     @Test
     void tryParseRejectsPhaseMismatchAgainstExpectedPhase() {
         Optional<NegotiationReference> parsed = NegotiationReference.tryParse(
-                "Negotiation-T/v1/information-negotiation/propose", NegotiationPhase.ACCEPT, "zh-CN");
+                StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(), NegotiationPhase.ACCEPT, "zh-CN");
 
         assertTrue(parsed.isEmpty());
     }
@@ -115,7 +116,7 @@ class NegotiationReferenceTest {
 
         NullPointerException exception = assertThrows(
                 NullPointerException.class,
-                () -> NegotiationReference.tryParse("Negotiation-T/v1/information-negotiation/propose", null, "zh-CN"));
+                () -> NegotiationReference.tryParse(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(), null, "zh-CN"));
         assertEquals("Expected negotiation phase must not be null.", exception.getMessage());
     }
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/resources/StandardTemplatesNegotiationConsistencyTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/resources/StandardTemplatesNegotiationConsistencyTest.java
@@ -1,0 +1,52 @@
+package net.openan.a2at.sdk.negotiation.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
+import net.openan.a2at.sdk.negotiation.content.NegotiationPhase;
+import net.openan.a2at.sdk.negotiation.content.NegotiationType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks the two sources of negotiation template URI spelling together: the constants in {@link StandardTemplates}
+ * (a2a-t-core, cannot depend on this module) and the compositional logic in {@link NegotiationReference} backed by
+ * the {@link NegotiationType}/{@link NegotiationPhase} enums. Any drift turns this test red.
+ */
+class StandardTemplatesNegotiationConsistencyTest {
+
+    @Test
+    void negotiationConstantsMatchReferenceComposition() {
+        for (NegotiationType type : NegotiationType.values()) {
+            for (NegotiationPhase phase : NegotiationPhase.values()) {
+                NegotiationReference reference = new NegotiationReference(type, phase, "en-US");
+                TemplateUri expected = findConstant(reference.uri());
+                assertEquals(
+                        reference.uri(),
+                        expected.uri(),
+                        "StandardTemplates has no constant matching the composed URI of " + type + "/" + phase);
+            }
+        }
+    }
+
+    @Test
+    void negotiationGroupCoversExactlyTheComposedUris() {
+        List<String> composed =
+                StandardTemplates.NEGOTIATION.stream().map(TemplateUri::uri).sorted().toList();
+        List<String> expected = new java.util.ArrayList<>();
+        for (NegotiationType type : NegotiationType.values()) {
+            for (NegotiationPhase phase : List.of(NegotiationPhase.PROPOSE, NegotiationPhase.ACCEPT)) {
+                expected.add(new NegotiationReference(type, phase, "en-US").uri());
+            }
+        }
+        assertEquals(expected.stream().sorted().toList(), composed);
+    }
+
+    private static TemplateUri findConstant(String uri) {
+        return StandardTemplates.NEGOTIATION.stream()
+                .filter(template -> template.uri().equals(uri))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No StandardTemplates constant for URI " + uri));
+    }
+}

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/BilateralInteropScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/BilateralInteropScenarioTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
 import net.openan.a2at.sdk.negotiation.content.InfoProposeContent;
@@ -28,9 +29,9 @@ class BilateralInteropScenarioTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
-    private static final String INFORMATION_ACCEPT_URI = "Negotiation-T/v1/information-negotiation/accept-reject";
+    private static final String INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
 
     private static final String EXTRACTION_RESPONSE =
             "{\"items\":[{\"name\":\"节能区域信息\",\"value\":\"松山湖\"}],\"relationship\":null}";

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/FeasibilityNegotiationScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/FeasibilityNegotiationScenarioTest.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityEndingContent;
@@ -37,9 +38,9 @@ import org.junit.jupiter.api.Test;
  */
 class FeasibilityNegotiationScenarioTest {
 
-    private static final String FEASIBILITY_PROPOSE_URI = "Negotiation-T/v1/feasibility-negotiation/propose";
+    private static final String FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri();
 
-    private static final String FEASIBILITY_ACCEPT_URI = "Negotiation-T/v1/feasibility-negotiation/accept-reject";
+    private static final String FEASIBILITY_ACCEPT_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri();
 
     @Test
     void feasibilityNegotiationRunsFromSemanticRejectionToATerminalAcceptance() throws IOException {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/InformationNegotiationScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/InformationNegotiationScenarioTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
@@ -30,9 +31,9 @@ class InformationNegotiationScenarioTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
-    private static final String INFORMATION_ACCEPT_URI = "Negotiation-T/v1/information-negotiation/accept-reject";
+    private static final String INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
 
     @Test
     void informationNegotiationReachesTheTerminalStateWithinOneRound() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/MaxRoundsExhaustionScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/MaxRoundsExhaustionScenarioTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
@@ -28,7 +29,7 @@ class MaxRoundsExhaustionScenarioTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String TARGET_ACCEPT_URI = "Negotiation-T/v1/target-negotiation/accept-reject";
+    private static final String TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri();
 
     @Test
     void exhaustedRoundBudgetEndsWithARejectMessageThePeerStillAccepts() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/TargetNegotiationScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/TargetNegotiationScenarioTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationConclusion;
@@ -28,9 +29,9 @@ class TargetNegotiationScenarioTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String TARGET_PROPOSE_URI = "Negotiation-T/v1/target-negotiation/propose";
+    private static final String TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri();
 
-    private static final String TARGET_ACCEPT_URI = "Negotiation-T/v1/target-negotiation/accept-reject";
+    private static final String TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri();
 
     @Test
     void targetNegotiationSwitchesConditionalSectionsAcrossRounds() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidatorTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidatorTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
@@ -68,7 +69,7 @@ class DefaultNegotiationSemanticValidatorTest {
         assertEquals("user", messages.get(1).get("role"));
         String userPrompt = messages.get(1).get("content");
         assertTrue(userPrompt.contains("information"));
-        assertTrue(userPrompt.contains("Negotiation-T/v1/information-negotiation/propose"));
+        assertTrue(userPrompt.contains(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri()));
         assertTrue(userPrompt.contains("confirmed_rate_mbps"));
         assertTrue(userPrompt.contains("energy saving region"));
         assertEquals(Map.of("merged", true), llmClient.lastSchema);

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptSlotSchemaLoader.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptSlotSchemaLoader.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.resources.ClasspathResourceDirectories;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotJsonSchema;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotSchema;
 import net.openan.a2at.sdk.resources.ClasspathPromptResourceLoader;
@@ -23,7 +24,8 @@ import net.openan.a2at.sdk.resources.PromptResourceKey;
  */
 public final class ClasspathPromptSlotSchemaLoader implements PromptSlotSchemaLoader {
 
-    private static final List<String> KNOWN_SLOT_TYPES = List.of("Task-T", "Notification-T");
+    private static final List<String> KNOWN_SLOT_TYPES =
+            List.of(StandardTemplates.TASK_EXTENSION_NAME, StandardTemplates.NOTIFICATION_EXTENSION_NAME);
 
     private static final List<String> SLOT_TYPES = discoverSlotTypes();
 

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptTemplateLoader.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptTemplateLoader.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.resources.ClasspathResourceDirectories;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.resources.ClasspathPromptResourceLoader;
 import net.openan.a2at.sdk.resources.PromptResourceKey;
 
@@ -19,7 +20,8 @@ import net.openan.a2at.sdk.resources.PromptResourceKey;
  */
 public final class ClasspathPromptTemplateLoader implements PromptTemplateTextLoader {
 
-    private static final List<String> KNOWN_TEMPLATE_TYPES = List.of("Task-T", "Notification-T", "Negotiation-T");
+    private static final List<String> KNOWN_TEMPLATE_TYPES = List.of(
+            StandardTemplates.TASK_EXTENSION_NAME, StandardTemplates.NOTIFICATION_EXTENSION_NAME, StandardTemplates.NEGOTIATION_EXTENSION_NAME);
 
     private static final List<String> TEMPLATE_TYPES = discoverTemplateTypes();
 

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Objects;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.validation.ContentValidator;
+import net.openan.a2at.sdk.core.validation.SimpleTemplateReference;
 import net.openan.a2at.sdk.core.validation.TemplateReference;
 import net.openan.a2at.sdk.core.validation.ValidationPipeline;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -21,7 +22,7 @@ import net.openan.a2at.sdk.prompt.resources.loader.PromptResourceAccess;
  */
 public final class DefaultContentValidator implements ContentValidator {
 
-    private final String extensionPrefix;
+    private final String extensionName;
     private final String language;
     private final int maxAttempts;
     private final LLMClient llmClient;
@@ -30,24 +31,24 @@ public final class DefaultContentValidator implements ContentValidator {
     private volatile ValidationPipeline pipeline;
 
     /**
-     * Creates a content validator for the given extension prefix and language.
+     * Creates a content validator for the given extension name and language.
      *
      * <p>The constructor does not load any prompt resources. The underlying semantic validator and its prompt resources
      * are loaded on the first {@link #validate} call.
      *
-     * @param extensionPrefix extension prefix used for template URI validation
+     * @param extensionName extension name used for template URI validation
      * @param language language code for prompt resource loading
      * @param maxAttempts maximum retry attempts for semantic validation
      * @param llmClient LLM client for semantic validation; may be {@code null} and set later
      * @param promptResourceAccess prompt resource access for loading validation prompts
      */
     public DefaultContentValidator(
-            String extensionPrefix,
+            String extensionName,
             String language,
             int maxAttempts,
             LLMClient llmClient,
             PromptResourceAccess promptResourceAccess) {
-        this.extensionPrefix = extensionPrefix;
+        this.extensionName = extensionName;
         this.language = language;
         this.maxAttempts = maxAttempts;
         this.llmClient = llmClient;
@@ -69,11 +70,10 @@ public final class DefaultContentValidator implements ContentValidator {
 
         String prefix = parts[0];
         String version = parts[1];
-        String scenario = parts[2];
 
-        if (!extensionPrefix.equals(prefix)) {
+        if (!extensionName.equals(prefix)) {
             throw new IllegalArgumentException(
-                    "Template URI prefix '" + prefix + "' does not match expected extension prefix '" + extensionPrefix
+                    "Template URI prefix '" + prefix + "' does not match expected extension prefix '" + extensionName
                             + "'.");
         }
 
@@ -81,7 +81,7 @@ public final class DefaultContentValidator implements ContentValidator {
             throw new IllegalArgumentException("Unsupported template URI version: " + version);
         }
 
-        TemplateReference reference = new SimpleTemplateReference(templateUri, language, extensionPrefix);
+        TemplateReference reference = new SimpleTemplateReference(templateUri, language, extensionName);
         return pipeline().validate(prompt, schema, reference);
     }
 
@@ -101,9 +101,4 @@ public final class DefaultContentValidator implements ContentValidator {
         }
         return p;
     }
-
-    /**
-     * Package-private template reference implementation.
-     */
-    record SimpleTemplateReference(String uri, String language, String extensionPrefix) implements TemplateReference {}
 }

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
@@ -102,7 +102,7 @@ public final class DefaultSemanticValidator implements SemanticValidator {
         }
 
         return userPromptTemplate
-                .replaceAll("\\[extension_name\\]", Matcher.quoteReplacement(reference.extensionPrefix()))
+                .replaceAll("\\[extension_name\\]", Matcher.quoteReplacement(reference.extensionName()))
                 .replaceAll("\\[input\\]", Matcher.quoteReplacement(prompt))
                 .replaceAll("\\[template_uri\\]", Matcher.quoteReplacement(reference.uri()))
                 .replaceAll("\\[schema\\]", Matcher.quoteReplacement(schemaJson));

--- a/a2a-t-resources/src/test/java/net/openan/a2at/sdk/resources/StandardTemplatesTest.java
+++ b/a2a-t-resources/src/test/java/net/openan/a2at/sdk/resources/StandardTemplatesTest.java
@@ -1,0 +1,81 @@
+package net.openan.a2at.sdk.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks the {@link StandardTemplates} constants to the template tree bundled in this module: adding or removing a
+ * {@code template.md} under {@code prompt_resources/templates} without updating the constants (or vice versa) turns
+ * this test red.
+ *
+ * <p>This test lives in a2a-t-resources because downstream modules ship their own {@code prompt_resources} test
+ * fixtures that would shadow this module's tree on the classpath.
+ */
+class StandardTemplatesTest {
+
+    @Test
+    void constantsMatchBundledTemplateTree() throws Exception {
+        Set<String> constantUris = new TreeSet<>();
+        Stream.of(StandardTemplates.TASK, StandardTemplates.NOTIFICATION, StandardTemplates.AUTHORIZATION,
+                        StandardTemplates.NEGOTIATION)
+                .flatMap(List::stream)
+                .map(TemplateUri::uri)
+                .forEach(constantUris::add);
+
+        assertEquals(
+                constantUris,
+                scanTemplateTree(),
+                "StandardTemplates constants and the bundled prompt_resources/templates tree have drifted");
+    }
+
+    @Test
+    void groupsPartitionAllConstants() {
+        List<TemplateUri> grouped = new ArrayList<>();
+        grouped.addAll(StandardTemplates.TASK);
+        grouped.addAll(StandardTemplates.NOTIFICATION);
+        grouped.addAll(StandardTemplates.AUTHORIZATION);
+        grouped.addAll(StandardTemplates.NEGOTIATION);
+        assertEquals(11, grouped.size(), "expected the 11 built-in templates");
+        assertEquals(2, StandardTemplates.TASK.size());
+        assertEquals(2, StandardTemplates.NOTIFICATION.size());
+        assertEquals(1, StandardTemplates.AUTHORIZATION.size());
+        assertEquals(6, StandardTemplates.NEGOTIATION.size());
+    }
+
+    /**
+     * Collects the template URIs present under {@code prompt_resources/templates} by stripping the trailing
+     * {@code <language>/template.md} segments from every {@code template.md} file.
+     */
+    private static Set<String> scanTemplateTree() throws IOException, java.net.URISyntaxException {
+        URL root = StandardTemplatesTest.class.getClassLoader().getResource("prompt_resources/templates");
+        if (root == null || !"file".equals(root.getProtocol())) {
+            // Directory walking only works on exploded classpaths; Maven test runs always satisfy this.
+            throw new IllegalStateException("prompt_resources/templates not reachable as a file URL: " + root);
+        }
+        Path rootPath = Path.of(root.toURI());
+        try (Stream<Path> files = Files.walk(rootPath)) {
+            Set<String> uris = new TreeSet<>();
+            files.filter(Files::isRegularFile)
+                    .filter(file -> "template.md".equals(file.getFileName().toString()))
+                    .forEach(file -> {
+                        Path relative = rootPath.relativize(file);
+                        int segmentCount = relative.getNameCount();
+                        // relative = <uri segments...>/<language>/template.md
+                        uris.add(relative.subpath(0, segmentCount - 2).toString().replace('\\', '/'));
+                    });
+            return uris;
+        }
+    }
+}

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/api/NegotiationFacadeOutputSymmetryTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/api/NegotiationFacadeOutputSymmetryTest.java
@@ -22,6 +22,7 @@ import net.openan.a2at.sdk.negotiation.content.FeasibilityProposeContent;
 import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
 import net.openan.a2at.sdk.negotiation.content.InfoProposeContent;
 import net.openan.a2at.sdk.core.model.MetadataContent;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.NegotiationAction;
 import net.openan.a2at.sdk.negotiation.content.NegotiationConclusion;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
@@ -151,7 +152,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "information_propose",
                         NegotiationPhase.PROPOSE,
-                        "Negotiation-T/v1/information-negotiation/propose",
+                        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(),
                         new NegotiationProposeData(
                                 new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5),
                                 new InfoProposeContent(
@@ -163,7 +164,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "target_propose",
                         NegotiationPhase.PROPOSE,
-                        "Negotiation-T/v1/target-negotiation/propose",
+                        StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(),
                         new NegotiationProposeData(
                                 new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 1, 5),
                                 new TargetProposeContent(
@@ -174,7 +175,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "feasibility_propose",
                         NegotiationPhase.PROPOSE,
-                        "Negotiation-T/v1/feasibility-negotiation/propose",
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
                         new NegotiationProposeData(
                                 new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5),
                                 new FeasibilityProposeContent(
@@ -185,36 +186,36 @@ class NegotiationFacadeOutputSymmetryTest {
                 endingCase(
                         "information_accept",
                         NegotiationPhase.ACCEPT,
-                        "Negotiation-T/v1/information-negotiation/accept-reject",
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(),
                         new InfoEndingContent(
                                 NegotiationConclusion.ACCEPT,
                                 List.of(new NegotiationItem("area information", "Songshan Lake")))),
                 endingCase(
                         "target_accept",
                         NegotiationPhase.ACCEPT,
-                        "Negotiation-T/v1/target-negotiation/accept-reject",
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(),
                         new TargetEndingContent(NegotiationConclusion.ACCEPT, "The confirmed intent.", null)),
                 endingCase(
                         "feasibility_accept",
                         NegotiationPhase.ACCEPT,
-                        "Negotiation-T/v1/feasibility-negotiation/accept-reject",
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
                         new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, "The target is achievable.")),
                 endingCase(
                         "information_reject",
                         NegotiationPhase.REJECT,
-                        "Negotiation-T/v1/information-negotiation/accept-reject",
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(),
                         new InfoEndingContent(
                                 NegotiationConclusion.REJECT,
                                 List.of(new NegotiationItem("area information", "not available")))),
                 endingCase(
                         "target_reject",
                         NegotiationPhase.REJECT,
-                        "Negotiation-T/v1/target-negotiation/accept-reject",
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(),
                         new TargetEndingContent(NegotiationConclusion.REJECT, null, "The intent is unclear.")),
                 endingCase(
                         "feasibility_reject",
                         NegotiationPhase.REJECT,
-                        "Negotiation-T/v1/feasibility-negotiation/accept-reject",
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
                         new FeasibilityEndingContent(NegotiationConclusion.REJECT, "The target is not achievable.")));
     }
 

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.List;
 import net.openan.a2at.sdk.core.model.A2ATConfig;
 import net.openan.a2at.sdk.core.validation.ContentValidator;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMClientConfig;
 import net.openan.a2at.sdk.llm.LLMClientFactory;
@@ -166,7 +167,7 @@ public final class DefaultA2ATServerBuilder {
         requireSupportedConfig();
         require(envPath, "Unified SDK env path must be configured.");
         return new DefaultContentValidator(
-                "Task-T",
+                StandardTemplates.TASK_EXTENSION_NAME,
                 config.prompt().language(),
                 config.llm().maxAttempts(),
                 createLlmClient(),
@@ -186,7 +187,7 @@ public final class DefaultA2ATServerBuilder {
         requireSupportedConfig();
         require(envPath, "Unified SDK env path must be configured.");
         return new DefaultContentValidator(
-                "Notification-T",
+                StandardTemplates.NOTIFICATION_EXTENSION_NAME,
                 config.prompt().language(),
                 config.llm().maxAttempts(),
                 createLlmClient(),
@@ -206,7 +207,7 @@ public final class DefaultA2ATServerBuilder {
         requireSupportedConfig();
         require(envPath, "Unified SDK env path must be configured.");
         return new DefaultContentValidator(
-                "Authorization-T",
+                StandardTemplates.AUTHORIZATION_EXTENSION_NAME,
                 config.prompt().language(),
                 config.llm().maxAttempts(),
                 createLlmClient(),

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/A2ATServerNegotiationApiTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/A2ATServerNegotiationApiTest.java
@@ -15,6 +15,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.server.A2ATServer;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,8 @@ class A2ATServerNegotiationApiTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI =
+            StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     @Test
     void generatesInformationProposeFromDataWithBuiltinChineseTemplates() throws IOException {
@@ -73,7 +75,8 @@ class A2ATServerNegotiationApiTest {
         A2ATServer server = new A2ATServer(writeEnv("zh-CN"));
 
         assertTrue(server.getNegotiationPrompt(INFORMATION_PROPOSE_URI).isPresent());
-        assertTrue(server.getNegotiationPrompt("Negotiation-T/v1/feasibility-negotiation/accept-reject")
+        assertTrue(server
+                .getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
                 .isPresent());
         assertFalse(server.getNegotiationPrompt("not-a-template-uri").isPresent());
         PromptTemplate template =

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/TaskPromptNegotiationCoexistenceTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/TaskPromptNegotiationCoexistenceTest.java
@@ -16,6 +16,7 @@ import net.openan.a2at.sdk.llm.LLMClientFactory;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.negotiation.content.InfoProposeContent;
 import net.openan.a2at.sdk.core.model.MetadataContent;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException;
@@ -46,7 +47,8 @@ class TaskPromptNegotiationCoexistenceTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = "Negotiation-T/v1/information-negotiation/propose";
+    private static final String INFORMATION_PROPOSE_URI =
+            StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     private static final String TASK_T_MESSAGE = "## 任务类型(Task Type)\n"
             + "无线能效优化\n\n"


### PR DESCRIPTION
# PR: StandardTemplates template constants + TemplateUri value type

Branch: `refactor/standard-template-uri`

## Summary

Introduces a `StandardCharsets`-style constants API for the built-in A2A-T content templates, backed by a new structured `TemplateUri` value type, and converges all hardcoded template URI strings in main code and tests onto it.

## Changes

### Phase 1 — core types (commit `25a0876`)

- **`TemplateUri`** (new, `a2a-t-core` `validation` package): a record of `extensionName`, `version` and trailing `segments`. Constructing or parsing validates every segment (`PathSegments.isSimpleSegment`), so a `TemplateUri` can never carry a malformed URI — the structural invariants that `DefaultContentValidator` and `PromptTemplateCatalog` previously re-derived by splitting raw strings are now encoded in the type. Provides `of(...)` (composition), `parse(...)` (wire-format parsing, `Optional` semantics mirroring `NegotiationReference.tryParse`), `uri()`, derived `extensionPrefix()` (legacy-term view of the first segment), and `withLanguage(...)` which binds the runtime language into a `TemplateReference`.
- **`StandardTemplates`** (new): 11 built-in template constants (`ENERGY_SAVING`, `PRIVATE_LINE_COMPLAINT`, `SUBSCRIBE_INCIDENT`, `SERVICE_RECOVERY`, `AUTHZ_POLICY_MGR`, and the six `*_NEGOTIATION_*` propose/accept-reject entries) plus `TASK`/`NOTIFICATION`/`AUTHORIZATION`/`NEGOTIATION` group views and `*_EXTENSION_NAME` string constants.
- **`TemplateReference`**: `extensionPrefix()` renamed to `extensionName()` for terminology consistency; `SimpleTemplateReference` moved from `DefaultContentValidator` (package-private) into core as the public plain-carrier implementation.
- **Language binding stays runtime-global**: callers pass the language-neutral `TemplateUri`; the SDK binds `A2AT_LANGUAGE` config internally. Facade signatures (`A2ATClient` / `A2ATServer`) unchanged.

### Phase 2 — convergence (commit `e114d5f`, 39 files)

- Main code: `DefaultA2ATServerBuilder` validator prefixes, `ClasspathPromptTemplateLoader.KNOWN_TEMPLATE_TYPES`, `ClasspathPromptSlotSchemaLoader.KNOWN_SLOT_TYPES` (probe order preserved) and `NegotiationReference.URI_PREFIX` now derive from the `*_EXTENSION_NAME` constants.
- Tests: ~90 hardcoded builtin template URI literals across all modules replaced with `StandardTemplates.XXX.uri()`; local `*_URI` test constants keep their names with initializers swapped. Negative/malformed-URI fixtures, non-builtin fixture URIs and compositional constructions intentionally remain raw strings.
- Javadoc literals that document *what a value is* remain raw; no usage-style examples existed.

### Consistency locks

- `StandardTemplatesTest` (a2a-t-resources): scans the bundled `prompt_resources/templates` tree and asserts it equals the constant set — resource drift turns red.
- `StandardTemplatesNegotiationConsistencyTest` (a2a-t-negotiation): asserts `NegotiationReference` composition over `NegotiationType` × `NegotiationPhase` matches the constants exactly.
- `TemplateUriTest` (a2a-t-core): factory validation, parse round-trips, language binding, defensive copies.

## Verification

- `mvn test` — BUILD SUCCESS, all 10 modules green (run twice: once by the workflow verify stage, once independently).
- `python tools/template_lint.py --resource-root a2a-t-resources/src/main/resources/prompt_resources` — passed.
- Pure convergence refactor: no behavior changes, no facade signature changes.

## Notes

- Facade overloads accepting `TemplateUri` were deliberately deferred (language is resolved from global runtime config; users pass the constant object directly when overloads land).
- No `Language` enum introduced; language remains a locale-id string.
