### PR TITLE
refactor(api): replace String templateUri with TemplateUri type on fa…

### DIFF
--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
@@ -3,6 +3,7 @@ package net.openan.a2at.sdk.client;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 import net.openan.a2at.sdk.client.prompt.assembly.DefaultA2ATClientBuilder;
@@ -11,6 +12,7 @@ import net.openan.a2at.sdk.core.model.A2ATConfig;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContentService;
 import net.openan.a2at.sdk.negotiation.content.NegotiationEndingData;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
@@ -19,6 +21,8 @@ import net.openan.a2at.sdk.negotiation.types.model.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.types.model.NegotiationStatus;
 import net.openan.a2at.sdk.negotiation.types.model.NegotiationType;
 import net.openan.a2at.sdk.prompt.resources.catalog.TemplateQueryService;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * High-level client facade for prompt generation and negotiation APIs. The caller provides the `.env` file path
@@ -71,10 +75,9 @@ public final class A2ATClient {
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the template URI is null
-     * @throws IllegalArgumentException if the template URI is blank or contains invalid characters
      */
-    public MetadataContent generateTaskPromptFromText(
-            String text, String templateUri) {
+    public MetadataContent generateTaskPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateTaskPromptFromText(text, templateUri);
     }
 
@@ -83,54 +86,57 @@ public final class A2ATClient {
      * identified by the template URI, bypassing scenario recognition.
      *
      * @param data structured task input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction
+     * @param schema optional data schema map for schema-guided extraction; null disables schema-guided extraction
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the template URI is null
-     * @throws IllegalArgumentException if the template URI is blank or contains invalid characters
      */
     public MetadataContent generateTaskPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String templateUri) {
+            @NonNull Map<String, Object> data,
+            @Nullable Map<String, Object> schema,
+            @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateTaskPromptFromDataWithSchema(data, schema, templateUri);
     }
 
     /**
      * Generates an authorization prompt with metadata from natural-language input using the template identified by the
-     * authorization type, bypassing scenario recognition.
+     * template URI, bypassing scenario recognition.
      *
      * <p><b>Experimental:</b> Authorization-T template resources (such as {@code authz-policy-mgr}) are bundled and
      * discovered automatically, but Authorization-T slot schemas are not yet bundled, so template-driven slot
      * extraction fails until Authorization-T slot resources are added or provided through the local resource root.
      *
      * @param text natural-language authorization input
-     * @param authorizationType authorization type used as the template identifier
+     * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the authorization type is null
-     * @throws IllegalArgumentException if the authorization type is blank or contains invalid characters
+     * @throws NullPointerException if the template URI is null
      */
-    public MetadataContent generateAuthPromptFromText(
-            String text, String authorizationType) {
-        return promptGenerationOrchestrator.generateAuthPromptFromText(text, authorizationType);
+    public MetadataContent generateAuthPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
+        return promptGenerationOrchestrator.generateAuthPromptFromText(text, templateUri);
     }
 
     /**
      * Generates an authorization prompt with metadata from structured input and an optional data schema using the
-     * template identified by the authorization type, bypassing scenario recognition.
+     * template identified by the template URI, bypassing scenario recognition.
      *
      * <p><b>Experimental:</b> Authorization-T template resources (such as {@code authz-policy-mgr}) are bundled and
      * discovered automatically, but Authorization-T slot schemas are not yet bundled, so template-driven slot
      * extraction fails until Authorization-T slot resources are added or provided through the local resource root.
      *
      * @param data structured authorization input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction
-     * @param authorizationType authorization type used as the template identifier
+     * @param schema optional data schema map for schema-guided extraction; null disables schema-guided extraction
+     * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the authorization type is null
-     * @throws IllegalArgumentException if the authorization type is blank or contains invalid characters
+     * @throws NullPointerException if the template URI is null
      */
     public MetadataContent generateAuthPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String authorizationType) {
-        return promptGenerationOrchestrator.generateAuthPromptFromDataWithSchema(data, schema, authorizationType);
+            @NonNull Map<String, Object> data,
+            @Nullable Map<String, Object> schema,
+            @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
+        return promptGenerationOrchestrator.generateAuthPromptFromDataWithSchema(data, schema, templateUri);
     }
 
     /**
@@ -141,10 +147,9 @@ public final class A2ATClient {
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the template URI is null
-     * @throws IllegalArgumentException if the template URI is blank or contains invalid characters
      */
-    public MetadataContent generateNotificationPromptFromText(
-            String text, String templateUri) {
+    public MetadataContent generateNotificationPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateNotificationPromptFromText(text, templateUri);
     }
 
@@ -153,14 +158,16 @@ public final class A2ATClient {
      * template identified by the template URI, bypassing scenario recognition.
      *
      * @param data structured notification input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction
+     * @param schema optional data schema map for schema-guided extraction; null disables schema-guided extraction
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the template URI is null
-     * @throws IllegalArgumentException if the template URI is blank or contains invalid characters
      */
     public MetadataContent generateNotificationPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String templateUri) {
+            @NonNull Map<String, Object> data,
+            @Nullable Map<String, Object> schema,
+            @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateNotificationPromptFromDataWithSchema(data, schema, templateUri);
     }
 
@@ -207,17 +214,18 @@ public final class A2ATClient {
      * generator of the negotiation type addressed by the template URI and rendered from that template.
      *
      * @param data typed propose input carrying the negotiation context and the typed content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/propose}; its phase
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/propose/v1}; its phase
      *     segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, or its phase or type contradicts the method
-     *     or the content type
+     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content type
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, String templateUri) {
+    public MetadataContent generateNegotiationProposePromptFromData(
+            @NonNull NegotiationProposeData data, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.generateProposeFromData(data, templateUri);
     }
 
@@ -228,17 +236,19 @@ public final class A2ATClient {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/accept-reject}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its
+     *     phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, its phase or type contradicts the method or
-     *     the content, or the content conclusion is not {@code Accept}
+     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
+     *     content conclusion is not {@code Accept}
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateNegotiationAcceptPromptFromData(NegotiationEndingData data, String templateUri) {
+    public MetadataContent generateNegotiationAcceptPromptFromData(
+            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.generateAcceptFromData(data, templateUri);
     }
 
@@ -249,17 +259,19 @@ public final class A2ATClient {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/feasibility-negotiation/accept-reject}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its
+     *     phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, its phase or type contradicts the method or
-     *     the content, or the content conclusion is not {@code Reject}
+     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
+     *     content conclusion is not {@code Reject}
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateNegotiationRejectPromptFromData(NegotiationEndingData data, String templateUri) {
+    public MetadataContent generateNegotiationRejectPromptFromData(
+            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.generateRejectFromData(data, templateUri);
     }
 
@@ -273,11 +285,11 @@ public final class A2ATClient {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose}; its phase segment
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase segment
      *     must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws IllegalArgumentException if the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
@@ -286,7 +298,10 @@ public final class A2ATClient {
      *     content contradicts the phase
      */
     public MetadataContent generateNegotiationProposePromptFromText(
-            String text, net.openan.a2at.sdk.negotiation.content.NegotiationContext context, String templateUri) {
+            @NonNull String text,
+            net.openan.a2at.sdk.negotiation.content.NegotiationContext context,
+            @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.generateProposeFromText(text, context, templateUri);
     }
 
@@ -299,11 +314,11 @@ public final class A2ATClient {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/accept-reject}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its
+     *     phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws IllegalArgumentException if the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
@@ -312,7 +327,10 @@ public final class A2ATClient {
      *     conclusion is not {@code Accept}
      */
     public MetadataContent generateNegotiationAcceptPromptFromText(
-            String text, net.openan.a2at.sdk.negotiation.content.NegotiationContext context, String templateUri) {
+            @NonNull String text,
+            net.openan.a2at.sdk.negotiation.content.NegotiationContext context,
+            @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.generateAcceptFromText(text, context, templateUri);
     }
 
@@ -325,11 +343,11 @@ public final class A2ATClient {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/feasibility-negotiation/accept-reject}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its
+     *     phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws IllegalArgumentException if the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
@@ -338,7 +356,10 @@ public final class A2ATClient {
      *     conclusion is not {@code Reject}
      */
     public MetadataContent generateNegotiationRejectPromptFromText(
-            String text, net.openan.a2at.sdk.negotiation.content.NegotiationContext context, String templateUri) {
+            @NonNull String text,
+            net.openan.a2at.sdk.negotiation.content.NegotiationContext context,
+            @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.generateRejectFromText(text, context, templateUri);
     }
 
@@ -359,16 +380,16 @@ public final class A2ATClient {
     /**
      * Loads one template by its URI, regardless of the extension.
      *
-     * <p>This query never throws: a missing template or an unusable URI yields an empty result together with a warning
-     * log instead of a failure.
+     * <p>This query never throws: a missing template yields an empty result together with a warning log instead of a
+     * failure.
      *
-     * @param uri template URI such as {@code Negotiation-T/v1/target-negotiation/propose} or
-     *     {@code Task-T/v1/energy-saving}
-     * @return the addressed template, or an empty optional when the URI is malformed or no template exists for it in
-     *     the configured language
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1} or
+     *     {@code Task-T/network-layer/energy-saving/v1}
+     * @return the addressed template, or an empty optional when no template exists for it in the configured language
      */
-    public Optional<PromptTemplate> getPrompt(String uri) {
-        return templateQueryService.getPrompt(uri);
+    public Optional<PromptTemplate> getPrompt(@NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
+        return templateQueryService.getPrompt(templateUri);
     }
 
     /**
@@ -387,25 +408,24 @@ public final class A2ATClient {
     /**
      * Loads one negotiation template by its URI.
      *
-     * <p>This query never throws: a missing template or an unusable URI yields an empty result together with a warning
-     * log instead of a failure.
+     * <p>This query never throws: a missing template yields an empty result together with a warning log instead of a
+     * failure.
      *
-     * @param uri template URI such as {@code Negotiation-T/v1/target-negotiation/propose}
-     * @return the addressed template, or an empty optional when the URI is malformed or no template exists for it in
-     *     the configured language
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}
+     * @return the addressed template, or an empty optional when no template exists for it in the configured language
      */
-    public Optional<PromptTemplate> getNegotiationPrompt(String uri) {
-        return negotiationContentService.getNegotiationPrompt(uri);
+    public Optional<PromptTemplate> getNegotiationPrompt(@NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
+        return negotiationContentService.getNegotiationPrompt(templateUri);
     }
 
     /**
      * Validates a propose-phase negotiation message and extracts its parameters.
      *
-     * <p>The pipeline first checks the template URI format, then runs the deterministic rule gate (recognition of the
-     * negotiation context section and its strong constraints) before any LLM call, then performs one LLM semantic
-     * validation call that also extracts the parameters, and finally merges the parameters with the context parameters
-     * taking precedence. The semantic step is retried up to the configured attempt limit on the retryable LLM
-     * infrastructure failure code.
+     * <p>The pipeline first runs the deterministic rule gate (recognition of the negotiation context section and its
+     * strong constraints) before any LLM call, then performs one LLM semantic validation call that also extracts the
+     * parameters, and finally merges the parameters with the context parameters taking precedence. The semantic step
+     * is retried up to the configured attempt limit on the retryable LLM infrastructure failure code.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
@@ -413,8 +433,7 @@ public final class A2ATClient {
      *     {@code propose}
      * @return filled parameter data carrying the context parameters and the extracted parameters
      * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or its phase
-     *     contradicts the method
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation_invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
@@ -423,16 +442,17 @@ public final class A2ATClient {
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
     public FilledParamData validateAndFillingProposeData(
-            String prompt, Map<String, Object> schema, String templateUri) {
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.validateAndFillingProposeData(prompt, schema, templateUri);
     }
 
     /**
      * Validates an accept-phase negotiation message and extracts its parameters.
      *
-     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, String)} with the expected phase
-     * fixed to accept: the template URI must declare the {@code accept-reject} segment and the message must satisfy the
-     * accept-phase semantic constraints.
+     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, TemplateUri)} with the expected
+     * phase fixed to accept: the template URI must declare the {@code accept-reject} segment and the message must
+     * satisfy the accept-phase semantic constraints.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
@@ -440,8 +460,7 @@ public final class A2ATClient {
      *     {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
      * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or its phase
-     *     contradicts the method
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation_invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
@@ -449,16 +468,18 @@ public final class A2ATClient {
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
-    public FilledParamData validateAndFillingAcceptData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingAcceptData(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.validateAndFillingAcceptData(prompt, schema, templateUri);
     }
 
     /**
      * Validates a reject-phase negotiation message and extracts its parameters.
      *
-     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, String)} with the expected phase
-     * fixed to reject: the template URI must declare the {@code accept-reject} segment and the message must satisfy the
-     * reject-phase semantic constraints.
+     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, TemplateUri)} with the expected
+     * phase fixed to reject: the template URI must declare the {@code accept-reject} segment and the message must
+     * satisfy the reject-phase semantic constraints.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
@@ -466,8 +487,7 @@ public final class A2ATClient {
      *     {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
      * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or its phase
-     *     contradicts the method
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation_invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
@@ -475,7 +495,9 @@ public final class A2ATClient {
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
-    public FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingRejectData(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         return negotiationContentService.validateAndFillingRejectData(prompt, schema, templateUri);
     }
 }

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/package-info.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/package-info.java
@@ -1,2 +1,5 @@
 /** Client-facing APIs for the a2a-t Java SDK. */
+@NullMarked
 package net.openan.a2at.sdk.client;
+
+import org.jspecify.annotations.NullMarked;

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/ClientPromptGenerationOrchestrator.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/ClientPromptGenerationOrchestrator.java
@@ -3,6 +3,7 @@ package net.openan.a2at.sdk.client.prompt.orchestration;
 import java.util.Map;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 
 /**
  * Internal prompt-generation orchestration contract used by the client facade.
@@ -27,7 +28,7 @@ public interface ClientPromptGenerationOrchestrator {
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      */
-    MetadataContent generateTaskPromptFromText(String text, String templateUri);
+    MetadataContent generateTaskPromptFromText(String text, TemplateUri templateUri);
 
     /**
      * Generates a task prompt with metadata from structured input and an optional data schema using the template
@@ -39,29 +40,29 @@ public interface ClientPromptGenerationOrchestrator {
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      */
     MetadataContent generateTaskPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String templateUri);
+            Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri);
 
     /**
      * Generates an authorization prompt with metadata from natural-language input using the template identified by the
-     * authorization type, bypassing scenario recognition.
+     * template URI, bypassing scenario recognition.
      *
      * @param text natural-language authorization input
-     * @param authorizationType authorization type used as the template identifier
+     * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      */
-    MetadataContent generateAuthPromptFromText(String text, String authorizationType);
+    MetadataContent generateAuthPromptFromText(String text, TemplateUri templateUri);
 
     /**
      * Generates an authorization prompt with metadata from structured input and an optional data schema using the
-     * template identified by the authorization type, bypassing scenario recognition.
+     * template identified by the template URI, bypassing scenario recognition.
      *
      * @param data structured authorization input as a string-to-object map
      * @param schema optional data schema map for schema-guided extraction
-     * @param authorizationType authorization type used as the template identifier
+     * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      */
     MetadataContent generateAuthPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String authorizationType);
+            Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri);
 
     /**
      * Generates a notification prompt with metadata from natural-language input using the template identified by the
@@ -71,7 +72,7 @@ public interface ClientPromptGenerationOrchestrator {
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      */
-    MetadataContent generateNotificationPromptFromText(String text, String templateUri);
+    MetadataContent generateNotificationPromptFromText(String text, TemplateUri templateUri);
 
     /**
      * Generates a notification prompt with metadata from structured input and an optional data schema using the
@@ -83,5 +84,5 @@ public interface ClientPromptGenerationOrchestrator {
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      */
     MetadataContent generateNotificationPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String templateUri);
+            Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri);
 }

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestrator.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestrator.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.client.model.PromptGenerationFailure;
@@ -18,6 +17,7 @@ import net.openan.a2at.sdk.core.exception.FailedParameter;
 import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.prompt.analysis.model.ScenarioRecognitionResult;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotDefinition;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotSchema;
@@ -31,8 +31,6 @@ import net.openan.a2at.sdk.prompt.taskrendering.exception.TaskPromptRenderExcept
  * @since 2026-06
  */
 public final class DefaultClientPromptGenerationOrchestrator implements ClientPromptGenerationOrchestrator {
-
-    private static final Pattern TEMPLATE_IDENTIFIER_PATTERN = Pattern.compile("[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)*");
 
     private final ClientScenarioRecognizer scenarioRecognizer;
 
@@ -129,44 +127,44 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
     }
 
     @Override
-    public MetadataContent generateTaskPromptFromText(String text, String templateUri) {
+    public MetadataContent generateTaskPromptFromText(String text, TemplateUri templateUri) {
         return generateFromTemplateUriWithMetadata(text, templateUri, ExtensionUriConstants.TASK_T_EXTENSION_URI);
     }
 
     @Override
     public MetadataContent generateTaskPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String templateUri) {
+            Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri) {
         return generateFromDataWithSchema(data, schema, templateUri, ExtensionUriConstants.TASK_T_EXTENSION_URI);
     }
 
     @Override
-    public MetadataContent generateAuthPromptFromText(String text, String authorizationType) {
-        return generateFromTemplateUriWithMetadata(
-                text, authorizationType, ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI);
+    public MetadataContent generateAuthPromptFromText(String text, TemplateUri templateUri) {
+        return generateFromTemplateUriWithMetadata(text, templateUri, ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI);
     }
 
     @Override
     public MetadataContent generateAuthPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String authorizationType) {
+            Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri) {
         return generateFromDataWithSchema(
-                data, schema, authorizationType, ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI);
+                data, schema, templateUri, ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI);
     }
 
     @Override
-    public MetadataContent generateNotificationPromptFromText(String text, String templateUri) {
+    public MetadataContent generateNotificationPromptFromText(String text, TemplateUri templateUri) {
         return generateFromTemplateUriWithMetadata(
                 text, templateUri, ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI);
     }
 
     @Override
     public MetadataContent generateNotificationPromptFromDataWithSchema(
-            Map<String, Object> data, Map<String, Object> schema, String templateUri) {
+            Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri) {
         return generateFromDataWithSchema(data, schema, templateUri, ExtensionUriConstants.NOTIFICATION_T_EXTENSION_URI);
     }
 
     private MetadataContent generateFromTemplateUriWithMetadata(
-            String userInput, String templateIdentifier, String extensionUri) {
-        requireValidTemplateIdentifier(templateIdentifier);
+            String userInput, TemplateUri templateUri, String extensionUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
+        String templateIdentifier = templateUri.uri();
         final String templateText;
         try {
             templateText = templateLoader.loadTemplate(templateIdentifier, language);
@@ -196,9 +194,10 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
     private MetadataContent generateFromDataWithSchema(
             Map<String, Object> data,
             Map<String, Object> schema,
-            String templateIdentifier,
+            TemplateUri templateUri,
             String extensionUri) {
-        requireValidTemplateIdentifier(templateIdentifier);
+        Objects.requireNonNull(templateUri, "templateUri");
+        String templateIdentifier = templateUri.uri();
         final String templateText;
         try {
             templateText = templateLoader.loadTemplate(templateIdentifier, language);
@@ -224,20 +223,6 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
             throw new PromptGenerationException("render_failed", e.getMessage(), e);
         }
         return new MetadataContent(templateIdentifier, renderedPrompt, extensionUri);
-    }
-
-    /**
-     * Enforces the caller contract of the template identifier: a null identifier is a {@link NullPointerException},
-     * a blank or malformed identifier is an {@link IllegalArgumentException}. Both stay outside the {@link A2ATError}
-     * tree because they are programming errors of the caller.
-     */
-    private static void requireValidTemplateIdentifier(String templateIdentifier) {
-        Objects.requireNonNull(templateIdentifier, "templateIdentifier");
-        if (templateIdentifier.isBlank() || !TEMPLATE_IDENTIFIER_PATTERN.matcher(templateIdentifier).matches()) {
-            throw new IllegalArgumentException(
-                    "Template URI is blank or contains invalid characters (invalid_template_uri): "
-                            + templateIdentifier);
-        }
     }
 
     private void validateRequiredSlots(Map<String, String> slots, String templateIdentifier) {

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationApiTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationApiTest.java
@@ -21,6 +21,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,9 @@ class A2ATClientNegotiationApiTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
+
+    private static final String INFORMATION_PROPOSE_URI = INFORMATION_PROPOSE.uri();
 
     @Test
     void generatesInformationProposeFromDataWithBuiltinChineseTemplates() throws IOException {
@@ -47,7 +50,7 @@ class A2ATClientNegotiationApiTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -67,7 +70,7 @@ class A2ATClientNegotiationApiTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("Region", "Songshan Lake")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -87,12 +90,14 @@ class A2ATClientNegotiationApiTest {
     void queriesSingleNegotiationTemplateWithoutThrowing() throws IOException {
         A2ATClient client = new A2ATClient(writeEnv("zh-CN"));
 
-        assertTrue(client.getNegotiationPrompt(INFORMATION_PROPOSE_URI).isPresent());
-        assertTrue(client.getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
+        assertTrue(client.getNegotiationPrompt(INFORMATION_PROPOSE).isPresent());
+        assertTrue(client
+                .getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
                 .isPresent());
-        assertFalse(client.getNegotiationPrompt("not-a-template-uri").isPresent());
-        PromptTemplate template =
-                client.getNegotiationPrompt(INFORMATION_PROPOSE_URI).orElseThrow();
+        assertFalse(client
+                .getNegotiationPrompt(TemplateUri.of("Negotiation-T", "v9", "information-negotiation", "propose"))
+                .isPresent());
+        PromptTemplate template = client.getNegotiationPrompt(INFORMATION_PROPOSE).orElseThrow();
         assertEquals(INFORMATION_PROPOSE_URI, template.uri());
         assertFalse(template.content().isBlank());
     }

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationEnvConfigTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationEnvConfigTest.java
@@ -58,7 +58,9 @@ class A2ATClientNegotiationEnvConfigTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
+
+    private static final String INFORMATION_PROPOSE_URI = INFORMATION_PROPOSE.uri();
 
     private static final String CUSTOM_TEMPLATE_MARKER = "CUSTOM-TEMPLATE-MARKER-7d31";
 
@@ -103,7 +105,7 @@ class A2ATClientNegotiationEnvConfigTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE);
 
         assertTrue(result.promptText().contains("协商上下文"), "the zh-CN language must select the Chinese templates");
         assertTrue(
@@ -113,7 +115,7 @@ class A2ATClientNegotiationEnvConfigTest {
         NegotiationGenerationException failure = assertThrows(
                 NegotiationGenerationException.class,
                 () -> client.generateNegotiationProposePromptFromText(
-                        "请提供节能区域。", new NegotiationContext(UUID, 1, 5), INFORMATION_PROPOSE_URI));
+                        "请提供节能区域。", new NegotiationContext(UUID, 1, 5), INFORMATION_PROPOSE));
         assertEquals(A2ATErrorCodes.NEGOTIATION_LLM_INFRASTRUCTURE_ERROR, failure.getCode());
         assertEquals(
                 1,
@@ -135,19 +137,19 @@ class A2ATClientNegotiationEnvConfigTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("Region", "Songshan Lake")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE);
 
         assertTrue(result.promptText().contains("Negotiation Context"), "the default language must be en-US");
         assertTrue(result.promptText().contains("Required Information Items"));
         assertEquals(6, client.getNegotiationPrompts().size(), "the built-in resources must be used by default");
-        assertTrue(client.getNegotiationPrompt(INFORMATION_PROPOSE_URI).isPresent());
+        assertTrue(client.getNegotiationPrompt(INFORMATION_PROPOSE).isPresent());
 
         assertThrows(
                 NegotiationGenerationException.class,
                 () -> client.generateNegotiationProposePromptFromText(
                         "Provide the energy-saving region.",
                         new NegotiationContext(UUID, 1, 5),
-                        INFORMATION_PROPOSE_URI));
+                        INFORMATION_PROPOSE));
         assertEquals(
                 2,
                 retryEventCount(),

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
@@ -18,6 +18,7 @@ import net.openan.a2at.sdk.client.prompt.orchestration.ClientPromptGenerationOrc
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMClientConfig;
 import net.openan.a2at.sdk.llm.LLMClientFactory;
@@ -257,13 +258,11 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
     void fromTextEntryPointsReturnMetadataContent() throws IOException {
         Path envFile = writeMinimalClientEnvWithoutRequiredSlots(TEST_MOCK_PROVIDER);
         A2ATClient client = new A2ATClient(envFile);
+        TemplateUri unconstrained = TemplateUri.of("Task-T", "v1", "network-layer", "unconstrained");
 
-        MetadataContent taskResult =
-                client.generateTaskPromptFromText("Please analyze Site A.", "Task-T/network-layer/unconstrained/v1");
-        MetadataContent authResult =
-                client.generateAuthPromptFromText("Authorize access.", "Task-T/network-layer/unconstrained/v1");
-        MetadataContent notificationResult =
-                client.generateNotificationPromptFromText("Report finished.", "Task-T/network-layer/unconstrained/v1");
+        MetadataContent taskResult = client.generateTaskPromptFromText("Please analyze Site A.", unconstrained);
+        MetadataContent authResult = client.generateAuthPromptFromText("Authorize access.", unconstrained);
+        MetadataContent notificationResult = client.generateNotificationPromptFromText("Report finished.", unconstrained);
 
         assertNotNull(taskResult);
         assertEquals("Task-T/network-layer/unconstrained/v1", taskResult.templateUri());
@@ -289,11 +288,11 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
         Map<String, Object> schema = Map.of("type", "object");
 
         MetadataContent taskResult =
-                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
+                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
         MetadataContent authResult =
-                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
+                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
         MetadataContent notificationResult =
-                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
+                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
 
         assertNotNull(taskResult);
         assertEquals(StandardTemplates.ENERGY_SAVING.uri(), taskResult.templateUri());
@@ -315,13 +314,11 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
     void fromTextReturnsCorrectExtensionUriPerContentType() throws IOException {
         Path envFile = writeMinimalClientEnvWithoutRequiredSlots(TEST_MOCK_PROVIDER);
         A2ATClient client = new A2ATClient(envFile);
+        TemplateUri unconstrained = TemplateUri.of("Task-T", "v1", "network-layer", "unconstrained");
 
-        MetadataContent taskResult =
-                client.generateTaskPromptFromText("Please analyze Site A.", "Task-T/network-layer/unconstrained/v1");
-        MetadataContent authResult =
-                client.generateAuthPromptFromText("Authorize access.", "Task-T/network-layer/unconstrained/v1");
-        MetadataContent notificationResult =
-                client.generateNotificationPromptFromText("Report finished.", "Task-T/network-layer/unconstrained/v1");
+        MetadataContent taskResult = client.generateTaskPromptFromText("Please analyze Site A.", unconstrained);
+        MetadataContent authResult = client.generateAuthPromptFromText("Authorize access.", unconstrained);
+        MetadataContent notificationResult = client.generateNotificationPromptFromText("Report finished.", unconstrained);
 
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskResult.extensionUri());
         assertEquals(ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI, authResult.extensionUri());
@@ -336,11 +333,11 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
         Map<String, Object> schema = Map.of("type", "object");
 
         MetadataContent taskResult =
-                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
+                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
         MetadataContent authResult =
-                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
+                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
         MetadataContent notificationResult =
-                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING.uri());
+                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
 
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskResult.extensionUri());
         assertEquals(ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI, authResult.extensionUri());
@@ -348,43 +345,40 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
     }
 
     @Test
-    void fromTextThrowsOnInvalidTemplateUri() throws IOException {
+    void fromTextThrowsOnNullTemplateUri() throws IOException {
         Path envFile = writeMinimalLocalClientEnv();
         A2ATClient client = new A2ATClient(envFile);
 
-        IllegalArgumentException taskEx = assertThrows(
-                IllegalArgumentException.class,
-                () -> client.generateTaskPromptFromText("Please analyze Site A.", "../etc/passwd"));
-        assertFalse(A2ATError.class.isInstance(taskEx), "invalid template URI must stay outside the A2ATError tree");
-        IllegalArgumentException authEx = assertThrows(
-                IllegalArgumentException.class,
-                () -> client.generateAuthPromptFromText("Authorize access.", "../etc/passwd"));
-        assertFalse(A2ATError.class.isInstance(authEx), "invalid template URI must stay outside the A2ATError tree");
-        IllegalArgumentException notifEx = assertThrows(
-                IllegalArgumentException.class,
-                () -> client.generateNotificationPromptFromText("Report finished.", "../etc/passwd"));
-        assertFalse(A2ATError.class.isInstance(notifEx), "invalid template URI must stay outside the A2ATError tree");
+        NullPointerException taskEx =
+                assertThrows(NullPointerException.class, () -> client.generateTaskPromptFromText("Please analyze Site A.", null));
+        assertFalse(A2ATError.class.isInstance(taskEx), "null template URI must stay outside the A2ATError tree");
+        NullPointerException authEx =
+                assertThrows(NullPointerException.class, () -> client.generateAuthPromptFromText("Authorize access.", null));
+        assertFalse(A2ATError.class.isInstance(authEx), "null template URI must stay outside the A2ATError tree");
+        NullPointerException notifEx =
+                assertThrows(NullPointerException.class, () -> client.generateNotificationPromptFromText("Report finished.", null));
+        assertFalse(A2ATError.class.isInstance(notifEx), "null template URI must stay outside the A2ATError tree");
     }
 
     @Test
-    void fromDataWithSchemaThrowsOnInvalidTemplateUri() throws IOException {
+    void fromDataWithSchemaThrowsOnNullTemplateUri() throws IOException {
         Path envFile = writeMinimalLocalClientEnv();
         A2ATClient client = new A2ATClient(envFile);
         Map<String, Object> data = Map.of("site", "Site A");
         Map<String, Object> schema = Map.of("type", "object");
 
-        IllegalArgumentException taskEx = assertThrows(
-                IllegalArgumentException.class,
-                () -> client.generateTaskPromptFromDataWithSchema(data, schema, "../etc/passwd"));
-        assertFalse(A2ATError.class.isInstance(taskEx), "invalid template URI must stay outside the A2ATError tree");
-        IllegalArgumentException authEx = assertThrows(
-                IllegalArgumentException.class,
-                () -> client.generateAuthPromptFromDataWithSchema(data, schema, "../etc/passwd"));
-        assertFalse(A2ATError.class.isInstance(authEx), "invalid template URI must stay outside the A2ATError tree");
-        IllegalArgumentException notifEx = assertThrows(
-                IllegalArgumentException.class,
-                () -> client.generateNotificationPromptFromDataWithSchema(data, schema, "../etc/passwd"));
-        assertFalse(A2ATError.class.isInstance(notifEx), "invalid template URI must stay outside the A2ATError tree");
+        NullPointerException taskEx = assertThrows(
+                NullPointerException.class,
+                () -> client.generateTaskPromptFromDataWithSchema(data, schema, null));
+        assertFalse(A2ATError.class.isInstance(taskEx), "null template URI must stay outside the A2ATError tree");
+        NullPointerException authEx = assertThrows(
+                NullPointerException.class,
+                () -> client.generateAuthPromptFromDataWithSchema(data, schema, null));
+        assertFalse(A2ATError.class.isInstance(authEx), "null template URI must stay outside the A2ATError tree");
+        NullPointerException notifEx = assertThrows(
+                NullPointerException.class,
+                () -> client.generateNotificationPromptFromDataWithSchema(data, schema, null));
+        assertFalse(A2ATError.class.isInstance(notifEx), "null template URI must stay outside the A2ATError tree");
     }
 
     private static Path writeMinimalClientEnvWithoutRequiredSlots(String provider) throws IOException {

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
@@ -20,6 +20,7 @@ import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMRuntimeError;
 import net.openan.a2at.sdk.prompt.analysis.model.ScenarioRecognitionResult;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotDefinition;
@@ -32,6 +33,9 @@ class DefaultClientPromptGenerationOrchestratorTest {
 
     private static final ClientSlotSchemaLoader EMPTY_SCHEMA_LOADER =
             (scenarioCode, language) -> new PromptSlotSchema(scenarioCode, List.of());
+
+    private static final TemplateUri AUTH_DATABASE_READ =
+            TemplateUri.of("Authorization-T", "v1", "database_read");
 
     @Test
     void generateTaskPromptLoadsTemplateAndRendersExtractedSlotsWhenScenarioIsMatched() {
@@ -306,7 +310,7 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent result = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri());
+        MetadataContent result = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
 
         assertEquals(StandardTemplates.ENERGY_SAVING.uri(), result.templateUri());
         assertEquals("Site: Site A", result.promptText());
@@ -320,7 +324,7 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
-        orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri());
+        orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
 
         assertEquals(0, recognizer.invocationCount);
     }
@@ -340,26 +344,6 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
     }
 
     @Test
-    void generateFromTemplateUriWithMetadataThrowsOnBlankOrMalformedTemplateUri() {
-        for (String invalidUri : new String[] {"", "   ", "../etc/passwd", "has space", "id;drop"}) {
-            RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
-            CountingFailingTemplateLoader templateLoader = new CountingFailingTemplateLoader();
-            DefaultClientPromptGenerationOrchestrator orchestrator =
-                    newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of()));
-
-            IllegalArgumentException ex = assertThrows(
-                    IllegalArgumentException.class,
-                    () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", invalidUri));
-            assertFalse(A2ATError.class.isInstance(ex), "invalid template URI must stay outside the A2ATError tree");
-            assertTrue(
-                    ex.getMessage().contains("invalid_template_uri"),
-                    "the failure must carry the invalid_template_uri detail but was: " + ex.getMessage());
-            assertEquals(0, recognizer.invocationCount);
-            assertEquals(0, templateLoader.loadCount);
-        }
-    }
-
-    @Test
     void generateFromTemplateUriWithMetadataPropagatesResourceNotFoundException() {
         DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
                 new RecordingScenarioRecognizer(),
@@ -369,7 +353,7 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
                 new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
 PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("template_not_found", ex.getCode());
     }
 
@@ -381,7 +365,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
 PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("render_failed", ex.getCode());
     }
 
@@ -395,7 +379,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 });
 
 PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("llm_invocation_failed", ex.getCode());
     }
 
@@ -410,7 +394,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING.uri());
+                Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING);
 
         assertEquals(StandardTemplates.ENERGY_SAVING.uri(), result.templateUri());
         assertEquals("Site: Site A", result.promptText());
@@ -426,7 +410,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         Map<String, Object> schema = Map.of("site", "string", "count", "number");
-        orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), schema, StandardTemplates.ENERGY_SAVING.uri());
+        orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), schema, StandardTemplates.ENERGY_SAVING);
 
         assertEquals(schema, slotValueExtractor.lastSchema);
         assertEquals(StandardTemplates.ENERGY_SAVING.uri(), slotValueExtractor.lastScenarioCode);
@@ -442,7 +426,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), null, StandardTemplates.ENERGY_SAVING.uri());
+                Map.of("site", "Site A"), null, StandardTemplates.ENERGY_SAVING);
 
         assertEquals("Site: Site A", result.promptText());
         assertEquals(null, slotValueExtractor.lastSchema);
@@ -457,28 +441,10 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
 
         assertEquals("Site: Site A", result.promptText());
         assertEquals(Map.of(), slotValueExtractor.lastSchema);
-    }
-
-    @Test
-    void generateFromDataWithSchemaThrowsOnInvalidTemplateUri() {
-        RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
-        CountingFailingTemplateLoader templateLoader = new CountingFailingTemplateLoader();
-        DefaultClientPromptGenerationOrchestrator orchestrator =
-                newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractorWithSchema(Map.of()));
-
-        IllegalArgumentException ex = assertThrows(
-                IllegalArgumentException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), "has space"));
-        assertFalse(A2ATError.class.isInstance(ex), "invalid template URI must stay outside the A2ATError tree");
-        assertTrue(
-                ex.getMessage().contains("invalid_template_uri"),
-                "the failure must carry the invalid_template_uri detail but was: " + ex.getMessage());
-        assertEquals(0, recognizer.invocationCount);
-        assertEquals(0, templateLoader.loadCount);
     }
 
     @Test
@@ -491,7 +457,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A")));
 
 PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
         assertEquals("template_not_found", ex.getCode());
     }
 
@@ -503,7 +469,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A")));
 
 PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
         assertEquals("render_failed", ex.getCode());
     }
 
@@ -515,7 +481,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 new FailingExtractSlotsWithSchema(new LLMRuntimeError("LLM invocation failed.")));
 
 PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
         assertEquals("llm_invocation_failed", ex.getCode());
     }
 
@@ -528,7 +494,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                         new ResourceNotFoundException("Slot schema file does not exist.", "energy-saving")));
 
 PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_schema_not_found", ex.getCode());
     }
 
@@ -542,15 +508,15 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri());
+        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
         MetadataContent taskData = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
-        MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", "Authorization-T/database_read/v1");
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
+        MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", AUTH_DATABASE_READ);
         MetadataContent authData = orchestrator.generateAuthPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), "Authorization-T/database_read/v1");
-        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING.uri());
+                Map.of("site", "Site A"), Map.of(), AUTH_DATABASE_READ);
+        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING);
         MetadataContent notifData = orchestrator.generateNotificationPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
 
         assertTrue(taskText.promptText().contains("Site A"));
         assertTrue(taskData.promptText().contains("Site A"));
@@ -566,15 +532,15 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
         DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
                 new RecordingScenarioRecognizer(), templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
-        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri());
+        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
         MetadataContent taskData = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
-        MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", "Authorization-T/database_read/v1");
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
+        MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", AUTH_DATABASE_READ);
         MetadataContent authData = orchestrator.generateAuthPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), "Authorization-T/database_read/v1");
-        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING.uri());
+                Map.of("site", "Site A"), Map.of(), AUTH_DATABASE_READ);
+        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING);
         MetadataContent notifData = orchestrator.generateNotificationPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING.uri());
+                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
 
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskText.extensionUri());
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskData.extensionUri());
@@ -585,14 +551,14 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
     }
 
     @Test
-    void authorizationMetadataEntryPointsPassAuthorizationTypeAsTemplateIdentifier() {
+    void authorizationMetadataEntryPointsPassTemplateUriIdentifier() {
         FakeTemplateLoader templateLoader = new FakeTemplateLoader("Access: {scope}");
         FakeSlotValueExtractorWithSchema slotValueExtractor =
                 new FakeSlotValueExtractorWithSchema(Map.of("scope", "read"));
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent nlResult = orchestrator.generateAuthPromptFromText("Grant read access.", "Authorization-T/database_read/v1");
+        MetadataContent nlResult = orchestrator.generateAuthPromptFromText("Grant read access.", AUTH_DATABASE_READ);
 
         assertEquals("Authorization-T/database_read/v1", nlResult.templateUri());
         assertEquals("Access: read", nlResult.promptText());
@@ -601,7 +567,7 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
         assertEquals("Grant read access.", slotValueExtractor.lastUserInput);
 
         MetadataContent jsonResult = orchestrator.generateAuthPromptFromDataWithSchema(
-                Map.of("scope", "read"), Map.of("scope", "string"), "Authorization-T/database_read/v1");
+                Map.of("scope", "read"), Map.of("scope", "string"), AUTH_DATABASE_READ);
 
         assertEquals("Authorization-T/database_read/v1", jsonResult.templateUri());
         assertEquals("Authorization-T/database_read/v1", templateLoader.lastScenarioCode);
@@ -624,7 +590,7 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
                 schemaLoader);
 
         PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_validation_error", ex.getCode());
         List<FailedParameter> failed = ex.failedParameters();
         assertFalse(failed.isEmpty());
@@ -647,7 +613,7 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
                 schemaLoader);
 
         PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_validation_error", ex.getCode());
         assertEquals(1, ex.failedParameters().size());
         assertEquals("target", ex.failedParameters().get(0).parameterName());
@@ -666,7 +632,7 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
                 });
 
         PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_schema_not_found", ex.getCode());
     }
 
@@ -683,7 +649,7 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
                 EMPTY_SCHEMA_LOADER);
 
         PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_schema_not_found", ex.getCode());
     }
 
@@ -700,7 +666,7 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
                 EMPTY_SCHEMA_LOADER);
 
         PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("prompt_resource_load_error", ex.getCode());
     }
 
@@ -717,7 +683,7 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
                 EMPTY_SCHEMA_LOADER);
 
         PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING.uri()));
+                () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("llm_invocation_failed", ex.getCode());
     }
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATError.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATError.java
@@ -1,6 +1,8 @@
 package net.openan.a2at.sdk.core.exception;
 
 import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Single root exception type for all A2A-T SDK processing failures.
@@ -32,7 +34,7 @@ public class A2ATError extends RuntimeException {
      * @param message failure message
      * @param cause root cause
      */
-    public A2ATError(String message, Throwable cause) {
+    public A2ATError(String message, @Nullable Throwable cause) {
         this(A2ATErrorCodes.SDK_INTERNAL_ERROR, message, cause);
     }
 
@@ -43,7 +45,7 @@ public class A2ATError extends RuntimeException {
      * @param message failure message
      * @throws NullPointerException if {@code code} is null
      */
-    public A2ATError(String code, String message) {
+    public A2ATError(@NonNull String code, String message) {
         super(message);
         this.code = Objects.requireNonNull(code, "code must not be null");
     }
@@ -56,7 +58,7 @@ public class A2ATError extends RuntimeException {
      * @param cause root cause
      * @throws NullPointerException if {@code code} is null
      */
-    public A2ATError(String code, String message, Throwable cause) {
+    public A2ATError(@NonNull String code, String message, @Nullable Throwable cause) {
         super(message, cause);
         this.code = Objects.requireNonNull(code, "code must not be null");
     }
@@ -66,7 +68,7 @@ public class A2ATError extends RuntimeException {
      *
      * @return error code, never null
      */
-    public String getCode() {
+    public @NonNull String getCode() {
         return code;
     }
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATParamExtractionError.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATParamExtractionError.java
@@ -2,6 +2,7 @@ package net.openan.a2at.sdk.core.exception;
 
 import java.util.List;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Shared failure type raised when validating a prompt and extracting parameters from it fails.
@@ -33,7 +34,8 @@ public class A2ATParamExtractionError extends A2ATError {
      * @param message failure message
      * @param errors structured per-slot validation error details
      */
-    public A2ATParamExtractionError(String code, String message, List<SlotValidationError> errors) {
+    public A2ATParamExtractionError(
+            @NonNull String code, String message, @NonNull List<SlotValidationError> errors) {
         super(code, message);
         this.errors = List.copyOf(errors);
     }
@@ -43,7 +45,7 @@ public class A2ATParamExtractionError extends A2ATError {
      *
      * @return immutable list of slot validation errors, never null
      */
-    public List<SlotValidationError> getErrors() {
+    public @NonNull List<SlotValidationError> getErrors() {
         return errors;
     }
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/ConfigFileNotFoundException.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/ConfigFileNotFoundException.java
@@ -1,6 +1,7 @@
 package net.openan.a2at.sdk.core.exception;
 
 import java.nio.file.Path;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Thrown when one required configuration file path does not exist.
@@ -14,7 +15,7 @@ public final class ConfigFileNotFoundException extends A2ATError {
      *
      * @param path missing config file path
      */
-    public ConfigFileNotFoundException(Path path) {
+    public ConfigFileNotFoundException(@NonNull Path path) {
         super("Config file does not exist: " + path);
     }
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/FailedParameter.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/FailedParameter.java
@@ -1,5 +1,7 @@
 package net.openan.a2at.sdk.core.exception;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * Describes a single failed required slot during slot validation.
  *
@@ -7,4 +9,4 @@ package net.openan.a2at.sdk.core.exception;
  * @param reason the failure reason, e.g. {@code missing_required}
  * @since 2026-08
  */
-public record FailedParameter(String parameterName, String reason) {}
+public record FailedParameter(@NonNull String parameterName, @NonNull String reason) {}

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/PromptGenerationException.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/PromptGenerationException.java
@@ -1,6 +1,8 @@
 package net.openan.a2at.sdk.core.exception;
 
 import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Unified exception type for MetadataContent pipeline failures.
@@ -20,7 +22,7 @@ public final class PromptGenerationException extends A2ATError {
      * @param message human-readable failure description
      * @throws NullPointerException if {@code code} is null
      */
-    public PromptGenerationException(String code, String message) {
+    public PromptGenerationException(@NonNull String code, String message) {
         super(code, message);
         this.failedParameters = List.of();
     }
@@ -34,7 +36,8 @@ public final class PromptGenerationException extends A2ATError {
      * @param failedParameters list of failed parameters
      * @throws NullPointerException if {@code code} is null
      */
-    public PromptGenerationException(String code, String message, List<FailedParameter> failedParameters) {
+    public PromptGenerationException(
+            @NonNull String code, String message, @Nullable List<FailedParameter> failedParameters) {
         super(code, message);
         this.failedParameters = failedParameters == null ? List.of() : List.copyOf(failedParameters);
     }
@@ -48,7 +51,7 @@ public final class PromptGenerationException extends A2ATError {
      * @param cause root cause
      * @throws NullPointerException if {@code code} is null
      */
-    public PromptGenerationException(String code, String message, Throwable cause) {
+    public PromptGenerationException(@NonNull String code, String message, @Nullable Throwable cause) {
         super(code, message, cause);
         this.failedParameters = List.of();
     }
@@ -58,7 +61,7 @@ public final class PromptGenerationException extends A2ATError {
      *
      * @return failed parameters
      */
-    public List<FailedParameter> failedParameters() {
+    public @NonNull List<FailedParameter> failedParameters() {
         return failedParameters;
     }
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/ResourceNotFoundException.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/ResourceNotFoundException.java
@@ -1,5 +1,7 @@
 package net.openan.a2at.sdk.core.exception;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * Raised when a referenced SDK resource cannot be resolved.
  *
@@ -15,7 +17,7 @@ public final class ResourceNotFoundException extends A2ATError {
      * @param message failure message
      * @param resourcePath missing classpath resource path
      */
-    public ResourceNotFoundException(String message, String resourcePath) {
+    public ResourceNotFoundException(String message, @NonNull String resourcePath) {
         super(message);
         this.resourcePath = resourcePath;
     }
@@ -25,7 +27,7 @@ public final class ResourceNotFoundException extends A2ATError {
      *
      * @return missing resource path
      */
-    public String resourcePath() {
+    public @NonNull String resourcePath() {
         return resourcePath;
     }
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/A2ATConfig.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/A2ATConfig.java
@@ -2,6 +2,7 @@ package net.openan.a2at.sdk.core.model;
 
 import java.nio.file.Path;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Unified SDK configuration entry point loaded from one caller-supplied `.env` file.
@@ -21,7 +22,7 @@ public record A2ATConfig(
      * @param envPath caller-supplied `.env` file path
      * @return unified SDK config
      */
-    public static A2ATConfig load(Path envPath) {
+    public static @NonNull A2ATConfig load(@NonNull Path envPath) {
         Map<String, String> values = DotEnvConfigSource.load(envPath);
         return new A2ATConfig(
                 PromptRuntimeConfig.fromMap(values),

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/DotEnvConfigSource.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/DotEnvConfigSource.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.ConfigFileNotFoundException;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Reads SDK configuration from one caller-supplied `.env` file.
@@ -29,7 +30,7 @@ public final class DotEnvConfigSource {
      * @return parsed non-empty key/value pairs
      * @throws A2ATError if the file contains more than {@value #MAX_ENTRIES} entries or cannot be read
      */
-    public static Map<String, String> load(Path path) {
+    public static @NonNull Map<String, String> load(@NonNull Path path) {
         if (!Files.exists(path)) {
             throw new ConfigFileNotFoundException(path);
         }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/MetadataContent.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/MetadataContent.java
@@ -2,6 +2,8 @@ package net.openan.a2at.sdk.core.model;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Successful result of an A2A-T prompt generation call.
@@ -11,7 +13,7 @@ import java.util.Map;
  * @param extensionUri TMF extension URI under which the message travels in A2A-T metadata
  * @since 2026-08
  */
-public record MetadataContent(String templateUri, String promptText, String extensionUri) {
+public record MetadataContent(@Nullable String templateUri, @Nullable String promptText, @NonNull String extensionUri) {
 
     /** Metadata key carrying the template URI alongside the message itself. */
     public static final String TEMPLATE_URI_METADATA_KEY = "templateUri";
@@ -24,7 +26,7 @@ public record MetadataContent(String templateUri, String promptText, String exte
      *
      * @return newly built metadata map with exactly the extension URI and {@code templateUri} keys
      */
-    public Map<String, String> buildMetadataContent() {
+    public @NonNull Map<String, String> buildMetadataContent() {
         Map<String, String> metadata = new LinkedHashMap<>();
         metadata.put(extensionUri, promptText);
         metadata.put(TEMPLATE_URI_METADATA_KEY, templateUri);

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/OperationResult.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/OperationResult.java
@@ -2,6 +2,8 @@ package net.openan.a2at.sdk.core.model;
 
 import java.util.Objects;
 import net.openan.a2at.sdk.core.exception.A2ATError;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Minimal structured result wrapper used by higher-level orchestration flows.
@@ -9,7 +11,7 @@ import net.openan.a2at.sdk.core.exception.A2ATError;
  * @param <T> result value type
  * @since 2026-06
  */
-public record OperationResult<T>(T value, A2ATError error) {
+public record OperationResult<T>(@Nullable T value, @Nullable A2ATError error) {
 
     /**
      * Creates a successful operation result.
@@ -18,7 +20,7 @@ public record OperationResult<T>(T value, A2ATError error) {
      * @param <T> value type
      * @return successful result wrapper
      */
-    public static <T> OperationResult<T> success(T value) {
+    public static <T> OperationResult<T> success(@NonNull T value) {
         return new OperationResult<>(value, null);
     }
 
@@ -29,7 +31,7 @@ public record OperationResult<T>(T value, A2ATError error) {
      * @param <T> value type
      * @return failed result wrapper
      */
-    public static <T> OperationResult<T> failure(A2ATError error) {
+    public static <T> OperationResult<T> failure(@NonNull A2ATError error) {
         return new OperationResult<>(null, Objects.requireNonNull(error, "error"));
     }
 

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/PromptTemplate.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/PromptTemplate.java
@@ -3,7 +3,8 @@ package net.openan.a2at.sdk.core.model;
 /**
  * One loadable prompt template of any A2A-T extension.
  *
- * @param uri template URI such as {@code Task-T/v1/energy-saving} or {@code Negotiation-T/v1/information-negotiation/propose}
+ * @param uri template URI such as {@code Task-T/network-layer/energy-saving/v1} or
+ *     {@code Negotiation-T/information-negotiation/propose/v1}
  * @param description template description taken from the leading HTML comment; empty string when the template has no
  *     comment
  * @param content full template file text

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/resources/PathSegments.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/resources/PathSegments.java
@@ -1,5 +1,7 @@
 package net.openan.a2at.sdk.core.resources;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Validates path segment values used to compose classpath or filesystem resource paths.
  *
@@ -20,7 +22,7 @@ public final class PathSegments {
      * @param value candidate path segment such as a language or category identifier
      * @return true when the value is non-null, non-blank and contains no slash, backslash or {@code ..} sequence
      */
-    public static boolean isSimpleSegment(String value) {
+    public static boolean isSimpleSegment(@Nullable String value) {
         return value != null
                 && !value.isBlank()
                 && !value.contains("/")

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/ContentValidator.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/ContentValidator.java
@@ -2,6 +2,7 @@ package net.openan.a2at.sdk.core.validation;
 
 import java.util.Map;
 import net.openan.a2at.sdk.core.model.FilledParamData;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Entry point for validating content and extracting filled parameters.
@@ -18,11 +19,13 @@ public interface ContentValidator {
      *
      * @param prompt content prompt text
      * @param schema caller-provided parameter JSON schema
-     * @param templateUri URI of the template the content is validated against
+     * @param templateUri URI of the template the content is validated against, such as
+     *     {@code Task-T/network-layer/energy-saving/v1}
      * @return filled parameter data carrying the merged parameters
      * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank or the template URI is blank or malformed
+     * @throws IllegalArgumentException if the prompt is blank
      * @throws ContentValidationException if the validation fails at any stage
      */
-    FilledParamData validate(String prompt, Map<String, Object> schema, String templateUri);
+    FilledParamData validate(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri);
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/SemanticValidator.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/SemanticValidator.java
@@ -1,6 +1,7 @@
 package net.openan.a2at.sdk.core.validation;
 
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 /**
  * LLM-backed semantic validator for content.
@@ -24,5 +25,6 @@ public interface SemanticValidator<T> {
      * @throws net.openan.a2at.sdk.core.exception.ResourceNotFoundException if the semantic validation prompt resources
      *     are missing
      */
-    ValidationResult validate(String prompt, Map<String, Object> schema, T reference);
+    @NonNull ValidationResult validate(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull T reference);
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/TemplateUri.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/TemplateUri.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.openan.a2at.sdk.core.resources.PathSegments;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Structured, always-valid identifier of a content template.
@@ -27,7 +29,8 @@ import net.openan.a2at.sdk.core.resources.PathSegments;
  * @param templateVersion trailing URI segment, such as {@code v1}
  * @since 2026-08
  */
-public record TemplateUri(String extensionName, List<String> pathSegments, String templateVersion) {
+public record TemplateUri(
+        @NonNull String extensionName, @NonNull List<String> pathSegments, @NonNull String templateVersion) {
 
     /** Default template version segment used by all built-in templates. */
     public static final String DEFAULT_TEMPLATE_VERSION = "v1";
@@ -61,7 +64,8 @@ public record TemplateUri(String extensionName, List<String> pathSegments, Strin
      * @throws NullPointerException if any component is null
      * @throws IllegalArgumentException if any component is not a simple path segment or no path segment is given
      */
-    public static TemplateUri of(String extensionName, String templateVersion, String... pathSegments) {
+    public static @NonNull TemplateUri of(
+            @NonNull String extensionName, @NonNull String templateVersion, @NonNull String... pathSegments) {
         return new TemplateUri(extensionName, List.of(pathSegments), templateVersion);
     }
 
@@ -72,7 +76,7 @@ public record TemplateUri(String extensionName, List<String> pathSegments, Strin
      * @return parsed template URI, or an empty result when the input is null, blank, has fewer than three segments or
      *     contains a segment that is not a simple path segment
      */
-    public static Optional<TemplateUri> parse(String templateUri) {
+    public static Optional<TemplateUri> parse(@Nullable String templateUri) {
         if (templateUri == null || templateUri.isBlank()) {
             return Optional.empty();
         }
@@ -96,7 +100,7 @@ public record TemplateUri(String extensionName, List<String> pathSegments, Strin
      *
      * @return template URI such as {@code Negotiation-T/information-negotiation/propose/v1}
      */
-    public String uri() {
+    public @NonNull String uri() {
         return Stream.concat(
                         Stream.concat(Stream.of(extensionName), pathSegments.stream()),
                         Stream.of(templateVersion))

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/ValidationPipeline.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/ValidationPipeline.java
@@ -9,6 +9,7 @@ import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,8 @@ public final class ValidationPipeline<T> {
      * @param maxAttempts maximum number of retry attempts for the semantic validation step
      * @throws NullPointerException if the rule checker or the semantic validator is null
      */
-    public ValidationPipeline(RuleChecker ruleChecker, SemanticValidator<T> semanticValidator, int maxAttempts) {
+    public ValidationPipeline(
+            @NonNull RuleChecker ruleChecker, @NonNull SemanticValidator<T> semanticValidator, int maxAttempts) {
         this.ruleChecker = Objects.requireNonNull(ruleChecker, "ruleChecker");
         this.semanticValidator = Objects.requireNonNull(semanticValidator, "semanticValidator");
         this.maxAttempts = maxAttempts;
@@ -58,7 +60,8 @@ public final class ValidationPipeline<T> {
      * @throws IllegalArgumentException if the prompt is blank
      * @throws ContentValidationException if the validation fails at any stage
      */
-    public FilledParamData validate(String prompt, Map<String, Object> schema, T reference) {
+    public @NonNull FilledParamData validate(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull T reference) {
         Objects.requireNonNull(schema, "schema");
         Objects.requireNonNull(prompt, "prompt");
         if (prompt.isBlank()) {

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationContentService.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationContentService.java
@@ -10,9 +10,12 @@ import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.PromptRuntimeConfig;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestrator;
 import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestratorBuilder;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Shared service for the negotiation content layer consumed by both the client and the server facade.
@@ -32,7 +35,7 @@ public final class NegotiationContentService {
      *
      * @param orchestrator negotiation generation orchestrator carrying the actual pipelines
      */
-    public NegotiationContentService(NegotiationGenerationOrchestrator orchestrator) {
+    public NegotiationContentService(@NonNull NegotiationGenerationOrchestrator orchestrator) {
         this.orchestrator = Objects.requireNonNull(orchestrator, "Negotiation orchestrator must not be null.");
     }
 
@@ -47,7 +50,8 @@ public final class NegotiationContentService {
      * @param llmClient LLM client for the LLM-backed steps; null keeps those steps unavailable
      * @return assembled negotiation generation orchestrator
      */
-    public static NegotiationGenerationOrchestrator buildOrchestrator(A2ATConfig config, LLMClient llmClient) {
+    public static NegotiationGenerationOrchestrator buildOrchestrator(
+            @NonNull A2ATConfig config, @Nullable LLMClient llmClient) {
         return NegotiationGenerationOrchestratorBuilder.builder()
                 .language(config.prompt().language())
                 .localRootDir(config.prompt().localRootDir())
@@ -66,7 +70,8 @@ public final class NegotiationContentService {
      * @param envPath resolved `.env` file path the config was loaded from
      * @return config with the local root resolved to an absolute normalized path
      */
-    public static A2ATConfig resolvePromptResourceLocalRootDir(A2ATConfig config, Path envPath) {
+    public static A2ATConfig resolvePromptResourceLocalRootDir(
+            @NonNull A2ATConfig config, @NonNull Path envPath) {
         String localRootDir = config.prompt().localRootDir();
         Path localRootPath = Path.of(localRootDir);
         Path resolvedLocalRootPath = localRootPath.isAbsolute()
@@ -86,13 +91,13 @@ public final class NegotiationContentService {
      * @param data typed propose input carrying the negotiation context and the typed content
      * @param templateUri template URI whose phase segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, or its phase or type contradicts the method
-     *     or the content type
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase or type contradicts the method or the content type
      * @throws NegotiationGenerationException with the code {@code template_not_found} or
      *     {@code negotiation_slot_missing} when loading or rendering the template fails
      */
-    public MetadataContent generateProposeFromData(NegotiationProposeData data, String templateUri) {
+    public MetadataContent generateProposeFromData(
+            @NonNull NegotiationProposeData data, @NonNull TemplateUri templateUri) {
         return orchestrator.generateProposeFromData(data, templateUri);
     }
 
@@ -102,13 +107,14 @@ public final class NegotiationContentService {
      * @param data typed terminal input whose content conclusion must be {@code Accept}
      * @param templateUri template URI whose phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, its phase or type contradicts the method or
-     *     the content, or the content conclusion is not {@code Accept}
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase or type contradicts the method or the content, or
+     *     the content conclusion is not {@code Accept}
      * @throws NegotiationGenerationException with the code {@code template_not_found} or
      *     {@code negotiation_slot_missing} when loading or rendering the template fails
      */
-    public MetadataContent generateAcceptFromData(NegotiationEndingData data, String templateUri) {
+    public MetadataContent generateAcceptFromData(
+            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
         return orchestrator.generateAcceptFromData(data, templateUri);
     }
 
@@ -118,13 +124,14 @@ public final class NegotiationContentService {
      * @param data typed terminal input whose content conclusion must be {@code Reject}
      * @param templateUri template URI whose phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, its phase or type contradicts the method or
-     *     the content, or the content conclusion is not {@code Reject}
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase or type contradicts the method or the content, or
+     *     the content conclusion is not {@code Reject}
      * @throws NegotiationGenerationException with the code {@code template_not_found} or
      *     {@code negotiation_slot_missing} when loading or rendering the template fails
      */
-    public MetadataContent generateRejectFromData(NegotiationEndingData data, String templateUri) {
+    public MetadataContent generateRejectFromData(
+            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
         return orchestrator.generateRejectFromData(data, templateUri);
     }
 
@@ -135,14 +142,15 @@ public final class NegotiationContentService {
      * @param context negotiation context injected into the rendered message without any LLM involvement
      * @param templateUri template URI whose phase segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI contradicts the method
      * @throws NegotiationGenerationException with the code {@code template_not_found},
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when loading or
      *     extracting fails, {@code negotiation_slot_missing} when the extracted content misses a required field, or
      *     {@code negotiation_invalid_input} when the text is blank or the extracted content contradicts the phase
      */
-    public MetadataContent generateProposeFromText(String text, NegotiationContext context, String templateUri) {
+    public MetadataContent generateProposeFromText(
+            String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
         return orchestrator.generateProposeFromText(text, context, templateUri);
     }
 
@@ -153,14 +161,15 @@ public final class NegotiationContentService {
      * @param context negotiation context injected into the rendered message without any LLM involvement
      * @param templateUri template URI whose phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI contradicts the method
      * @throws NegotiationGenerationException with the code {@code template_not_found},
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when loading or
      *     extracting fails, {@code negotiation_slot_missing} when the extracted content misses a required field, or
      *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Accept}
      */
-    public MetadataContent generateAcceptFromText(String text, NegotiationContext context, String templateUri) {
+    public MetadataContent generateAcceptFromText(
+            String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
         return orchestrator.generateAcceptFromText(text, context, templateUri);
     }
 
@@ -171,14 +180,15 @@ public final class NegotiationContentService {
      * @param context negotiation context injected into the rendered message without any LLM involvement
      * @param templateUri template URI whose phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI contradicts the method
      * @throws NegotiationGenerationException with the code {@code template_not_found},
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when loading or
      *     extracting fails, {@code negotiation_slot_missing} when the extracted content misses a required field, or
      *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Reject}
      */
-    public MetadataContent generateRejectFromText(String text, NegotiationContext context, String templateUri) {
+    public MetadataContent generateRejectFromText(
+            String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
         return orchestrator.generateRejectFromText(text, context, templateUri);
     }
 
@@ -195,11 +205,12 @@ public final class NegotiationContentService {
     /**
      * Loads one negotiation template by its URI; never throws.
      *
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose}
-     * @return the addressed template, or an empty optional when the URI is malformed or no template exists for it in
-     *     the configured language
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}
+     * @return the addressed template, or an empty optional when the URI does not address a negotiation template or no
+     *     template exists for it in the configured language
+     * @throws NullPointerException if the template URI is null
      */
-    public Optional<PromptTemplate> getNegotiationPrompt(String templateUri) {
+    public Optional<PromptTemplate> getNegotiationPrompt(@NonNull TemplateUri templateUri) {
         return orchestrator.getNegotiationPrompt(templateUri);
     }
 
@@ -210,16 +221,15 @@ public final class NegotiationContentService {
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI whose phase segment must be {@code propose}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or contradicts the
-     *     method
+     * @throws NullPointerException if the prompt, the schema or the template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input},
      *     {@code negotiation_rule_violation}, {@code negotiation_semantic_rejected},
      *     {@code negotiation_llm_infrastructure_error} or {@code template_not_found} when the validation pipeline
      *     fails
      */
     public FilledParamData validateAndFillingProposeData(
-            String prompt, Map<String, Object> schema, String templateUri) {
+            String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
         return orchestrator.validateAndFillingProposeData(prompt, schema, templateUri);
     }
 
@@ -230,15 +240,15 @@ public final class NegotiationContentService {
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI whose phase segment must be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or contradicts the
-     *     method
+     * @throws NullPointerException if the prompt, the schema or the template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input},
      *     {@code negotiation_rule_violation}, {@code negotiation_semantic_rejected},
      *     {@code negotiation_llm_infrastructure_error} or {@code template_not_found} when the validation pipeline
      *     fails
      */
-    public FilledParamData validateAndFillingAcceptData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingAcceptData(
+            String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
         return orchestrator.validateAndFillingAcceptData(prompt, schema, templateUri);
     }
 
@@ -249,15 +259,15 @@ public final class NegotiationContentService {
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI whose phase segment must be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or contradicts the
-     *     method
+     * @throws NullPointerException if the prompt, the schema or the template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input},
      *     {@code negotiation_rule_violation}, {@code negotiation_semantic_rejected},
      *     {@code negotiation_llm_infrastructure_error} or {@code template_not_found} when the validation pipeline
      *     fails
      */
-    public FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingRejectData(
+            String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
         return orchestrator.validateAndFillingRejectData(prompt, schema, templateUri);
     }
 }

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
@@ -12,6 +12,7 @@ import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationEndingData;
@@ -23,6 +24,7 @@ import net.openan.a2at.sdk.negotiation.content.Vocabulary;
 import net.openan.a2at.sdk.negotiation.resources.NegotiationReference;
 import net.openan.a2at.sdk.negotiation.resources.NegotiationTemplateLoader;
 import net.openan.a2at.sdk.negotiation.validation.ParamExtractor;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,16 +97,16 @@ public final class NegotiationGenerationOrchestrator {
      * generator of the negotiation type addressed by the template URI and rendered from that template.
      *
      * @param data typed propose input carrying the negotiation context and the typed content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/propose}; its phase
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/propose/v1}; its phase
      *     segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, or its phase or type contradicts the method
-     *     or the content type
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase or type contradicts the method or the content type
      * @throws NegotiationGenerationException with the code {@code template_not_found} when no template exists for the
      *     URI in any resource root, or the code {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateProposeFromData(NegotiationProposeData data, String templateUri) {
+    public MetadataContent generateProposeFromData(
+            @NonNull NegotiationProposeData data, @NonNull TemplateUri templateUri) {
         Objects.requireNonNull(data, "Negotiation propose data must not be null.");
         return generateFromData(data.context(), data.content(), templateUri, NegotiationPhase.PROPOSE);
     }
@@ -116,16 +118,17 @@ public final class NegotiationGenerationOrchestrator {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/accept-reject}; its phase
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its phase
      *     segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, its phase or type contradicts the method or
-     *     the content, or the content conclusion is not {@code Accept}
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase or type contradicts the method or the content, or
+     *     the content conclusion is not {@code Accept}
      * @throws NegotiationGenerationException with the code {@code template_not_found} when no template exists for the
      *     URI in any resource root, or the code {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateAcceptFromData(NegotiationEndingData data, String templateUri) {
+    public MetadataContent generateAcceptFromData(
+            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
         Objects.requireNonNull(data, "Negotiation ending data must not be null.");
         return generateFromData(data.context(), data.content(), templateUri, NegotiationPhase.ACCEPT);
     }
@@ -137,16 +140,17 @@ public final class NegotiationGenerationOrchestrator {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/feasibility-negotiation/accept-reject}; its phase
+     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its phase
      *     segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, its phase or type contradicts the method or
-     *     the content, or the content conclusion is not {@code Reject}
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase or type contradicts the method or the content, or
+     *     the content conclusion is not {@code Reject}
      * @throws NegotiationGenerationException with the code {@code template_not_found} when no template exists for the
      *     URI in any resource root, or the code {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateRejectFromData(NegotiationEndingData data, String templateUri) {
+    public MetadataContent generateRejectFromData(
+            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
         Objects.requireNonNull(data, "Negotiation ending data must not be null.");
         return generateFromData(data.context(), data.content(), templateUri, NegotiationPhase.REJECT);
     }
@@ -161,18 +165,19 @@ public final class NegotiationGenerationOrchestrator {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose}; its phase segment
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase segment
      *     must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase contradicts the method
      * @throws NegotiationGenerationException with the code {@code template_not_found} when no template or prompt
      *     resource exists for the URI and language, {@code negotiation_content_extract_failed} or
      *     {@code negotiation_llm_infrastructure_error} when the extraction step fails after exhausting its retries,
      *     {@code negotiation_slot_missing} when the extracted content misses a required field, or
      *     {@code negotiation_invalid_input} when the text is blank or the extracted content contradicts the phase
      */
-    public MetadataContent generateProposeFromText(String text, NegotiationContext context, String templateUri) {
+    public MetadataContent generateProposeFromText(
+            String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
         return generateFromText(text, context, templateUri, NegotiationPhase.PROPOSE);
     }
 
@@ -185,18 +190,19 @@ public final class NegotiationGenerationOrchestrator {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/accept-reject}; its phase
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its phase
      *     segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase contradicts the method
      * @throws NegotiationGenerationException with the code {@code template_not_found} when no template or prompt
      *     resource exists for the URI and language, {@code negotiation_content_extract_failed} or
      *     {@code negotiation_llm_infrastructure_error} when the extraction step fails after exhausting its retries,
      *     {@code negotiation_slot_missing} when the extracted content misses a required field, or
      *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Accept}
      */
-    public MetadataContent generateAcceptFromText(String text, NegotiationContext context, String templateUri) {
+    public MetadataContent generateAcceptFromText(
+            String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
         return generateFromText(text, context, templateUri, NegotiationPhase.ACCEPT);
     }
 
@@ -209,18 +215,19 @@ public final class NegotiationGenerationOrchestrator {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/feasibility-negotiation/accept-reject}; its phase
+     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its phase
      *     segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase contradicts the method
      * @throws NegotiationGenerationException with the code {@code template_not_found} when no template or prompt
      *     resource exists for the URI and language, {@code negotiation_content_extract_failed} or
      *     {@code negotiation_llm_infrastructure_error} when the extraction step fails after exhausting its retries,
      *     {@code negotiation_slot_missing} when the extracted content misses a required field, or
      *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Reject}
      */
-    public MetadataContent generateRejectFromText(String text, NegotiationContext context, String templateUri) {
+    public MetadataContent generateRejectFromText(
+            String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
         return generateFromText(text, context, templateUri, NegotiationPhase.REJECT);
     }
 
@@ -245,20 +252,21 @@ public final class NegotiationGenerationOrchestrator {
     /**
      * Loads one negotiation template addressed by its URI.
      *
-     * <p>This query never throws: a malformed URI or a template that exists nowhere for the configured language returns
-     * an empty result and logs an actionable warning.
+     * <p>This query never throws: a URI that does not address a negotiation template or a template that exists nowhere
+     * for the configured language returns an empty result and logs an actionable warning.
      *
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose}
-     * @return the addressed template, or an empty result when the URI is malformed or the template does not exist for
-     *     the configured language
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}
+     * @return the addressed template, or an empty result when the URI does not address a negotiation template or the
+     *     template does not exist for the configured language
+     * @throws NullPointerException if the template URI is null
      */
-    public Optional<PromptTemplate> getNegotiationPrompt(String templateUri) {
+    public Optional<PromptTemplate> getNegotiationPrompt(@NonNull TemplateUri templateUri) {
         Optional<NegotiationReference> reference = parseQueryReference(templateUri);
         if (reference.isEmpty()) {
             logger.atWarn()
                     .log(
                             "negotiation_template_not_found uri={} language={} reason=invalid_template_uri hint={}",
-                            templateUri,
+                            templateUri.uri(),
                             language,
                             LANGUAGE_HINT);
             return Optional.empty();
@@ -269,7 +277,7 @@ public final class NegotiationGenerationOrchestrator {
             logger.atWarn()
                     .log(
                             "negotiation_template_not_found uri={} language={} hint={}",
-                            templateUri,
+                            templateUri.uri(),
                             language,
                             LANGUAGE_HINT);
             return Optional.empty();
@@ -279,17 +287,17 @@ public final class NegotiationGenerationOrchestrator {
     /**
      * Validates a propose-phase negotiation message and extracts its parameters.
      *
-     * <p>The pipeline checks the template URI format before any LLM call, runs the deterministic rule gate, then
-     * performs one semantic validation LLM call (retried on the retryable failure codes) and merges the extracted
-     * parameters with the rule-level context parameters; context parameters win on conflict.
+     * <p>The pipeline checks the template URI before any LLM call, runs the deterministic rule gate, then performs one
+     * semantic validation LLM call (retried on the retryable failure codes) and merges the extracted parameters with
+     * the rule-level context parameters; context parameters win on conflict.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
      *     {@code propose}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the schema is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input} when the prompt is
      *     not a negotiation message, {@code negotiation_rule_violation} when the negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
@@ -297,60 +305,62 @@ public final class NegotiationGenerationOrchestrator {
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
     public FilledParamData validateAndFillingProposeData(
-            String prompt, Map<String, Object> schema, String templateUri) {
+            String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
         return validateAndFilling(prompt, schema, templateUri, NegotiationPhase.PROPOSE);
     }
 
     /**
      * Validates an accept-phase negotiation message and extracts its parameters.
      *
-     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, String)} with the expected phase
-     * fixed to accept: the template URI must declare the {@code accept-reject} segment and the message must satisfy the
-     * accept-phase semantic constraints.
+     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, TemplateUri)} with the expected
+     * phase fixed to accept: the template URI must declare the {@code accept-reject} segment and the message must
+     * satisfy the accept-phase semantic constraints.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
      *     {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the schema is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input} when the prompt is
      *     not a negotiation message, {@code negotiation_rule_violation} when the negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
-    public FilledParamData validateAndFillingAcceptData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingAcceptData(
+            String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
         return validateAndFilling(prompt, schema, templateUri, NegotiationPhase.ACCEPT);
     }
 
     /**
      * Validates a reject-phase negotiation message and extracts its parameters.
      *
-     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, String)} with the expected phase
-     * fixed to reject: the template URI must declare the {@code accept-reject} segment and the message must satisfy the
-     * reject-phase semantic constraints.
+     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, TemplateUri)} with the expected
+     * phase fixed to reject: the template URI must declare the {@code accept-reject} segment and the message must
+     * satisfy the reject-phase semantic constraints.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
      *     {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the schema is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI's phase contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input} when the prompt is
      *     not a negotiation message, {@code negotiation_rule_violation} when the negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
-    public FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingRejectData(
+            String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
         return validateAndFilling(prompt, schema, templateUri, NegotiationPhase.REJECT);
     }
 
     private MetadataContent generateFromData(
-            NegotiationContext context, NegotiationContent content, String templateUri, NegotiationPhase phase) {
+            NegotiationContext context, NegotiationContent content, TemplateUri templateUri, NegotiationPhase phase) {
         requireContext(context);
         try {
             NegotiationReference reference = requireReference(templateUri, phase);
@@ -359,13 +369,13 @@ public final class NegotiationGenerationOrchestrator {
             return completeGeneration(reference, promptText, context);
         } catch (NegotiationGenerationException failure) {
             logger.atWarn()
-                    .log("negotiation_generation_failed code={} template_uri={}", failure.getCode(), templateUri);
+                    .log("negotiation_generation_failed code={} template_uri={}", failure.getCode(), templateUri.uri());
             throw failure;
         }
     }
 
     private MetadataContent generateFromText(
-            String text, NegotiationContext context, String templateUri, NegotiationPhase phase) {
+            String text, NegotiationContext context, TemplateUri templateUri, NegotiationPhase phase) {
         requireContext(context);
         try {
             NegotiationReference reference = requireReference(templateUri, phase);
@@ -375,7 +385,7 @@ public final class NegotiationGenerationOrchestrator {
             return completeGeneration(reference, promptText, context);
         } catch (NegotiationGenerationException failure) {
             logger.atWarn()
-                    .log("negotiation_generation_failed code={} template_uri={}", failure.getCode(), templateUri);
+                    .log("negotiation_generation_failed code={} template_uri={}", failure.getCode(), templateUri.uri());
             throw failure;
         }
     }
@@ -428,7 +438,7 @@ public final class NegotiationGenerationOrchestrator {
     }
 
     private FilledParamData validateAndFilling(
-            String prompt, Map<String, Object> schema, String templateUri, NegotiationPhase phase) {
+            String prompt, Map<String, Object> schema, TemplateUri templateUri, NegotiationPhase phase) {
         Objects.requireNonNull(schema, "Parameter schema must not be null.");
         NegotiationReference reference = requireReference(templateUri, phase);
         try {
@@ -444,27 +454,26 @@ public final class NegotiationGenerationOrchestrator {
     }
 
     /**
-     * Parses the template URI against one expected phase, rejecting every URI the parse rejects.
+     * Derives the reference of a typed template URI against one expected phase.
      *
      * @param templateUri template URI declared by the caller
      * @param phase API-level phase the calling method operates on
      * @return reference addressed by the URI carrying the expected phase
-     * @throws IllegalArgumentException if the URI is null, blank, malformed or its phase segment does not match the
-     *     expected phase
+     * @throws IllegalArgumentException if the URI does not address a negotiation template of the expected phase
      */
-    private NegotiationReference requireReference(String templateUri, NegotiationPhase phase) {
-        return NegotiationReference.tryParse(templateUri, phase, language)
+    private NegotiationReference requireReference(TemplateUri templateUri, NegotiationPhase phase) {
+        return NegotiationReference.fromTemplateUri(templateUri, phase, language)
                 .orElseThrow(() -> new IllegalArgumentException(
-                        "Template URI is malformed or contradicts the expected phase " + phase + " ("
-                                + phase.uriSegment() + "): " + templateUri + "."));
+                        "Template URI does not address a negotiation template of the expected phase " + phase + " ("
+                                + phase.uriSegment() + "): " + templateUri.uri() + "."));
     }
 
-    private Optional<NegotiationReference> parseQueryReference(String templateUri) {
+    private Optional<NegotiationReference> parseQueryReference(TemplateUri templateUri) {
         // The URI layer cannot distinguish accept from reject because both phases share the accept-reject template
         // segment. The query therefore addresses the shared template through the ACCEPT phase; the parsed phase is an
         // addressing artifact only and must never be read as the phase of any message.
         for (NegotiationPhase phase : List.of(NegotiationPhase.PROPOSE, NegotiationPhase.ACCEPT)) {
-            Optional<NegotiationReference> reference = NegotiationReference.tryParse(templateUri, phase, language);
+            Optional<NegotiationReference> reference = NegotiationReference.fromTemplateUri(templateUri, phase, language);
             if (reference.isPresent()) {
                 return reference;
             }

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReference.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReference.java
@@ -1,5 +1,6 @@
 package net.openan.a2at.sdk.negotiation.resources;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -8,6 +9,8 @@ import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.NegotiationPhase;
 import net.openan.a2at.sdk.negotiation.content.NegotiationType;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Addressing key for one negotiation template: negotiation type, API-level phase and language.
@@ -76,7 +79,7 @@ public record NegotiationReference(NegotiationType type, NegotiationPhase phase,
      * @throws NullPointerException if the expected phase is null
      */
     public static Optional<NegotiationReference> tryParse(
-            String templateUri, NegotiationPhase expectedPhase, String language) {
+            @Nullable String templateUri, @NonNull NegotiationPhase expectedPhase, String language) {
         Objects.requireNonNull(expectedPhase, "Expected negotiation phase must not be null.");
         if (templateUri == null || templateUri.isBlank()) {
             return Optional.empty();
@@ -96,6 +99,46 @@ public record NegotiationReference(NegotiationType type, NegotiationPhase phase,
             return Optional.empty();
         }
         if (!URI_VERSION_SEGMENT.equals(segments[3])) {
+            return Optional.empty();
+        }
+        return Optional.of(new NegotiationReference(parsedType, expectedPhase, language));
+    }
+
+    /**
+     * Derives a reference from a typed template URI, checking it against the expected phase.
+     *
+     * <p>The typed variant of {@link #tryParse(String, NegotiationPhase, String)}: because a {@link TemplateUri} is
+     * always structurally well formed, the checks operate on the URI components directly instead of splitting a raw
+     * string. The URI layer cannot distinguish accept from reject because both share the {@code accept-reject}
+     * segment; the expected phase disambiguates the result, which therefore always carries the expected phase.
+     *
+     * @param templateUri typed template URI such as {@code Negotiation-T/target-negotiation/accept-reject/v1}
+     * @param expectedPhase API-level phase the caller is operating on; the derived reference carries this phase
+     * @param language locale identifier for the derived reference
+     * @return reference addressed by the URI carrying the expected phase, or an empty result when the URI does not
+     *     address a negotiation template of the expected phase (wrong extension name, path segment count, type
+     *     segment, phase segment or template version)
+     * @throws NullPointerException if the template URI or the expected phase is null
+     */
+    public static Optional<NegotiationReference> fromTemplateUri(
+            @NonNull TemplateUri templateUri, @NonNull NegotiationPhase expectedPhase, String language) {
+        Objects.requireNonNull(templateUri, "Template URI must not be null.");
+        Objects.requireNonNull(expectedPhase, "Expected negotiation phase must not be null.");
+        if (!URI_PREFIX.equals(templateUri.extensionName())) {
+            return Optional.empty();
+        }
+        List<String> segments = templateUri.pathSegments();
+        if (segments.size() != 2) {
+            return Optional.empty();
+        }
+        NegotiationType parsedType = parseTypeSegment(segments.get(0));
+        if (parsedType == null) {
+            return Optional.empty();
+        }
+        if (!phaseSegmentMatches(segments.get(1), expectedPhase)) {
+            return Optional.empty();
+        }
+        if (!URI_VERSION_SEGMENT.equals(templateUri.templateVersion())) {
             return Optional.empty();
         }
         return Optional.of(new NegotiationReference(parsedType, expectedPhase, language));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/concurrency/NegotiationConcurrentMixedLoadTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/concurrency/NegotiationConcurrentMixedLoadTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.core.model.FilledParamData;
@@ -36,7 +37,7 @@ class NegotiationConcurrentMixedLoadTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     private static final int THREADS = 12;
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ConclusionLiteralAndExceptionSlotTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ConclusionLiteralAndExceptionSlotTest.java
@@ -47,7 +47,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 new InfoEndingContent(
                                         NegotiationConclusion.ACCEPT,
                                         List.of(new NegotiationItem("area information", "Songshan Lake")))),
-                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
         String target = orchestrator
                 .generateAcceptFromData(
@@ -55,7 +55,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 context,
                                 new TargetEndingContent(
                                         NegotiationConclusion.ACCEPT, "The confirmed intent is recorded.", null)),
-                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
         String feasibility = orchestrator
                 .generateAcceptFromData(
@@ -63,7 +63,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 context,
                                 new FeasibilityEndingContent(
                                         NegotiationConclusion.ACCEPT, "The target is achievable.")),
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
 
         assertTrue(information.contains(conclusionSection(language, "information") + "\nAccept"));
@@ -87,7 +87,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 new InfoEndingContent(
                                         NegotiationConclusion.REJECT,
                                         List.of(new NegotiationItem("area information", "not available")))),
-                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
         String target = orchestrator
                 .generateRejectFromData(
@@ -95,7 +95,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 context,
                                 new TargetEndingContent(
                                         NegotiationConclusion.REJECT, null, "The intent cannot be clarified.")),
-                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
         String feasibility = orchestrator
                 .generateRejectFromData(
@@ -103,7 +103,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                                 context,
                                 new FeasibilityEndingContent(
                                         NegotiationConclusion.REJECT, "The target is not achievable.")),
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
 
         assertTrue(information.contains(conclusionSection(language, "information") + "\nReject"));
@@ -126,14 +126,14 @@ class ConclusionLiteralAndExceptionSlotTest {
                         new NegotiationEndingData(
                                 new NegotiationContext(UUID, 2, 5),
                                 new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, summary)),
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
         String rejectText = orchestrator
                 .generateRejectFromData(
                         new NegotiationEndingData(
                                 new NegotiationContext(UUID, 2, 5),
                                 new FeasibilityEndingContent(NegotiationConclusion.REJECT, summary)),
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
 
         String sectionTitle =
@@ -157,7 +157,7 @@ class ConclusionLiteralAndExceptionSlotTest {
                         new NegotiationEndingData(
                                 new NegotiationContext(UUID, 2, 5),
                                 new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, summary)),
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
                 .promptText();
 
         assertEquals(1, countOccurrences(promptText, summary));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ConditionalSectionRenderingTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ConditionalSectionRenderingTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.stream.Stream;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationAction;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
@@ -28,9 +29,9 @@ class ConditionalSectionRenderingTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE;
 
-    private static final String TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE;
 
     static Stream<Arguments> languages() {
         return Stream.of(Arguments.of("zh-CN"), Arguments.of("en-US"));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/FromDataProgrammingErrorMatrixTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/FromDataProgrammingErrorMatrixTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
@@ -29,27 +30,28 @@ import org.junit.jupiter.api.Test;
 /**
  * Verifies the programming-error matrix of the from-data generation as one table-driven suite.
  *
- * <p>Every row of the input-validation matrix of the from-data variants — method-data mismatch, malformed or
- * mismatching template URIs, phase-conclusion mismatch, missing required fields and empty conditional content — fails
- * with a standard {@link NullPointerException} (pure null arguments) or {@link IllegalArgumentException} (blank,
- * malformed, range and semantic-contract violations) that is not part of the SDK processing-error hierarchy and
- * carries an English message pointing at the offending input. No row ever reaches the LLM.
+ * <p>Every row of the input-validation matrix of the from-data variants — method-data mismatch, template URIs that
+ * do not address a negotiation template of the expected phase, phase-conclusion mismatch, missing required fields and
+ * empty conditional content — fails with a standard {@link NullPointerException} (pure null arguments) or
+ * {@link IllegalArgumentException} (blank, range and semantic-contract violations) that is not part of the SDK
+ * processing-error hierarchy and carries an English message pointing at the offending input. No row ever reaches the
+ * LLM. Structural URI malformation is impossible by construction of {@link TemplateUri} and is therefore not a row.
  */
 class FromDataProgrammingErrorMatrixTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
-    private static final String INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT;
 
-    private static final String TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE;
 
-    private static final String FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE;
 
-    private static final String FEASIBILITY_ACCEPT_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri FEASIBILITY_ACCEPT_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT;
 
-    private static final String TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT;
 
     private final CountingClient llm = new CountingClient();
 
@@ -64,7 +66,7 @@ class FromDataProgrammingErrorMatrixTest {
 
         // The propose-versus-ending family mismatch of UT-GEN-002 is deliberately absent here: the typed data records
         // make that mismatch a compile-time error at the facade, so it cannot occur at runtime.
-        assertEquals(24, matrix.size(), "the full matrix must be exercised");
+        assertEquals(22, matrix.size(), "the full matrix must be exercised");
         for (MatrixRow row : matrix) {
             RuntimeException failure = assertThrows(
                     row.expectedException(), () -> row.call().get(), "row must fail: " + row.label());
@@ -213,54 +215,40 @@ class FromDataProgrammingErrorMatrixTest {
                         IllegalArgumentException.class,
                         "must not be blank"),
                 new MatrixRow(
-                        "template URI with too few segments",
-                        () -> orchestrator.generateProposeFromData(
-                                new NegotiationProposeData(context, informationProposeContent()),
-                                "information-negotiation/propose"),
-                        IllegalArgumentException.class,
-                        "Template URI is malformed or contradicts the expected phase PROPOSE (propose)"),
-                new MatrixRow(
-                        "template URI with too many segments",
-                        () -> orchestrator.generateProposeFromData(
-                                new NegotiationProposeData(context, informationProposeContent()),
-                                "Negotiation-T/information-negotiation/propose/v1/extra"),
-                        IllegalArgumentException.class,
-                        "Template URI is malformed or contradicts the expected phase PROPOSE (propose)"),
-                new MatrixRow(
                         "template URI with wrong prefix",
                         () -> orchestrator.generateProposeFromData(
                                 new NegotiationProposeData(context, informationProposeContent()),
-                                "Task-T/information-negotiation/propose/v1"),
+                                TemplateUri.of("Task-T", "v1", "information-negotiation", "propose")),
                         IllegalArgumentException.class,
-                        "Template URI is malformed or contradicts the expected phase PROPOSE (propose)"),
+                        "Template URI does not address a negotiation template of the expected phase PROPOSE (propose)"),
                 new MatrixRow(
                         "template URI with wrong version",
                         () -> orchestrator.generateProposeFromData(
                                 new NegotiationProposeData(context, informationProposeContent()),
-                                "Negotiation-T/information-negotiation/propose/v2"),
+                                TemplateUri.of("Negotiation-T", "v2", "information-negotiation", "propose")),
                         IllegalArgumentException.class,
-                        "Template URI is malformed or contradicts the expected phase PROPOSE (propose)"),
+                        "Template URI does not address a negotiation template of the expected phase PROPOSE (propose)"),
                 new MatrixRow(
                         "template URI with underscore type segment",
                         () -> orchestrator.generateProposeFromData(
                                 new NegotiationProposeData(context, informationProposeContent()),
-                                "Negotiation-T/information_negotiation/propose/v1"),
+                                TemplateUri.of("Negotiation-T", "v1", "information_negotiation", "propose")),
                         IllegalArgumentException.class,
-                        "Template URI is malformed or contradicts the expected phase PROPOSE (propose)"),
+                        "Template URI does not address a negotiation template of the expected phase PROPOSE (propose)"),
                 new MatrixRow(
                         "template URI with unknown type",
                         () -> orchestrator.generateProposeFromData(
                                 new NegotiationProposeData(context, informationProposeContent()),
-                                "Negotiation-T/unknown-negotiation/propose/v1"),
+                                TemplateUri.of("Negotiation-T", "v1", "unknown-negotiation", "propose")),
                         IllegalArgumentException.class,
-                        "Template URI is malformed or contradicts the expected phase PROPOSE (propose)"),
+                        "Template URI does not address a negotiation template of the expected phase PROPOSE (propose)"),
                 new MatrixRow(
                         "template URI phase contradicts the method",
                         () -> orchestrator.generateProposeFromData(
                                 new NegotiationProposeData(context, informationProposeContent()),
                                 INFORMATION_ACCEPT_URI),
                         IllegalArgumentException.class,
-                        "Template URI is malformed or contradicts the expected phase PROPOSE (propose)"),
+                        "Template URI does not address a negotiation template of the expected phase PROPOSE (propose)"),
                 new MatrixRow(
                         "template URI type contradicts the content type",
                         () -> orchestrator.generateProposeFromData(

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/FromTextLlmPipelineTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/FromTextLlmPipelineTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.A2ATConfig;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.model.LlmConfig;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
@@ -64,7 +65,7 @@ class FromTextLlmPipelineTest {
 
     private static final String EN_US = GoldenInputs.EN_US;
 
-    private static final String INFORMATION_PROPOSE_URI = GoldenCase.INFORMATION_PROPOSE.templateUri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = GoldenCase.INFORMATION_PROPOSE.template();
 
     private final ListAppender<ILoggingEvent> orchestratorAppender = new ListAppender<>();
 
@@ -108,7 +109,7 @@ class FromTextLlmPipelineTest {
         NegotiationGenerationOrchestrator orchestrator = orchestrator(ZH_CN, llm, 3);
 
         MetadataContent fromText = orchestrator.generateProposeFromText(
-                "请补充节能区域、节能速率保障目标与VLANId信息。", goldenCase.context(), goldenCase.templateUri());
+                "请补充节能区域、节能速率保障目标与VLANId信息。", goldenCase.context(), goldenCase.template());
 
         assertEquals(1, llm.calls, "from-text generation must run exactly one content extraction call");
         assertEquals(goldenCase.templateUri(), fromText.templateUri());
@@ -202,7 +203,7 @@ class FromTextLlmPipelineTest {
         NegotiationGenerationOrchestrator orchestrator = orchestrator(ZH_CN, llm, 3);
 
         MetadataContent result =
-                orchestrator.generateProposeFromText("请提供区域。", goldenCase.context(), goldenCase.templateUri());
+                orchestrator.generateProposeFromText("请提供区域。", goldenCase.context(), goldenCase.template());
 
         assertEquals(3, llm.calls, "two failures followed by one success must result in three calls");
         assertEquals(readGoldenFixture(goldenCase, ZH_CN), result.promptText());
@@ -308,7 +309,7 @@ class FromTextLlmPipelineTest {
         NegotiationGenerationException failure = assertThrows(
                 NegotiationGenerationException.class,
                 () -> orchestrator.generateAcceptFromText(
-                        "请接受。", GoldenCase.INFORMATION_ACCEPT.context(), GoldenCase.INFORMATION_ACCEPT.templateUri()));
+                        "请接受。", GoldenCase.INFORMATION_ACCEPT.context(), GoldenCase.INFORMATION_ACCEPT.template()));
 
         assertEquals(A2ATErrorCodes.NEGOTIATION_INVALID_INPUT, failure.getCode());
         assertEquals(1, llm.calls, "non-retryable failures must not be attempted again");
@@ -374,10 +375,10 @@ class FromTextLlmPipelineTest {
                 () -> orchestrator.generateProposeFromText(
                         "请提供区域。",
                         GoldenCase.INFORMATION_PROPOSE.context(),
-                        GoldenCase.INFORMATION_ACCEPT.templateUri()));
+                        GoldenCase.INFORMATION_ACCEPT.template()));
 
         assertTrue(
-                failure.getMessage().contains("Template URI is malformed or contradicts the expected phase PROPOSE"),
+                failure.getMessage().contains("Template URI does not address a negotiation template of the expected phase PROPOSE"),
                 "the failure must point at the template URI but was: " + failure.getMessage());
         assertEquals(0, llm.calls);
     }
@@ -440,7 +441,7 @@ class FromTextLlmPipelineTest {
         NegotiationGenerationOrchestrator recoveringOrchestrator = orchestrator(ZH_CN, recovering, large.maxAttempts());
 
         MetadataContent result = recoveringOrchestrator.generateProposeFromText(
-                "请提供区域。", goldenCase.context(), goldenCase.templateUri());
+                "请提供区域。", goldenCase.context(), goldenCase.template());
 
         assertEquals(10, recovering.calls, "nine failed attempts plus one success must consume the clamped limit");
         assertEquals(readGoldenFixture(goldenCase, ZH_CN), result.promptText());
@@ -458,7 +459,7 @@ class FromTextLlmPipelineTest {
         NegotiationGenerationException failure = assertThrows(
                 NegotiationGenerationException.class,
                 () -> failingOrchestrator.generateProposeFromText(
-                        "请提供区域。", goldenCase.context(), goldenCase.templateUri()));
+                        "请提供区域。", goldenCase.context(), goldenCase.template()));
 
         assertEquals(A2ATErrorCodes.NEGOTIATION_CONTENT_EXTRACT_FAILED, failure.getCode());
         assertEquals(1, failing.calls);
@@ -494,7 +495,7 @@ class FromTextLlmPipelineTest {
                 orchestrator(config.prompt().language(), llm, config.llm().maxAttempts());
 
         MetadataContent message =
-                orchestrator.generateProposeFromText(inputText, goldenCase.context(), goldenCase.templateUri());
+                orchestrator.generateProposeFromText(inputText, goldenCase.context(), goldenCase.template());
 
         assertEquals(1, llm.calls, "the en-US from-text chain needs exactly one extraction call");
         assertEquals(readGoldenFixture(goldenCase, EN_US), message.promptText());
@@ -508,7 +509,7 @@ class FromTextLlmPipelineTest {
         FilledParamData filled = orchestrator.validateAndFillingProposeData(
                 message.promptText(),
                 Map.of("type", "object", "properties", Map.of("region", Map.of("type", "string"))),
-                goldenCase.templateUri());
+                goldenCase.template());
 
         assertEquals(2, llm.calls, "the validation pipeline adds exactly one semantic validation call");
         assertEquals(goldenCase.context().id(), filled.data().get("id"));
@@ -553,9 +554,9 @@ class FromTextLlmPipelineTest {
     private static MetadataContent generateFromText(
             NegotiationGenerationOrchestrator orchestrator, GoldenCase goldenCase, String text) {
         return switch (goldenCase.phase()) {
-            case PROPOSE -> orchestrator.generateProposeFromText(text, goldenCase.context(), goldenCase.templateUri());
-            case ACCEPT -> orchestrator.generateAcceptFromText(text, goldenCase.context(), goldenCase.templateUri());
-            case REJECT -> orchestrator.generateRejectFromText(text, goldenCase.context(), goldenCase.templateUri());
+            case PROPOSE -> orchestrator.generateProposeFromText(text, goldenCase.context(), goldenCase.template());
+            case ACCEPT -> orchestrator.generateAcceptFromText(text, goldenCase.context(), goldenCase.template());
+            case REJECT -> orchestrator.generateRejectFromText(text, goldenCase.context(), goldenCase.template());
         };
     }
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilderWiringTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilderWiringTest.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMError;
@@ -43,7 +44,7 @@ class NegotiationGenerationOrchestratorBuilderWiringTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     private Logger rootLogger;
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -30,7 +31,9 @@ class NegotiationGenerationOrchestratorTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
+
+    private static final String INFORMATION_PROPOSE_URI = INFORMATION_PROPOSE.uri();
 
     @Test
     void generatesInformationProposeFromDataInChinese() {
@@ -39,7 +42,7 @@ class NegotiationGenerationOrchestratorTest {
                         new NegotiationProposeData(
                                 new NegotiationContext(UUID, 1, 5),
                                 new InfoProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                        INFORMATION_PROPOSE_URI);
+                        INFORMATION_PROPOSE);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertEquals(NegotiationHandler.NEGOTIATION_T_URI, result.extensionUri());
@@ -63,7 +66,7 @@ class NegotiationGenerationOrchestratorTest {
                         new NegotiationProposeData(
                                 new NegotiationContext(UUID, 2, 5),
                                 new InfoProposeContent(List.of(new NegotiationItem("Region", "Songshan Lake")), null)),
-                        INFORMATION_PROPOSE_URI);
+                        INFORMATION_PROPOSE);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -82,7 +85,7 @@ class NegotiationGenerationOrchestratorTest {
                 .build();
 
         MetadataContent result = orchestrator.generateProposeFromText(
-                "请提供故障发生时间。", new NegotiationContext(UUID, 2, 5), INFORMATION_PROPOSE_URI);
+                "请提供故障发生时间。", new NegotiationContext(UUID, 2, 5), INFORMATION_PROPOSE);
 
         assertEquals(1, llm.calls);
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
@@ -104,12 +107,12 @@ class NegotiationGenerationOrchestratorTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE);
 
         FilledParamData filled = orchestrator.validateAndFillingProposeData(
                 message.promptText(),
                 Map.of("type", "object", "properties", Map.of("region", Map.of("type", "string"))),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE);
 
         assertEquals(1, llm.calls);
         assertEquals(UUID, filled.data().get("id"));
@@ -126,15 +129,16 @@ class NegotiationGenerationOrchestratorTest {
 
     @Test
     void queriesSingleTemplateByUri() {
-        assertTrue(
-                zhOrchestrator().getNegotiationPrompt(INFORMATION_PROPOSE_URI).isPresent());
+        assertTrue(zhOrchestrator().getNegotiationPrompt(INFORMATION_PROPOSE).isPresent());
         assertTrue(zhOrchestrator()
-                .getNegotiationPrompt(StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri())
+                .getNegotiationPrompt(StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT)
                 .isPresent());
-        assertFalse(zhOrchestrator()
-                .getNegotiationPrompt("Negotiation-T/unknown-negotiation/propose/v1")
-                .isPresent());
-        assertFalse(zhOrchestrator().getNegotiationPrompt("malformed-uri").isPresent());
+        assertFalse(
+                zhOrchestrator()
+                        .getNegotiationPrompt(
+                                TemplateUri.of("Negotiation-T", "v1", "unknown-negotiation", "propose"))
+                        .isPresent());
+        assertFalse(zhOrchestrator().getNegotiationPrompt(StandardTemplates.ENERGY_SAVING).isPresent());
     }
 
     @Test
@@ -147,7 +151,7 @@ class NegotiationGenerationOrchestratorTest {
                 .build();
 
         MetadataContent result = orchestrator.generateProposeFromText(
-                "请提供区域。", new NegotiationContext(UUID, 1, 5), INFORMATION_PROPOSE_URI);
+                "请提供区域。", new NegotiationContext(UUID, 1, 5), INFORMATION_PROPOSE);
 
         assertEquals(3, llm.calls);
         assertFalse(result.promptText().isBlank());
@@ -165,7 +169,7 @@ class NegotiationGenerationOrchestratorTest {
         NegotiationGenerationException failure = assertThrows(
                 NegotiationGenerationException.class,
                 () -> orchestrator.generateProposeFromText(
-                        "请提供区域。", new NegotiationContext(UUID, 1, 5), INFORMATION_PROPOSE_URI));
+                        "请提供区域。", new NegotiationContext(UUID, 1, 5), INFORMATION_PROPOSE));
 
         assertEquals(2, llm.calls);
         assertEquals(A2ATErrorCodes.NEGOTIATION_LLM_INFRASTRUCTURE_ERROR, failure.getCode());
@@ -184,7 +188,7 @@ class NegotiationGenerationOrchestratorTest {
                         new NegotiationProposeData(
                                 new NegotiationContext(UUID, 1, 5),
                                 new InfoProposeContent(List.of(new NegotiationItem("区域", "松山湖")), null)),
-                        INFORMATION_PROPOSE_URI));
+                        INFORMATION_PROPOSE));
         assertEquals(A2ATErrorCodes.TEMPLATE_NOT_FOUND, generationFailure.getCode());
 
         NegotiationGenerationOrchestrator validationOrchestrator = NegotiationGenerationOrchestratorBuilder.builder()
@@ -200,7 +204,7 @@ class NegotiationGenerationOrchestratorTest {
                 () -> validationOrchestrator.validateAndFillingProposeData(
                         "## 协商上下文\n- id: " + UUID + "\n- round: 1\n- maxRounds: 5",
                         Map.of("type", "object"),
-                        INFORMATION_PROPOSE_URI));
+                        INFORMATION_PROPOSE));
         assertEquals(A2ATErrorCodes.TEMPLATE_NOT_FOUND, extractionFailure.getCode());
     }
 
@@ -218,35 +222,37 @@ class NegotiationGenerationOrchestratorTest {
                 () -> orchestrator.validateAndFillingProposeData(
                         "plain text without any negotiation section",
                         Map.of("type", "object"),
-                        INFORMATION_PROPOSE_URI));
+                        INFORMATION_PROPOSE));
 
         assertEquals(A2ATErrorCodes.NEGOTIATION_INVALID_INPUT, failure.getCode());
         assertEquals(0, llm.calls);
     }
 
     @Test
-    void rejectsMalformedTemplateUriAsAnIllegalArgument() {
-        IllegalArgumentException malformedUriFailure =
-                assertThrows(IllegalArgumentException.class, () -> zhOrchestrator()
-                        .generateProposeFromData(
-                                new NegotiationProposeData(
-                                        new NegotiationContext(UUID, 1, 5),
-                                        new InfoProposeContent(List.of(new NegotiationItem("区域", "松山湖")), null)),
-                                "information-negotiation/propose"));
-        assertTrue(malformedUriFailure
-                .getMessage()
-                .contains("Template URI is malformed or contradicts the expected phase PROPOSE (propose)"));
-
+    void rejectsTemplateUriThatDoesNotAddressTheExpectedPhase() {
         IllegalArgumentException phaseMismatchFailure =
                 assertThrows(IllegalArgumentException.class, () -> zhOrchestrator()
                         .generateProposeFromData(
                                 new NegotiationProposeData(
                                         new NegotiationContext(UUID, 1, 5),
                                         new InfoProposeContent(List.of(new NegotiationItem("区域", "松山湖")), null)),
-                                StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri()));
+                                StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT));
         assertTrue(phaseMismatchFailure
                 .getMessage()
-                .contains("Template URI is malformed or contradicts the expected phase PROPOSE (propose)"));
+                .contains("Template URI does not address a negotiation template of the expected phase PROPOSE"
+                        + " (propose)"));
+
+        IllegalArgumentException wrongExtensionFailure =
+                assertThrows(IllegalArgumentException.class, () -> zhOrchestrator()
+                        .generateProposeFromData(
+                                new NegotiationProposeData(
+                                        new NegotiationContext(UUID, 1, 5),
+                                        new InfoProposeContent(List.of(new NegotiationItem("区域", "松山湖")), null)),
+                                StandardTemplates.ENERGY_SAVING));
+        assertTrue(wrongExtensionFailure
+                .getMessage()
+                .contains("Template URI does not address a negotiation template of the expected phase PROPOSE"
+                        + " (propose)"));
     }
 
     private static NegotiationGenerationOrchestrator zhOrchestrator() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationTemplateQueryBoundaryTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationTemplateQueryBoundaryTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,9 +26,9 @@ import org.slf4j.LoggerFactory;
  * Verifies the boundary behavior of the template query API of the negotiation content layer.
  *
  * <p>The list query returns exactly the six built-in templates of the configured language in the fixed type and phase
- * order; the single-template query resolves a valid URI into its template record, and answers a missing or malformed
- * URI with an empty result plus a {@code negotiation_template_not_found} warning that mentions the language
- * configuration hint. Neither query ever throws.
+ * order; the single-template query resolves a valid URI into its template record, and answers a URI that addresses no
+ * negotiation template with an empty result plus a {@code negotiation_template_not_found} warning that mentions the
+ * language configuration hint. Neither query ever throws.
  */
 class NegotiationTemplateQueryBoundaryTest {
 
@@ -86,7 +87,7 @@ class NegotiationTemplateQueryBoundaryTest {
         NegotiationGenerationOrchestrator orchestrator = orchestrator(language);
 
         Optional<PromptTemplate> template =
-                orchestrator.getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri());
+                orchestrator.getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE);
 
         assertTrue(template.isPresent());
         assertEquals(
@@ -103,18 +104,18 @@ class NegotiationTemplateQueryBoundaryTest {
     void singleQueryAnswersAMissingUriWithEmptyAndAWarning() {
         NegotiationGenerationOrchestrator orchestrator = orchestrator("zh-CN");
 
-        Optional<PromptTemplate> template =
-                orchestrator.getNegotiationPrompt("Negotiation-T/unknown-negotiation/propose/v1");
+        Optional<PromptTemplate> template = orchestrator.getNegotiationPrompt(
+                TemplateUri.of("Negotiation-T", "v1", "unknown-negotiation", "propose"));
 
         assertTrue(template.isEmpty());
         assertTrue(hasWarning("negotiation_template_not_found", "A2AT_LANGUAGE"));
     }
 
     @Test
-    void singleQueryAnswersAMalformedUriWithEmptyAndAWarning() {
+    void singleQueryAnswersANonNegotiationUriWithEmptyAndAWarning() {
         NegotiationGenerationOrchestrator orchestrator = orchestrator("zh-CN");
 
-        Optional<PromptTemplate> template = orchestrator.getNegotiationPrompt("malformed-uri");
+        Optional<PromptTemplate> template = orchestrator.getNegotiationPrompt(StandardTemplates.ENERGY_SAVING);
 
         assertTrue(template.isEmpty());
         assertTrue(hasWarning("negotiation_template_not_found", "A2AT_LANGUAGE"));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/RelationshipLineRenderingTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/RelationshipLineRenderingTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.InfoProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
@@ -22,7 +23,7 @@ class RelationshipLineRenderingTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     @Test
     void chineseRelationshipIsAppendedWithTheChineseLabel() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/TemplateUriEntryMatrixTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/TemplateUriEntryMatrixTest.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -33,22 +34,24 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Verifies the template-URI entry matrix of the from-data generation.
  *
  * <p>The six built-in URIs address their templates and render outputs identical to the golden fixtures; a well-formed
- * URI that resolves to no template fails with the code {@code template_not_found} before any LLM call; a malformed URI
- * (wrong segment count, prefix, version, suffix, separator or enumeration value, including the underscore misspelling
- * of the type segment) fails as a programming error pointing at {@code templateUri}; and a template placed under a
- * local resource root overrides the built-in template addressed by the same URI.
+ * URI that resolves to no template fails with the code {@code template_not_found} before any LLM call; a typed URI
+ * that does not address a negotiation template of the expected phase (wrong extension name, version, type segment,
+ * phase segment or separator, including the underscore misspelling of the type segment) fails as a programming error
+ * pointing at {@code templateUri}, while structural malformation is impossible by construction of
+ * {@link TemplateUri}; and a template placed under a local resource root overrides the built-in template addressed
+ * by the same URI.
  */
 class TemplateUriEntryMatrixTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     private static final String BUILTIN_INFORMATION_PROPOSE_TEMPLATE =
             "templates/Negotiation-T/information-negotiation/propose/v1/zh-CN/template.md";
@@ -107,26 +110,14 @@ class TemplateUriEntryMatrixTest {
     }
 
     /**
-     * Entry (c): every malformed URI — wrong segment count, prefix, version, type suffix, separator (underscore
-     * misspelling), unknown type and invalid phase segment — fails as a programming error with an
-     * {@link IllegalArgumentException} pointing at the template URI, without any LLM call.
+     * Entry (c): every typed URI that does not address a negotiation template of the expected phase — wrong extension
+     * name, version, type segment, phase segment and separator (underscore misspelling), plus unknown types and
+     * unknown phase segments — fails as a programming error with an {@link IllegalArgumentException} pointing at the
+     * template URI, without any LLM call. Structurally malformed URIs cannot exist as {@link TemplateUri} values.
      */
-    @ParameterizedTest(name = "malformed URI [{0}] is rejected as a templateUri programming error")
-    @ValueSource(
-            strings = {
-                "foo",
-                "foo/bar",
-                "information-negotiation/propose",
-                "Negotiation-T/information-negotiation/propose/v1/extra",
-                "Task-T/information-negotiation/propose/v1",
-                "Negotiation-T/information-negotiation/propose/v2",
-                "Negotiation-T/information/propose/v1",
-                "Negotiation-T/information_negotiation/propose/v1",
-                "Negotiation-T/unknown-negotiation/propose/v1",
-                "Negotiation-T/information-negotiation/propose-x/v1",
-                "Negotiation-T/information-negotiation/accept/v1"
-            })
-    void malformedUriIsRejectedAsATemplateUriProgrammingError(String templateUri) {
+    @ParameterizedTest(name = "non-addressing URI [{0}] is rejected as a templateUri programming error")
+    @MethodSource("nonAddressingTemplateUris")
+    void nonAddressingUriIsRejectedAsATemplateUriProgrammingError(TemplateUri templateUri) {
         CountingClient llm = new CountingClient();
         NegotiationGenerationOrchestrator orchestrator = NegotiationGenerationOrchestratorBuilder.builder()
                 .language("zh-CN")
@@ -138,9 +129,21 @@ class TemplateUriEntryMatrixTest {
                 () -> orchestrator.generateProposeFromData(informationProposeData(), templateUri));
 
         assertTrue(
-                failure.getMessage().contains("Template URI is malformed or contradicts the expected phase PROPOSE"),
+                failure.getMessage().contains(
+                        "Template URI does not address a negotiation template of the expected phase PROPOSE"),
                 "the failure must point at the template URI but was: " + failure.getMessage());
         assertEquals(0, llm.calls);
+    }
+
+    static List<TemplateUri> nonAddressingTemplateUris() {
+        return List.of(
+                TemplateUri.of("Task-T", "v1", "information-negotiation", "propose"),
+                TemplateUri.of("Negotiation-T", "v2", "information-negotiation", "propose"),
+                TemplateUri.of("Negotiation-T", "v1", "information", "propose"),
+                TemplateUri.of("Negotiation-T", "v1", "information_negotiation", "propose"),
+                TemplateUri.of("Negotiation-T", "v1", "unknown-negotiation", "propose"),
+                TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "propose-x"),
+                TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "accept"));
     }
 
     /**

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidateAndFillingDataPipelineTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidateAndFillingDataPipelineTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
@@ -42,12 +43,12 @@ class ValidateAndFillingDataPipelineTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
-    private static final String INFORMATION_ACCEPT_REJECT_URI =
-            StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri INFORMATION_ACCEPT_REJECT_URI =
+            StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT;
 
-    private static final String TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE;
 
     private static final Map<String, Object> REGION_SCHEMA = Map.of(
             "type", "object", "properties", Map.of("region", Map.of("type", "string")), "required", List.of("region"));

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidateAndFillingSignatureContractTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidateAndFillingSignatureContractTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.resources.NegotiationReference;
 import net.openan.a2at.sdk.negotiation.validation.NegotiationSemanticValidator;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ class ValidateAndFillingSignatureContractTest {
             assertEquals(3, parameterTypes.length, methodName + " must take exactly three parameters");
             assertEquals(String.class, parameterTypes[0], methodName + " first parameter is the prompt text");
             assertEquals(Map.class, parameterTypes[1], methodName + " second parameter is the caller parameter schema");
-            assertEquals(String.class, parameterTypes[2], methodName + " third parameter is the template URI");
+            assertEquals(TemplateUri.class, parameterTypes[2], methodName + " third parameter is the template URI");
         }
     }
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/golden/GoldenInputs.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/golden/GoldenInputs.java
@@ -1,6 +1,8 @@
 package net.openan.a2at.sdk.negotiation.golden;
 
 import java.util.List;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityEndingContent;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityProposeContent;
 import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
@@ -233,12 +235,25 @@ public final class GoldenInputs {
         }
 
         /**
+         * Returns the built-in template URI addressed by this fixture as a typed value.
+         *
+         * @return template URI such as {@code Negotiation-T/information-negotiation/propose/v1}
+         */
+        public TemplateUri template() {
+            return TemplateUri.of(
+                    StandardTemplates.NEGOTIATION_EXTENSION_NAME,
+                    TemplateUri.DEFAULT_TEMPLATE_VERSION,
+                    typeSegment,
+                    phase.uriSegment());
+        }
+
+        /**
          * Returns the built-in template URI addressed by this fixture.
          *
          * @return template URI such as {@code Negotiation-T/information-negotiation/propose/v1}
          */
         public String templateUri() {
-            return "Negotiation-T/" + typeSegment + "/" + phase.uriSegment() + "/v1";
+            return template().uri();
         }
 
         /**
@@ -285,11 +300,11 @@ public final class GoldenInputs {
         public MetadataContent generate(NegotiationGenerationOrchestrator orchestrator) {
             return switch (phase) {
                 case PROPOSE -> orchestrator.generateProposeFromData(
-                        new NegotiationProposeData(context(), (NegotiationProposeContent) content()), templateUri());
+                        new NegotiationProposeData(context(), (NegotiationProposeContent) content()), template());
                 case ACCEPT -> orchestrator.generateAcceptFromData(
-                        new NegotiationEndingData(context(), (NegotiationEndingContent) content()), templateUri());
+                        new NegotiationEndingData(context(), (NegotiationEndingContent) content()), template());
                 case REJECT -> orchestrator.generateRejectFromData(
-                        new NegotiationEndingData(context(), (NegotiationEndingContent) content()), templateUri());
+                        new NegotiationEndingData(context(), (NegotiationEndingContent) content()), template());
             };
         }
     }

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/language/CustomRootPromptsIgnoredTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/language/CustomRootPromptsIgnoredTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.core.model.FilledParamData;
@@ -33,7 +34,7 @@ class CustomRootPromptsIgnoredTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     private static final String FAKE_PROMPT_MARKER = "FAKE_PROMPT_MARKER_5b19";
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/language/NegotiationLanguageSwitchTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/language/NegotiationLanguageSwitchTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestrator;
 import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestratorBuilder;
@@ -31,7 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 class NegotiationLanguageSwitchTest {
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     static Stream<GoldenCase> goldenCases() {
         return Stream.of(GoldenCase.values());
@@ -85,8 +86,8 @@ class NegotiationLanguageSwitchTest {
                 .getNegotiationPrompt(INFORMATION_PROPOSE_URI)
                 .orElseThrow();
 
-        assertEquals(INFORMATION_PROPOSE_URI, zhCnTemplate.uri());
-        assertEquals(INFORMATION_PROPOSE_URI, enUsTemplate.uri());
+        assertEquals(INFORMATION_PROPOSE_URI.uri(), zhCnTemplate.uri());
+        assertEquals(INFORMATION_PROPOSE_URI.uri(), enUsTemplate.uri());
         assertNotEquals(zhCnTemplate.content(), enUsTemplate.content());
         assertEquals(
                 orchestrator(GoldenInputs.ZH_CN).getNegotiationPrompts().stream()

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationErrorCodeUsageMatrixTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationErrorCodeUsageMatrixTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
@@ -42,9 +43,9 @@ class NegotiationErrorCodeUsageMatrixTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
-    private static final String INFORMATION_ENDING_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri INFORMATION_ENDING_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT;
 
     private static final String VALID_CONTEXT_PROMPT = "## 协商上下文\n- id: " + UUID + "\n- round: 1\n- maxRounds: 5";
 
@@ -177,7 +178,7 @@ class NegotiationErrorCodeUsageMatrixTest {
                                 .language("zh-CN")
                                 .llmClient(llm)
                                 .build()
-                                .generateProposeFromData(proposeData(), "malformed-template-uri"),
+                                .generateProposeFromData(proposeData(), StandardTemplates.ENERGY_SAVING),
                         IllegalArgumentException.class,
                         null),
                 row(
@@ -254,7 +255,7 @@ class NegotiationErrorCodeUsageMatrixTest {
                     "row " + name + " must stay outside A2ATError because it carries no code");
             assertNullCode(expectedCode, name);
             assertTrue(
-                    argumentFailure.getMessage().contains("Template URI is malformed"),
+                    argumentFailure.getMessage().contains("Template URI does not address"),
                     "row " + name + " must name the offending argument in its message but was: "
                             + argumentFailure.getMessage());
             return;

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationExceptionTreeRootCatchTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationExceptionTreeRootCatchTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -36,7 +37,7 @@ class NegotiationExceptionTreeRootCatchTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     @Test
     void exhaustedGenerationLlmFailureIsCatchableThroughTheCommonRoot() {
@@ -136,7 +137,7 @@ class NegotiationExceptionTreeRootCatchTest {
                     new NegotiationProposeData(
                             new NegotiationContext(UUID, 1, 5),
                             new InfoProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                    "malformed-template-uri");
+                    StandardTemplates.ENERGY_SAVING);
         } catch (A2ATError caughtByRoot) {
             fail("content programming errors must stay outside the A2ATError tree but were caught: "
                     + caughtByRoot.getMessage());
@@ -145,7 +146,7 @@ class NegotiationExceptionTreeRootCatchTest {
                     A2ATError.class.isInstance(expected),
                     "content programming errors must stay outside the A2ATError tree");
             assertTrue(
-                    expected.getMessage().contains("Template URI is malformed"),
+                    expected.getMessage().contains("Template URI does not address"),
                     "the failure must point at the template URI but was: " + expected.getMessage());
         }
     }

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationLogEventContractTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationLogEventContractTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
@@ -49,7 +50,7 @@ class NegotiationLogEventContractTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     private static final Map<String, Set<Level>> EXPECTED_EVENT_LEVELS = Map.ofEntries(
             Map.entry("negotiation_template_loaded", Set.of(Level.DEBUG)),
@@ -207,13 +208,13 @@ class NegotiationLogEventContractTest {
         NegotiationGenerationOrchestrator builtinOrchestrator = NegotiationGenerationOrchestratorBuilder.builder()
                 .language("zh-CN")
                 .build();
-        builtinOrchestrator.getNegotiationPrompt("malformed-template-uri");
+        builtinOrchestrator.getNegotiationPrompt(StandardTemplates.ENERGY_SAVING);
 
         List<String> warnings = messagesOf("negotiation_template_not_found");
         assertEquals(3, warnings.size());
         assertTrue(warnings.get(0).contains("uri=all"));
         assertTrue(warnings.get(0).contains("language=zh-CN"));
-        assertTrue(warnings.get(1).contains("uri=" + INFORMATION_PROPOSE_URI));
+        assertTrue(warnings.get(1).contains("uri=" + INFORMATION_PROPOSE_URI.uri()));
         assertTrue(warnings.get(1).contains("language=zh-CN"));
         assertTrue(warnings.get(2).contains("reason=invalid_template_uri"));
         for (String warning : warnings) {
@@ -342,7 +343,7 @@ class NegotiationLogEventContractTest {
                 .build();
         orchestrator.getNegotiationPrompts();
         orchestrator.getNegotiationPrompt(INFORMATION_PROPOSE_URI);
-        assertTrue(orchestrator.getNegotiationPrompt("malformed-template-uri").isEmpty());
+        assertTrue(orchestrator.getNegotiationPrompt(StandardTemplates.ENERGY_SAVING).isEmpty());
     }
 
     private static String validExtractionPayload() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationPublicExceptionSurfaceTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationPublicExceptionSurfaceTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.A2ATParamExtractionError;
@@ -34,7 +35,7 @@ class NegotiationPublicExceptionSurfaceTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
     private static final List<Class<?>> PUBLIC_EXCEPTION_TYPES = List.of(
             A2ATError.class,
@@ -78,7 +79,7 @@ class NegotiationPublicExceptionSurfaceTest {
                         INFORMATION_PROPOSE_URI)),
                 failureMessageOf(() -> new NegotiationContext(" ", 1, 5)),
                 failureMessageOf(() -> orchestrator.generateProposeFromText(
-                        "text", new NegotiationContext(UUID, 1, 5), "malformed-template-uri")));
+                        "text", new NegotiationContext(UUID, 1, 5), StandardTemplates.ENERGY_SAVING)));
 
         for (String message : messages) {
             assertTrue(message != null && !message.isBlank(), "failure messages must not be blank");

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReferenceTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReferenceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.NegotiationPhase;
 import net.openan.a2at.sdk.negotiation.content.NegotiationType;
 import org.junit.jupiter.api.Test;
@@ -122,6 +123,105 @@ class NegotiationReferenceTest {
                 NullPointerException.class,
                 () -> NegotiationReference.tryParse(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(), null, "zh-CN"));
         assertEquals("Expected negotiation phase must not be null.", exception.getMessage());
+    }
+
+    @Test
+    void fromTemplateUriAcceptsAllSixTypedUris() {
+        for (NegotiationType type : NegotiationType.values()) {
+            NegotiationReference propose = requirePresent(
+                    NegotiationReference.fromTemplateUri(proposeTemplate(type), NegotiationPhase.PROPOSE, "zh-CN"));
+            assertEquals(type, propose.type());
+            assertEquals(NegotiationPhase.PROPOSE, propose.phase());
+            assertEquals(proposeUri(type), propose.uri());
+            assertEquals("zh-CN", propose.language());
+
+            NegotiationReference reject = requirePresent(
+                    NegotiationReference.fromTemplateUri(acceptRejectTemplate(type), NegotiationPhase.REJECT, "en-US"));
+            assertEquals(type, reject.type());
+            assertEquals(NegotiationPhase.REJECT, reject.phase());
+            assertEquals(acceptRejectUri(type), reject.uri());
+        }
+    }
+
+    @Test
+    void fromTemplateUriRejectsNonNegotiationUris() {
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        StandardTemplates.ENERGY_SAVING, NegotiationPhase.PROPOSE, "zh-CN")
+                .isEmpty());
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        TemplateUri.of("negotiation-t", "v1", "information-negotiation", "propose"),
+                        NegotiationPhase.PROPOSE,
+                        "zh-CN")
+                .isEmpty());
+    }
+
+    @Test
+    void fromTemplateUriRejectsWrongPathSegmentCount() {
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        TemplateUri.of("Negotiation-T", "v1", "information-negotiation"),
+                        NegotiationPhase.PROPOSE,
+                        "zh-CN")
+                .isEmpty());
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "propose", "extra"),
+                        NegotiationPhase.PROPOSE,
+                        "zh-CN")
+                .isEmpty());
+    }
+
+    @Test
+    void fromTemplateUriRejectsWrongVersionTypeAndPhaseSegments() {
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        TemplateUri.of("Negotiation-T", "v2", "information-negotiation", "propose"),
+                        NegotiationPhase.PROPOSE,
+                        "zh-CN")
+                .isEmpty());
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        TemplateUri.of("Negotiation-T", "v1", "information", "propose"),
+                        NegotiationPhase.PROPOSE,
+                        "zh-CN")
+                .isEmpty());
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        TemplateUri.of("Negotiation-T", "v1", "information_negotiation", "propose"),
+                        NegotiationPhase.PROPOSE,
+                        "zh-CN")
+                .isEmpty());
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        TemplateUri.of("Negotiation-T", "v1", "unknown-negotiation", "propose"),
+                        NegotiationPhase.PROPOSE,
+                        "zh-CN")
+                .isEmpty());
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "propose-x"),
+                        NegotiationPhase.PROPOSE,
+                        "zh-CN")
+                .isEmpty());
+    }
+
+    @Test
+    void fromTemplateUriRejectsPhaseMismatchAndThrowsOnNullArguments() {
+        assertTrue(NegotiationReference.fromTemplateUri(
+                        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE, NegotiationPhase.ACCEPT, "zh-CN")
+                .isEmpty());
+
+        NullPointerException uriFailure = assertThrows(
+                NullPointerException.class,
+                () -> NegotiationReference.fromTemplateUri(null, NegotiationPhase.PROPOSE, "zh-CN"));
+        assertEquals("Template URI must not be null.", uriFailure.getMessage());
+
+        NullPointerException phaseFailure = assertThrows(
+                NullPointerException.class,
+                () -> NegotiationReference.fromTemplateUri(
+                        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE, null, "zh-CN"));
+        assertEquals("Expected negotiation phase must not be null.", phaseFailure.getMessage());
+    }
+
+    private static TemplateUri proposeTemplate(NegotiationType type) {
+        return TemplateUri.of("Negotiation-T", "v1", type.typeSegment(), "propose");
+    }
+
+    private static TemplateUri acceptRejectTemplate(NegotiationType type) {
+        return TemplateUri.of("Negotiation-T", "v1", type.typeSegment(), "accept-reject");
     }
 
     private static String proposeUri(NegotiationType type) {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/BilateralInteropScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/BilateralInteropScenarioTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
 import net.openan.a2at.sdk.negotiation.content.InfoProposeContent;
@@ -29,9 +30,9 @@ class BilateralInteropScenarioTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
-    private static final String INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT;
 
     private static final String EXTRACTION_RESPONSE =
             "{\"items\":[{\"name\":\"节能区域信息\",\"value\":\"松山湖\"}],\"relationship\":null}";

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/FeasibilityNegotiationScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/FeasibilityNegotiationScenarioTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
 import net.openan.a2at.sdk.negotiation.content.FeasibilityEndingContent;
@@ -38,9 +39,9 @@ import org.junit.jupiter.api.Test;
  */
 class FeasibilityNegotiationScenarioTest {
 
-    private static final String FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri FEASIBILITY_PROPOSE_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE;
 
-    private static final String FEASIBILITY_ACCEPT_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri FEASIBILITY_ACCEPT_URI = StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT;
 
     @Test
     void feasibilityNegotiationRunsFromSemanticRejectionToATerminalAcceptance() throws IOException {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/InformationNegotiationScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/InformationNegotiationScenarioTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
@@ -31,9 +32,9 @@ class InformationNegotiationScenarioTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
 
-    private static final String INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri INFORMATION_ACCEPT_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT;
 
     @Test
     void informationNegotiationReachesTheTerminalStateWithinOneRound() {

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/MaxRoundsExhaustionScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/MaxRoundsExhaustionScenarioTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
@@ -29,7 +30,7 @@ class MaxRoundsExhaustionScenarioTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT;
 
     @Test
     void exhaustedRoundBudgetEndsWithARejectMessageThePeerStillAccepts() {
@@ -77,7 +78,7 @@ class MaxRoundsExhaustionScenarioTest {
         assertEquals(1, peerLlm.callCount(), "the rule gate must fail before any semantic LLM call");
 
         assertTrue(
-                agent.getNegotiationPrompt("Negotiation-T/target-negotiation/abort/v1")
+                agent.getNegotiationPrompt(TemplateUri.of("Negotiation-T", "v1", "target-negotiation", "abort"))
                         .isEmpty(),
                 "no template of an abort phase exists anywhere");
     }

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/TargetNegotiationScenarioTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/scenario/TargetNegotiationScenarioTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationConclusion;
@@ -29,9 +30,9 @@ class TargetNegotiationScenarioTest {
 
     private static final String SESSION_ID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri TARGET_PROPOSE_URI = StandardTemplates.TARGET_NEGOTIATION_PROPOSE;
 
-    private static final String TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri();
+    private static final TemplateUri TARGET_ACCEPT_URI = StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT;
 
     @Test
     void targetNegotiationSwitchesConditionalSectionsAcrossRounds() {

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/catalog/PromptTemplateCatalog.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/catalog/PromptTemplateCatalog.java
@@ -14,6 +14,7 @@ import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
@@ -21,6 +22,9 @@ import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
 import net.openan.a2at.sdk.core.resources.ClasspathResourceStreams;
 import net.openan.a2at.sdk.core.resources.PathSegments;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +34,9 @@ import org.slf4j.LoggerFactory;
  * <p>The catalog enumerates the {@code templates/} tree of the bundled prompt resources by walking its directories,
  * so every extension directory that appears under {@code prompt_resources/templates/} — Task-T, Notification-T,
  * Authorization-T, Negotiation-T and any extension added later — is picked up without a hardcoded extension list.
- * A template file lives at {@code templates/<extension>/<version>/<scenario>[/<sub-template>]/<language>/template.md}
+ * A template file lives at {@code templates/<extensionName>/<pathSegments>/<templateVersion>/<language>/template.md}
  * and is addressed by the URI formed from the segments before the language, for example
- * {@code Negotiation-T/v1/information-negotiation/propose} or {@code Task-T/v1/energy-saving}.
+ * {@code Negotiation-T/information-negotiation/propose/v1} or {@code Task-T/network-layer/energy-saving/v1}.
  *
  * <p>A local file under the configured local resource root overrides the built-in classpath template of the same
  * path, and the classpath is the fallback otherwise. Both query methods never throw: a template or a root that cannot
@@ -66,7 +70,7 @@ public final class PromptTemplateCatalog {
      *     local template overrides
      * @throws IllegalArgumentException if the language is not a simple path segment
      */
-    public PromptTemplateCatalog(String language, String localRootDir) {
+    public PromptTemplateCatalog(@NonNull String language, @Nullable String localRootDir) {
         if (!PathSegments.isSimpleSegment(language)) {
             throw new IllegalArgumentException(
                     "Prompt template catalog language must be a non-blank simple path segment but was " + language
@@ -85,7 +89,7 @@ public final class PromptTemplateCatalog {
      *
      * @return loadable templates of the configured language sorted by URI; empty when none can be loaded
      */
-    public List<PromptTemplate> loadAll() {
+    public @NonNull List<PromptTemplate> loadAll() {
         Map<String, String> contentsByPath = new LinkedHashMap<>();
         try {
             contentsByPath.putAll(classpathTemplates());
@@ -118,16 +122,14 @@ public final class PromptTemplateCatalog {
     /**
      * Loads one template of the configured language by its URI, regardless of the extension.
      *
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose} or
-     *     {@code Task-T/v1/energy-saving}
-     * @return the addressed template, or an empty optional when the URI is malformed or no template exists for it in
-     *     the configured language
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/propose/v1} or
+     *     {@code Task-T/network-layer/energy-saving/v1}
+     * @return the addressed template, or an empty optional when no template exists for it in the configured language
+     * @throws NullPointerException if the template URI is null
      */
-    public Optional<PromptTemplate> load(String templateUri) {
-        String uri = templateUri == null ? null : templateUri.strip();
-        if (!isCatalogableUri(uri)) {
-            return Optional.empty();
-        }
+    public Optional<PromptTemplate> load(@NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
+        String uri = templateUri.uri();
         String relativePath = String.join("/", TEMPLATE_DIRECTORY, uri, language, TEMPLATE_FILE_NAME);
         try {
             String content = readTemplate(relativePath);

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/catalog/TemplateQueryService.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/catalog/TemplateQueryService.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The service exposes the extension-agnostic template queries of the design document over a
  * {@link PromptTemplateCatalog}: {@link #getPrompts()} lists every loadable template of the configured language
- * across all A2A-T extensions and {@link #getPrompt(String)} loads one template by its URI. Both queries never
+ * across all A2A-T extensions and {@link #getPrompt(TemplateUri)} loads one template by its URI. Both queries never
  * throw; a missing template is answered with an empty result and an actionable warning log.
  *
  * @since 2026-08
@@ -37,7 +40,8 @@ public final class TemplateQueryService {
      * @param templateCatalog directory-driven catalog over the template tree of every extension
      * @param language locale identifier the catalog was created for; only used in log messages
      */
-    public TemplateQueryService(PromptTemplateCatalog templateCatalog, String language) {
+    public TemplateQueryService(
+            @NonNull PromptTemplateCatalog templateCatalog, @NonNull String language) {
         this.templateCatalog = Objects.requireNonNull(templateCatalog, "Prompt template catalog must not be null.");
         this.language = Objects.requireNonNull(language, "Language must not be null.");
         this.logger = DEFAULT_LOGGER;
@@ -50,7 +54,7 @@ public final class TemplateQueryService {
      * @param localRootDir local prompt resource root containing the {@code templates/} tree; null or blank disables
      *     local template overrides
      */
-    public TemplateQueryService(String language, String localRootDir) {
+    public TemplateQueryService(@NonNull String language, @Nullable String localRootDir) {
         this(new PromptTemplateCatalog(language, localRootDir), language);
     }
 
@@ -64,28 +68,29 @@ public final class TemplateQueryService {
      * @return loadable templates of the configured language across all extensions, sorted by URI; empty when none can
      *     be loaded
      */
-    public List<PromptTemplate> getPrompts() {
+    public @NonNull List<PromptTemplate> getPrompts() {
         return templateCatalog.loadAll();
     }
 
     /**
      * Loads one template by its URI, regardless of the extension.
      *
-     * <p>This query never throws: a malformed URI or a template that exists nowhere for the configured language
-     * returns an empty result and logs an actionable warning.
+     * <p>This query never throws: a template that exists nowhere for the configured language returns an empty result
+     * and logs an actionable warning.
      *
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose} or
-     *     {@code Task-T/v1/energy-saving}
-     * @return the addressed template, or an empty result when the URI is malformed or the template does not exist for
-     *     the configured language
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/propose/v1} or
+     *     {@code Task-T/network-layer/energy-saving/v1}
+     * @return the addressed template, or an empty result when the template does not exist for the configured language
+     * @throws NullPointerException if the template URI is null
      */
-    public Optional<PromptTemplate> getPrompt(String templateUri) {
+    public Optional<PromptTemplate> getPrompt(@NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
         Optional<PromptTemplate> template = templateCatalog.load(templateUri);
         if (template.isEmpty()) {
             logger.atWarn()
                     .log(
                             "prompt_template_not_found uri={} language={} hint={}",
-                            templateUri,
+                            templateUri.uri(),
                             language,
                             LANGUAGE_HINT);
         }

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
@@ -8,6 +8,8 @@ import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ValidationPipeline;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.prompt.resources.loader.PromptResourceAccess;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Default content validator that orchestrates the full validation pipeline with a no-op rule checker and an LLM-backed
@@ -42,11 +44,11 @@ public final class DefaultContentValidator implements ContentValidator {
      * @param promptResourceAccess prompt resource access for loading validation prompts
      */
     public DefaultContentValidator(
-            String extensionName,
-            String language,
+            @NonNull String extensionName,
+            @NonNull String language,
             int maxAttempts,
-            LLMClient llmClient,
-            PromptResourceAccess promptResourceAccess) {
+            @Nullable LLMClient llmClient,
+            @NonNull PromptResourceAccess promptResourceAccess) {
         this.extensionName = extensionName;
         this.language = language;
         this.maxAttempts = maxAttempts;
@@ -54,36 +56,36 @@ public final class DefaultContentValidator implements ContentValidator {
         this.promptResourceAccess = promptResourceAccess;
     }
 
+    /**
+     * Validates one content prompt and extracts its filled parameters.
+     *
+     * @param prompt content prompt text
+     * @param schema caller-provided parameter JSON schema
+     * @param templateUri URI of the template the content is validated against, such as
+     *     {@code Task-T/network-layer/energy-saving/v1}
+     * @return filled parameter data carrying the merged parameters
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, the template URI addresses another extension than the
+     *     one this validator is configured for, or the template URI version is unsupported
+     * @throws net.openan.a2at.sdk.core.validation.ContentValidationException if the validation fails at any stage
+     */
     @Override
-    public FilledParamData validate(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validate(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
         Objects.requireNonNull(templateUri, "templateUri");
-        if (templateUri.isBlank()) {
-            throw new IllegalArgumentException("Template URI must not be blank.");
-        }
 
-        String[] parts = templateUri.split("/");
-        if (parts.length < 3) {
+        if (!extensionName.equals(templateUri.extensionName())) {
             throw new IllegalArgumentException(
-                    "Template URI format must be {extensionName}/{pathSegments}/{templateVersion}, got: "
-                            + templateUri);
+                    "Template URI extension '" + templateUri.extensionName()
+                            + "' does not match expected extension '" + extensionName + "'.");
         }
 
-        String prefix = parts[0];
-        String templateVersion = parts[parts.length - 1];
-
-        if (!extensionName.equals(prefix)) {
+        if (!TemplateUri.DEFAULT_TEMPLATE_VERSION.equals(templateUri.templateVersion())) {
             throw new IllegalArgumentException(
-                    "Template URI prefix '" + prefix + "' does not match expected extension prefix '" + extensionName
-                            + "'.");
+                    "Unsupported template URI version: " + templateUri.templateVersion());
         }
 
-        if (!TemplateUri.DEFAULT_TEMPLATE_VERSION.equals(templateVersion)) {
-            throw new IllegalArgumentException("Unsupported template URI version: " + templateVersion);
-        }
-
-        TemplateUri reference = TemplateUri.of(
-                prefix, templateVersion, java.util.Arrays.copyOfRange(parts, 1, parts.length - 1));
-        return pipeline().validate(prompt, schema, reference);
+        return pipeline().validate(prompt, schema, templateUri);
     }
 
     private ValidationPipeline pipeline() {

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
@@ -20,6 +20,8 @@ import net.openan.a2at.sdk.core.validation.ValidationResult;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.prompt.resources.loader.PromptResourceAccess;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +50,9 @@ public final class DefaultSemanticValidator implements SemanticValidator<Templat
      * @throws net.openan.a2at.sdk.core.exception.ResourceNotFoundException if prompt resources are missing
      */
     public DefaultSemanticValidator(
-            LLMClient llmClient, String language, PromptResourceAccess promptResourceAccess) {
+            @Nullable LLMClient llmClient,
+            @NonNull String language,
+            @NonNull PromptResourceAccess promptResourceAccess) {
         this.llmClient = llmClient;
         this.systemPrompt = promptResourceAccess.loadPrompt("content_validation", language, "system");
         this.userPromptTemplate = promptResourceAccess.loadPrompt("content_validation", language, "user");
@@ -56,7 +60,8 @@ public final class DefaultSemanticValidator implements SemanticValidator<Templat
     }
 
     @Override
-    public ValidationResult validate(String prompt, Map<String, Object> schema, TemplateUri reference) {
+    public ValidationResult validate(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri reference) {
         if (llmClient == null) {
             throw new ContentValidationException(
                     A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR,

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/api/NegotiationFacadeOutputSymmetryTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/api/NegotiationFacadeOutputSymmetryTest.java
@@ -23,6 +23,7 @@ import net.openan.a2at.sdk.negotiation.content.InfoEndingContent;
 import net.openan.a2at.sdk.negotiation.content.InfoProposeContent;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.NegotiationAction;
 import net.openan.a2at.sdk.negotiation.content.NegotiationConclusion;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
@@ -101,7 +102,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 assertNotNull(clientResult.promptText());
                 assertEquals(clientResult, serverResult, "case " + symmetryCase.label() + " [" + language + "]");
                 assertEquals(clientResult.buildMetadataContent(), serverResult.buildMetadataContent());
-                assertEquals(symmetryCase.templateUri(), clientResult.templateUri());
+                assertEquals(symmetryCase.templateUri().uri(), clientResult.templateUri());
             }
         }
     }
@@ -152,7 +153,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "information_propose",
                         NegotiationPhase.PROPOSE,
-                        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(),
+                        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE,
                         new NegotiationProposeData(
                                 new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5),
                                 new InfoProposeContent(
@@ -164,7 +165,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "target_propose",
                         NegotiationPhase.PROPOSE,
-                        StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(),
+                        StandardTemplates.TARGET_NEGOTIATION_PROPOSE,
                         new NegotiationProposeData(
                                 new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 1, 5),
                                 new TargetProposeContent(
@@ -175,7 +176,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "feasibility_propose",
                         NegotiationPhase.PROPOSE,
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE,
                         new NegotiationProposeData(
                                 new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5),
                                 new FeasibilityProposeContent(
@@ -186,41 +187,41 @@ class NegotiationFacadeOutputSymmetryTest {
                 endingCase(
                         "information_accept",
                         NegotiationPhase.ACCEPT,
-                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(),
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT,
                         new InfoEndingContent(
                                 NegotiationConclusion.ACCEPT,
                                 List.of(new NegotiationItem("area information", "Songshan Lake")))),
                 endingCase(
                         "target_accept",
                         NegotiationPhase.ACCEPT,
-                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(),
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT,
                         new TargetEndingContent(NegotiationConclusion.ACCEPT, "The confirmed intent.", null)),
                 endingCase(
                         "feasibility_accept",
                         NegotiationPhase.ACCEPT,
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT,
                         new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, "The target is achievable.")),
                 endingCase(
                         "information_reject",
                         NegotiationPhase.REJECT,
-                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(),
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT,
                         new InfoEndingContent(
                                 NegotiationConclusion.REJECT,
                                 List.of(new NegotiationItem("area information", "not available")))),
                 endingCase(
                         "target_reject",
                         NegotiationPhase.REJECT,
-                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(),
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT,
                         new TargetEndingContent(NegotiationConclusion.REJECT, null, "The intent is unclear.")),
                 endingCase(
                         "feasibility_reject",
                         NegotiationPhase.REJECT,
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT,
                         new FeasibilityEndingContent(NegotiationConclusion.REJECT, "The target is not achievable.")));
     }
 
     private static SymmetryCase endingCase(
-            String label, NegotiationPhase phase, String templateUri, NegotiationEndingContent content) {
+            String label, NegotiationPhase phase, TemplateUri templateUri, NegotiationEndingContent content) {
         return new SymmetryCase(
                 label,
                 phase,
@@ -230,7 +231,7 @@ class NegotiationFacadeOutputSymmetryTest {
     }
 
     /** One symmetry case: a fixed input addressed to one of the three from-data generation methods. */
-    private record SymmetryCase(String label, NegotiationPhase phase, String templateUri, Object data) {
+    private record SymmetryCase(String label, NegotiationPhase phase, TemplateUri templateUri, Object data) {
 
         MetadataContent generate(ProposeGenerator propose, EndingGenerator accept, EndingGenerator reject) {
             return switch (phase) {
@@ -244,13 +245,13 @@ class NegotiationFacadeOutputSymmetryTest {
     @FunctionalInterface
     private interface ProposeGenerator {
 
-        MetadataContent generate(NegotiationProposeData data, String templateUri);
+        MetadataContent generate(NegotiationProposeData data, TemplateUri templateUri);
     }
 
     @FunctionalInterface
     private interface EndingGenerator {
 
-        MetadataContent generate(NegotiationEndingData data, String templateUri);
+        MetadataContent generate(NegotiationEndingData data, TemplateUri templateUri);
     }
 
     public static final class RecordingClient implements LLMClient {

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
@@ -3,12 +3,14 @@ package net.openan.a2at.sdk.server;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import net.openan.a2at.sdk.core.model.A2ATConfig;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
 import net.openan.a2at.sdk.core.validation.ContentValidator;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContentService;
 import net.openan.a2at.sdk.negotiation.content.NegotiationEndingData;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
@@ -20,6 +22,7 @@ import net.openan.a2at.sdk.prompt.resources.catalog.TemplateQueryService;
 import net.openan.a2at.sdk.server.assembly.DefaultA2ATServerBuilder;
 import net.openan.a2at.sdk.server.compliance.ServerPromptComplianceOrchestrator;
 import net.openan.a2at.sdk.server.model.PromptComplianceResult;
+import org.jspecify.annotations.NonNull;
 
 /**
  * High-level server facade for prompt compliance and negotiation APIs. The caller provides the `.env` file path
@@ -69,7 +72,7 @@ public final class A2ATServer {
      * @param processedPromptText processed task prompt text
      * @return compliance result containing only success state or failure details
      */
-    public PromptComplianceResult checkTaskPrompt(String processedPromptText) {
+    public PromptComplianceResult checkTaskPrompt(@NonNull String processedPromptText) {
         return promptComplianceOrchestrator.checkTaskPrompt(processedPromptText);
     }
 
@@ -81,7 +84,8 @@ public final class A2ATServer {
      * @param facts structured facts attached to the payload
      * @return transport payload representing the initial negotiation turn
      */
-    public Map<String, Object> startNegotiation(NegotiationType type, String contentText, Map<String, Object> facts) {
+    public Map<String, Object> startNegotiation(
+            @NonNull NegotiationType type, @NonNull String contentText, @NonNull Map<String, Object> facts) {
         return negotiationOrchestrator.startNegotiation(type, contentText, facts);
     }
 
@@ -92,7 +96,7 @@ public final class A2ATServer {
      * @param context transport context payload associated with the message
      * @return normalized payload describing the receive result
      */
-    public Map<String, Object> receiveNegotiation(String message, Map<String, Object> context) {
+    public Map<String, Object> receiveNegotiation(@NonNull String message, @NonNull Map<String, Object> context) {
         return negotiationOrchestrator.receiveNegotiation(message, context);
     }
 
@@ -105,7 +109,7 @@ public final class A2ATServer {
      * @return transport payload representing the next negotiation turn
      */
     public Map<String, Object> continueNegotiation(
-            NegotiationContext context, NegotiationStatus status, String contentText) {
+            @NonNull NegotiationContext context, @NonNull NegotiationStatus status, @NonNull String contentText) {
         return negotiationOrchestrator.continueNegotiation(context, status, contentText);
     }
 
@@ -116,17 +120,18 @@ public final class A2ATServer {
      * generator of the negotiation type addressed by the template URI and rendered from that template.
      *
      * @param data typed propose input carrying the negotiation context and the typed content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/propose}; its phase
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/propose/v1}; its phase
      *     segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, or its phase or type contradicts the method
-     *     or the content type
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content type
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, String templateUri) {
+    public MetadataContent generateNegotiationProposePromptFromData(
+            @NonNull NegotiationProposeData data, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.generateProposeFromData(data, templateUri);
     }
 
@@ -137,17 +142,19 @@ public final class A2ATServer {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/accept-reject}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its
+     *     phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, its phase or type contradicts the method or
-     *     the content, or the content conclusion is not {@code Accept}
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
+     *     content conclusion is not {@code Accept}
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateNegotiationAcceptPromptFromData(NegotiationEndingData data, String templateUri) {
+    public MetadataContent generateNegotiationAcceptPromptFromData(
+            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.generateAcceptFromData(data, templateUri);
     }
 
@@ -158,17 +165,19 @@ public final class A2ATServer {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/v1/feasibility-negotiation/accept-reject}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its
+     *     phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI is malformed, its phase or type contradicts the method or
-     *     the content, or the content conclusion is not {@code Reject}
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
+     *     content conclusion is not {@code Reject}
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation_slot_missing} when rendering the template fails
      */
-    public MetadataContent generateNegotiationRejectPromptFromData(NegotiationEndingData data, String templateUri) {
+    public MetadataContent generateNegotiationRejectPromptFromData(
+            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.generateRejectFromData(data, templateUri);
     }
 
@@ -182,11 +191,11 @@ public final class A2ATServer {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose}; its phase segment
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase segment
      *     must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
@@ -195,7 +204,10 @@ public final class A2ATServer {
      *     content contradicts the phase
      */
     public MetadataContent generateNegotiationProposePromptFromText(
-            String text, net.openan.a2at.sdk.negotiation.content.NegotiationContext context, String templateUri) {
+            @NonNull String text,
+            net.openan.a2at.sdk.negotiation.content.NegotiationContext context,
+            @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.generateProposeFromText(text, context, templateUri);
     }
 
@@ -208,11 +220,11 @@ public final class A2ATServer {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/information-negotiation/accept-reject}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its
+     *     phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
@@ -221,7 +233,10 @@ public final class A2ATServer {
      *     conclusion is not {@code Accept}
      */
     public MetadataContent generateNegotiationAcceptPromptFromText(
-            String text, net.openan.a2at.sdk.negotiation.content.NegotiationContext context, String templateUri) {
+            @NonNull String text,
+            net.openan.a2at.sdk.negotiation.content.NegotiationContext context,
+            @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.generateAcceptFromText(text, context, templateUri);
     }
 
@@ -234,11 +249,11 @@ public final class A2ATServer {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/v1/feasibility-negotiation/accept-reject}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its
+     *     phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI is malformed or its phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
@@ -247,7 +262,10 @@ public final class A2ATServer {
      *     conclusion is not {@code Reject}
      */
     public MetadataContent generateNegotiationRejectPromptFromText(
-            String text, net.openan.a2at.sdk.negotiation.content.NegotiationContext context, String templateUri) {
+            @NonNull String text,
+            net.openan.a2at.sdk.negotiation.content.NegotiationContext context,
+            @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.generateRejectFromText(text, context, templateUri);
     }
 
@@ -268,15 +286,15 @@ public final class A2ATServer {
     /**
      * Loads one template by its URI, regardless of the extension.
      *
-     * <p>This query never throws: a malformed URI or a template that exists nowhere for the configured language returns
-     * an empty result and logs an actionable warning.
+     * <p>This query never throws: a template that exists nowhere for the configured language returns an empty result
+     * and logs an actionable warning.
      *
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose} or
-     *     {@code Task-T/v1/energy-saving}
-     * @return the addressed template, or an empty result when the URI is malformed or the template does not exist for
-     *     the configured language
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1} or
+     *     {@code Task-T/network-layer/energy-saving/v1}
+     * @return the addressed template, or an empty result when the template does not exist for the configured language
      */
-    public Optional<PromptTemplate> getPrompt(String templateUri) {
+    public Optional<PromptTemplate> getPrompt(@NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return templateQueryService.getPrompt(templateUri);
     }
 
@@ -296,14 +314,14 @@ public final class A2ATServer {
     /**
      * Loads one negotiation template addressed by its URI.
      *
-     * <p>This query never throws: a malformed URI or a template that exists nowhere for the configured language returns
-     * an empty result and logs an actionable warning.
+     * <p>This query never throws: a template that exists nowhere for the configured language returns an empty result
+     * and logs an actionable warning.
      *
-     * @param templateUri template URI such as {@code Negotiation-T/v1/target-negotiation/propose}
-     * @return the addressed template, or an empty result when the URI is malformed or the template does not exist for
-     *     the configured language
+     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}
+     * @return the addressed template, or an empty result when the template does not exist for the configured language
      */
-    public Optional<PromptTemplate> getNegotiationPrompt(String templateUri) {
+    public Optional<PromptTemplate> getNegotiationPrompt(@NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.getNegotiationPrompt(templateUri);
     }
 
@@ -319,9 +337,8 @@ public final class A2ATServer {
      * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
      *     {@code propose}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or its phase
-     *     contradicts the method
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank or the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation_invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
@@ -330,25 +347,25 @@ public final class A2ATServer {
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
     public FilledParamData validateAndFillingProposeData(
-            String prompt, Map<String, Object> schema, String templateUri) {
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.validateAndFillingProposeData(prompt, schema, templateUri);
     }
 
     /**
      * Validates an accept-phase negotiation message and extracts its parameters.
      *
-     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, String)} with the expected phase
-     * fixed to accept: the template URI must declare the {@code accept-reject} segment and the message must satisfy the
-     * accept-phase semantic constraints.
+     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, TemplateUri)} with the expected
+     * phase fixed to accept: the template URI must declare the {@code accept-reject} segment and the message must
+     * satisfy the accept-phase semantic constraints.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
      *     {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or its phase
-     *     contradicts the method
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank or the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation_invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
@@ -356,25 +373,26 @@ public final class A2ATServer {
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
-    public FilledParamData validateAndFillingAcceptData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingAcceptData(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.validateAndFillingAcceptData(prompt, schema, templateUri);
     }
 
     /**
      * Validates a reject-phase negotiation message and extracts its parameters.
      *
-     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, String)} with the expected phase
-     * fixed to reject: the template URI must declare the {@code accept-reject} segment and the message must satisfy the
-     * reject-phase semantic constraints.
+     * <p>The pipeline is the one of {@link #validateAndFillingProposeData(String, Map, TemplateUri)} with the expected
+     * phase fixed to reject: the template URI must declare the {@code accept-reject} segment and the message must
+     * satisfy the reject-phase semantic constraints.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
      *     {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is malformed or its phase
-     *     contradicts the method
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank or the template URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation_invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
@@ -382,7 +400,9 @@ public final class A2ATServer {
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing
      */
-    public FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingRejectData(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return negotiationContentService.validateAndFillingRejectData(prompt, schema, templateUri);
     }
 
@@ -395,13 +415,15 @@ public final class A2ATServer {
      *     {@code Task-T}
      * @return filled parameter data carrying the merged parameters
      * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank or the template URI is blank or malformed
+     * @throws IllegalArgumentException if the prompt is blank
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
      *     {@code validation_semantic_rejected} when the semantic validation rejects the content,
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing
      */
-    public FilledParamData validateAndFillingTaskData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingTaskData(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return taskContentValidator.validate(prompt, schema, templateUri);
     }
 
@@ -414,14 +436,15 @@ public final class A2ATServer {
      *     {@code Notification-T}
      * @return filled parameter data carrying the merged parameters
      * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank or the template URI is blank or malformed
+     * @throws IllegalArgumentException if the prompt is blank
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
      *     {@code validation_semantic_rejected} when the semantic validation rejects the content,
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing
      */
     public FilledParamData validateAndFillingNotificationData(
-            String prompt, Map<String, Object> schema, String templateUri) {
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return notificationContentValidator.validate(prompt, schema, templateUri);
     }
 
@@ -434,13 +457,19 @@ public final class A2ATServer {
      *     {@code Authorization-T}
      * @return filled parameter data carrying the merged parameters
      * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank or the template URI is blank or malformed
+     * @throws IllegalArgumentException if the prompt is blank
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
      *     {@code validation_semantic_rejected} when the semantic validation rejects the content,
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing
      */
-    public FilledParamData validateAndFillingAuthData(String prompt, Map<String, Object> schema, String templateUri) {
+    public FilledParamData validateAndFillingAuthData(
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        requireTemplateUri(templateUri);
         return authContentValidator.validate(prompt, schema, templateUri);
+    }
+
+    private static void requireTemplateUri(TemplateUri templateUri) {
+        Objects.requireNonNull(templateUri, "Template URI must not be null.");
     }
 }

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/package-info.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/package-info.java
@@ -1,2 +1,5 @@
 /** Server-facing APIs for the a2a-t Java SDK. */
+@NullMarked
 package net.openan.a2at.sdk.server;
+
+import org.jspecify.annotations.NullMarked;

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/A2ATServerNegotiationApiTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/A2ATServerNegotiationApiTest.java
@@ -16,6 +16,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.server.A2ATServer;
 import org.junit.jupiter.api.Test;
 
@@ -23,8 +24,9 @@ class A2ATServerNegotiationApiTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI =
-            StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
+
+    private static final String INFORMATION_PROPOSE_URI = INFORMATION_PROPOSE.uri();
 
     @Test
     void generatesInformationProposeFromDataWithBuiltinChineseTemplates() throws IOException {
@@ -34,7 +36,7 @@ class A2ATServerNegotiationApiTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -54,7 +56,7 @@ class A2ATServerNegotiationApiTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("Region", "Songshan Lake")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -74,13 +76,18 @@ class A2ATServerNegotiationApiTest {
     void queriesSingleNegotiationTemplateWithoutThrowing() throws IOException {
         A2ATServer server = new A2ATServer(writeEnv("zh-CN"));
 
-        assertTrue(server.getNegotiationPrompt(INFORMATION_PROPOSE_URI).isPresent());
+        assertTrue(server.getNegotiationPrompt(INFORMATION_PROPOSE).isPresent());
         assertTrue(server
-                .getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri())
+                .getNegotiationPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
                 .isPresent());
-        assertFalse(server.getNegotiationPrompt("not-a-template-uri").isPresent());
-        PromptTemplate template =
-                server.getNegotiationPrompt(INFORMATION_PROPOSE_URI).orElseThrow();
+        assertFalse(server
+                .getNegotiationPrompt(TemplateUri.of(
+                        StandardTemplates.NEGOTIATION_EXTENSION_NAME,
+                        TemplateUri.DEFAULT_TEMPLATE_VERSION,
+                        "unknown-negotiation",
+                        "propose"))
+                .isPresent());
+        PromptTemplate template = server.getNegotiationPrompt(INFORMATION_PROPOSE).orElseThrow();
         assertEquals(INFORMATION_PROPOSE_URI, template.uri());
         assertFalse(template.content().isBlank());
     }

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/TaskPromptNegotiationCoexistenceTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/TaskPromptNegotiationCoexistenceTest.java
@@ -17,6 +17,7 @@ import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.negotiation.content.InfoProposeContent;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.validation.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException;
@@ -47,8 +48,9 @@ class TaskPromptNegotiationCoexistenceTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final String INFORMATION_PROPOSE_URI =
-            StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri();
+    private static final TemplateUri INFORMATION_PROPOSE_TEMPLATE = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
+
+    private static final String INFORMATION_PROPOSE_URI = INFORMATION_PROPOSE_TEMPLATE.uri();
 
     private static final String TASK_T_MESSAGE = "## 任务类型(Task Type)\n"
             + "无线能效优化\n\n"
@@ -75,7 +77,7 @@ class TaskPromptNegotiationCoexistenceTest {
                 () -> server.validateAndFillingProposeData(
                         TASK_T_MESSAGE,
                         Map.of("type", "object", "properties", Map.of("region", Map.of("type", "string"))),
-                        INFORMATION_PROPOSE_URI));
+                        INFORMATION_PROPOSE_TEMPLATE));
 
         assertEquals("negotiation_invalid_input", negotiationFailure.getCode());
         assertTrue(negotiationFailure.getMessage().contains("checkTaskPrompt"));
@@ -85,7 +87,7 @@ class TaskPromptNegotiationCoexistenceTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE_TEMPLATE);
         assertEquals(INFORMATION_PROPOSE_URI, negotiationMessage.templateUri());
         assertTrue(negotiationMessage.promptText().contains("- id: " + UUID));
     }
@@ -105,7 +107,7 @@ class TaskPromptNegotiationCoexistenceTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 2, 5),
                         new InfoProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE_URI);
+                INFORMATION_PROPOSE_TEMPLATE);
         assertTrue(negotiationMessage.promptText().contains("- round: 2"));
 
         Map<String, Object> startedAgain = server.startNegotiation(NegotiationType.TARGET, "请澄清目标。", Map.of());

--- a/docs/en/developer_guide.md
+++ b/docs/en/developer_guide.md
@@ -421,12 +421,14 @@ The content layer is stateless. It deliberately does not own a session state mac
 
 All thirteen methods exist on both `A2ATClient` and `A2ATServer` with identical signatures and semantics.
 
+Every method that identifies a template takes the value type `net.openan.a2at.sdk.core.validation.TemplateUri` instead of a raw string. A `TemplateUri` is always well-formed — its constructor validates the extension name, path segments, and version — so malformed URIs cannot reach these APIs. Build one with `TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "propose")`, or better, use the constants in `StandardTemplates` from the same package (for example `StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE`, whose `uri()` is `Negotiation-T/information-negotiation/propose/v1`). When a URI string arrives from outside the code, `TemplateUri.parse(String)` returns an `Optional<TemplateUri>` and never throws.
+
 **Generation from typed data — deterministic, never calls an LLM:**
 
 ```java
-MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, String templateUri)
-MetadataContent generateNegotiationAcceptPromptFromData(NegotiationEndingData data, String templateUri)
-MetadataContent generateNegotiationRejectPromptFromData(NegotiationEndingData data, String templateUri)
+MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, TemplateUri templateUri)
+MetadataContent generateNegotiationAcceptPromptFromData(NegotiationEndingData data, TemplateUri templateUri)
+MetadataContent generateNegotiationRejectPromptFromData(NegotiationEndingData data, TemplateUri templateUri)
 ```
 
 The typed content is validated, dispatched to the generator of the negotiation type addressed by the template URI, and rendered from that template. The accept variant requires `content.conclusion() == ACCEPT`, the reject variant `REJECT`; a mismatched conclusion (including `ABORT`) is rejected with `IllegalArgumentException` as a programming error.
@@ -434,9 +436,9 @@ The typed content is validated, dispatched to the generator of the negotiation t
 **Generation from free text — one LLM extraction step with configurable retry:**
 
 ```java
-MetadataContent generateNegotiationProposePromptFromText(String text, NegotiationContext context, String templateUri)
-MetadataContent generateNegotiationAcceptPromptFromText(String text, NegotiationContext context, String templateUri)
-MetadataContent generateNegotiationRejectPromptFromText(String text, NegotiationContext context, String templateUri)
+MetadataContent generateNegotiationProposePromptFromText(String text, NegotiationContext context, TemplateUri templateUri)
+MetadataContent generateNegotiationAcceptPromptFromText(String text, NegotiationContext context, TemplateUri templateUri)
+MetadataContent generateNegotiationRejectPromptFromText(String text, NegotiationContext context, TemplateUri templateUri)
 ```
 
 The template is loaded before the LLM call; a missing template fails fast without consuming an LLM request. The LLM step extracts the typed content from the free text constrained by the template URI, then rendering proceeds deterministically like the from-data variant. The `NegotiationContext` is injected into the rendered message without any LLM involvement. The extraction step is retried up to the configured attempt limit on the retryable failure codes (see 1.10.5).
@@ -444,9 +446,9 @@ The template is loaded before the LLM call; a missing template fails fast withou
 **Compliance checking and parameter extraction:**
 
 ```java
-FilledParamData validateAndFillingProposeData(String prompt, Map<String, Object> schema, String templateUri)
-FilledParamData validateAndFillingAcceptData(String prompt, Map<String, Object> schema, String templateUri)
-FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> schema, String templateUri)
+FilledParamData validateAndFillingProposeData(String prompt, Map<String, Object> schema, TemplateUri templateUri)
+FilledParamData validateAndFillingAcceptData(String prompt, Map<String, Object> schema, TemplateUri templateUri)
+FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> schema, TemplateUri templateUri)
 ```
 
 The pipeline runs in a fixed order:
@@ -460,13 +462,13 @@ The pipeline runs in a fixed order:
 
 ```java
 List<PromptTemplate> getPrompts()   // templates of ALL extensions for the configured language, sorted by URI
-Optional<PromptTemplate> getPrompt(String templateUri)  // one template by URI across all extensions; empty on miss
+Optional<PromptTemplate> getPrompt(TemplateUri templateUri)  // one template by URI across all extensions; empty on miss
 
 List<PromptTemplate> getNegotiationPrompts()   // negotiation templates of the configured language, fixed order
-Optional<PromptTemplate> getNegotiationPrompt(String templateUri)  // one negotiation template by URI; empty on miss
+Optional<PromptTemplate> getNegotiationPrompt(TemplateUri templateUri)  // one negotiation template by URI; empty on miss
 ```
 
-A missing template or an unusable URI yields an empty result with a warning log. `PromptTemplate` is a record `(uri, description, content)`. The generic pair discovers the extension directories from the bundled resource tree itself — a template directory added under `prompt_resources/templates/` (for example a future `Authorization-T/`) is listed automatically without code changes. Local templates under the configured local resource root override built-in templates of the same path. Note that the SDK does not yet bundle Authorization-T template resources; `generateAuthPromptFromText` / `generateAuthPromptFromDataWithSchema` answer `template_not_found` under the classpath source until such templates are added or provided through the local resource root.
+A missing template yields an empty result with a warning log; because the argument is a validated `TemplateUri`, an unusable URI cannot occur, and a null argument raises `NullPointerException`. `PromptTemplate` is a record `(uri, description, content)`. The generic pair discovers the extension directories from the bundled resource tree itself — a template directory added under `prompt_resources/templates/` (for example a future `Authorization-T/`) is listed automatically without code changes. Local templates under the configured local resource root override built-in templates of the same path. Note that the SDK does not yet bundle Authorization-T template resources; `generateAuthPromptFromText` / `generateAuthPromptFromDataWithSchema` answer `template_not_found` under the classpath source until such templates are added or provided through the local resource root.
 
 ### 1.10.3 Template URIs and Custom Templates
 
@@ -476,7 +478,7 @@ The template URI format is:
 Negotiation-T/{type}-negotiation/{phase}/v1
 ```
 
-where `{type}` is `information`, `target`, or `feasibility`, `{phase}` is `propose` or `accept-reject`, and the trailing `v1` is the template version (the default version). URI parsing never throws: `NegotiationReference.tryParse` returns an `Optional<NegotiationReference>`, and a null, blank or malformed URI (wrong segment count, prefix, version, type or phase segment) simply yields an empty result. Six built-in templates ship with the SDK, one per combination, each in `zh-CN` and `en-US`:
+where `{type}` is `information`, `target`, or `feasibility`, `{phase}` is `propose` or `accept-reject`, and the trailing `v1` is the template version (the default version). The facade APIs take this as the typed `TemplateUri` value; one built-in constant exists per template in `StandardTemplates`. String-level parsing never throws: `TemplateUri.parse(String)` returns an `Optional<TemplateUri>`, and `NegotiationReference.tryParse` returns an `Optional<NegotiationReference>` — a null, blank or malformed URI (wrong segment count, prefix, version, type or phase segment) simply yields an empty result. Six built-in templates ship with the SDK, one per combination, each in `zh-CN` and `en-US`:
 
 | Template URI | Purpose |
 |--|--|
@@ -531,7 +533,7 @@ All SDK processing failures share one root, while programming errors stay outsid
   - `PromptComplianceCheckException` — a compliance-check failure carrying the code and the compliance stage (`getStage()`); raised by the server-side compliance pipeline with the codes `processed_prompt_parse_error`, `slot_validation_error` and `template_not_found`.
   - The remaining processing failures — prompt generation (`PromptGenerationException`), content validation (`ContentValidationException`), template rendering (`TaskPromptRenderException`), resource resolution (`ResourceNotFoundException`, `ConfigFileNotFoundException`), scenario recognition (`ScenarioRecognitionException`) and negotiation state access (`NegotiationStateException`) — are part of the same tree.
 
-Programming errors — argument-contract violations by the caller — intentionally stay **outside** the `A2ATError` tree, as standard JDK exceptions, so a generic `catch (A2ATError)` handler cannot swallow them: a null argument raises `NullPointerException`, and a blank, malformed or semantically contradictory argument (blank context id, malformed template URI, phase or conclusion mismatch, unsupported language) raises `IllegalArgumentException`. The former `NegotiationContentException` has been removed; the violations it used to report now surface as these standard exceptions, and each facade method documents them with `@throws` tags.
+Programming errors — argument-contract violations by the caller — intentionally stay **outside** the `A2ATError` tree, as standard JDK exceptions, so a generic `catch (A2ATError)` handler cannot swallow them: a null argument raises `NullPointerException`, and a blank or semantically contradictory argument (blank context id, invalid segments passed to the `TemplateUri` constructor, phase or conclusion mismatch, unsupported language) raises `IllegalArgumentException`. The former `NegotiationContentException` has been removed; the violations it used to report now surface as these standard exceptions, and each facade method documents them with `@throws` tags.
 
 Error codes and their meaning:
 
@@ -566,6 +568,7 @@ import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.exception.A2ATParamExtractionError;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.*;
 import net.openan.a2at.sdk.server.A2ATServer;
 
@@ -581,7 +584,7 @@ InfoProposeContent content = new InfoProposeContent(
 
 MetadataContent propose = client.generateNegotiationProposePromptFromData(
         new NegotiationProposeData(context, content),
-        "Negotiation-T/information-negotiation/propose/v1");
+        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
 
 // This two-key map travels in the A2A message metadata.
 Map<String, String> metadata = propose.buildMetadataContent();
@@ -600,7 +603,7 @@ Map<String, Object> schema = Map.of(
 
 try {
     FilledParamData params = server.validateAndFillingProposeData(
-            propose.promptText(), schema, "Negotiation-T/information-negotiation/propose/v1");
+            propose.promptText(), schema, StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
     // params.data() holds the extracted parameters plus the context parameters.
 } catch (A2ATParamExtractionError failure) {
     // Branch on failure.getCode(): negotiation_invalid_input, negotiation_rule_violation,
@@ -614,11 +617,11 @@ InfoEndingContent ending = new InfoEndingContent(
 
 MetadataContent accept = server.generateNegotiationAcceptPromptFromData(
         new NegotiationEndingData(context, ending),
-        "Negotiation-T/information-negotiation/accept-reject/v1");
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
 
-// The client validates the accept message the same way, with the accept-reject URI:
+// The client validates the accept message the same way, with the accept-reject template:
 // client.validateAndFillingAcceptData(accept.promptText(), schema,
-//         "Negotiation-T/information-negotiation/accept-reject/v1");
+//         StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
 ```
 
 When modifying the negotiation content layer, run:

--- a/docs/zh/开发指南.md
+++ b/docs/zh/开发指南.md
@@ -404,12 +404,14 @@ mvn -pl a2a-t-sample -am -DskipTests package
 
 以下十三个方法在 `A2ATClient` 和 `A2ATServer` 上具有完全相同的签名和语义。
 
+所有用于标识模板的参数均采用值类型 `net.openan.a2at.sdk.core.validation.TemplateUri`，而非裸字符串。`TemplateUri` 恒为格式正确 — 其构造器会校验扩展名、路径段与版本 — 因此格式错误的 URI 不可能进入这些 API。可用 `TemplateUri.of("Negotiation-T", "v1", "information-negotiation", "propose")` 构造，更推荐直接使用同包 `StandardTemplates` 中的常量（例如 `StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE`，其 `uri()` 为 `Negotiation-T/information-negotiation/propose/v1`）。当 URI 字符串来自代码之外时，`TemplateUri.parse(String)` 返回 `Optional<TemplateUri>` 且绝不抛出异常。
+
 **从类型化数据生成 — 确定性执行，绝不调用 LLM：**
 
 ```java
-MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, String templateUri)
-MetadataContent generateNegotiationAcceptPromptFromData(NegotiationEndingData data, String templateUri)
-MetadataContent generateNegotiationRejectPromptFromData(NegotiationEndingData data, String templateUri)
+MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, TemplateUri templateUri)
+MetadataContent generateNegotiationAcceptPromptFromData(NegotiationEndingData data, TemplateUri templateUri)
+MetadataContent generateNegotiationRejectPromptFromData(NegotiationEndingData data, TemplateUri templateUri)
 ```
 
 类型化内容先经过校验，再分发给模板 URI 所指协商类型的生成器，并由该模板渲染。accept 变体要求 `content.conclusion() == ACCEPT`，reject 变体要求 `REJECT`；结论不匹配（包括 `ABORT`）会以 `IllegalArgumentException`（编程错误）拒绝。
@@ -417,9 +419,9 @@ MetadataContent generateNegotiationRejectPromptFromData(NegotiationEndingData da
 **从自由文本生成 — 一次 LLM 抽取，支持可配置重试：**
 
 ```java
-MetadataContent generateNegotiationProposePromptFromText(String text, NegotiationContext context, String templateUri)
-MetadataContent generateNegotiationAcceptPromptFromText(String text, NegotiationContext context, String templateUri)
-MetadataContent generateNegotiationRejectPromptFromText(String text, NegotiationContext context, String templateUri)
+MetadataContent generateNegotiationProposePromptFromText(String text, NegotiationContext context, TemplateUri templateUri)
+MetadataContent generateNegotiationAcceptPromptFromText(String text, NegotiationContext context, TemplateUri templateUri)
+MetadataContent generateNegotiationRejectPromptFromText(String text, NegotiationContext context, TemplateUri templateUri)
 ```
 
 模板在调用 LLM 之前先行加载；模板缺失会快速失败，不会消耗 LLM 请求。LLM 步骤在模板 URI 的约束下从自由文本中抽取类型化内容，随后的渲染与 from-data 变体一样是确定性的。`NegotiationContext` 不经任何 LLM 直接注入渲染结果。抽取步骤在可重试错误码（见 1.10.5）上最多重试到配置的尝试上限。
@@ -427,9 +429,9 @@ MetadataContent generateNegotiationRejectPromptFromText(String text, Negotiation
 **合规校验与参数提取：**
 
 ```java
-FilledParamData validateAndFillingProposeData(String prompt, Map<String, Object> schema, String templateUri)
-FilledParamData validateAndFillingAcceptData(String prompt, Map<String, Object> schema, String templateUri)
-FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> schema, String templateUri)
+FilledParamData validateAndFillingProposeData(String prompt, Map<String, Object> schema, TemplateUri templateUri)
+FilledParamData validateAndFillingAcceptData(String prompt, Map<String, Object> schema, TemplateUri templateUri)
+FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> schema, TemplateUri templateUri)
 ```
 
 流水线按固定顺序执行：
@@ -443,13 +445,13 @@ FilledParamData validateAndFillingRejectData(String prompt, Map<String, Object> 
 
 ```java
 List<PromptTemplate> getPrompts()   // 全部扩展在当前配置语言下的模板，按 URI 排序
-Optional<PromptTemplate> getPrompt(String templateUri)  // 跨扩展按 URI 加载单个模板；未命中返回空
+Optional<PromptTemplate> getPrompt(TemplateUri templateUri)  // 跨扩展按 URI 加载单个模板；未命中返回空
 
 List<PromptTemplate> getNegotiationPrompts()   // 当前配置语言下的全部协商模板，固定顺序
-Optional<PromptTemplate> getNegotiationPrompt(String templateUri)  // 按 URI 加载单个协商模板；未命中返回空
+Optional<PromptTemplate> getNegotiationPrompt(TemplateUri templateUri)  // 按 URI 加载单个协商模板；未命中返回空
 ```
 
-模板缺失或 URI 不可用时返回空结果并记录 warning 日志。`PromptTemplate` 是一个记录类型 `(uri, description, content)`。泛化查询对直接从内置资源树中发现扩展目录 — 在 `prompt_resources/templates/` 下新增的模板目录（例如未来的 `Authorization-T/`）会被自动列出，无需代码改动。配置的本地资源根目录下的模板会覆盖同路径的内置模板。注意：SDK 尚未打包 Authorization-T 模板资源，`generateAuthPromptFromText` / `generateAuthPromptFromDataWithSchema` 在 classpath 源下会返回 `template_not_found`，直至补充该类模板或通过本地资源根目录提供。
+模板缺失时返回空结果并记录 warning 日志；由于入参是已通过校验的 `TemplateUri`，不存在 URI 不可用的情形，null 入参则抛出 `NullPointerException`。`PromptTemplate` 是一个记录类型 `(uri, description, content)`。泛化查询对直接从内置资源树中发现扩展目录 — 在 `prompt_resources/templates/` 下新增的模板目录（例如未来的 `Authorization-T/`）会被自动列出，无需代码改动。配置的本地资源根目录下的模板会覆盖同路径的内置模板。注意：SDK 尚未打包 Authorization-T 模板资源，`generateAuthPromptFromText` / `generateAuthPromptFromDataWithSchema` 在 classpath 源下会返回 `template_not_found`，直至补充该类模板或通过本地资源根目录提供。
 
 ### 1.10.3 模板 URI 与自定义模板
 
@@ -459,7 +461,7 @@ Optional<PromptTemplate> getNegotiationPrompt(String templateUri)  // 按 URI �
 Negotiation-T/{type}-negotiation/{phase}/v1
 ```
 
-其中 `{type}` 为 `information`、`target` 或 `feasibility`，`{phase}` 为 `propose` 或 `accept-reject`，末尾的 `v1` 是模板版本（默认版本）。URI 解析绝不抛出异常：`NegotiationReference.tryParse` 返回 `Optional<NegotiationReference>`，null、空白或格式错误的 URI（段数、前缀、版本、类型或 phase 段不匹配）只返回空结果。SDK 内置六个模板，每种组合一个，各自提供 `zh-CN` 与 `en-US` 两个语言版本：
+其中 `{type}` 为 `information`、`target` 或 `feasibility`，`{phase}` 为 `propose` 或 `accept-reject`，末尾的 `v1` 是模板版本（默认版本）。门面 API 以类型化的 `TemplateUri` 接收该值；`StandardTemplates` 为每个内置模板提供一个常量。字符串层面的解析绝不抛出异常：`TemplateUri.parse(String)` 返回 `Optional<TemplateUri>`，`NegotiationReference.tryParse` 返回 `Optional<NegotiationReference>` — null、空白或格式错误的 URI（段数、前缀、版本、类型或 phase 段不匹配）只返回空结果。SDK 内置六个模板，每种组合一个，各自提供 `zh-CN` 与 `en-US` 两个语言版本：
 
 | 模板 URI | 用途 |
 |--|--|
@@ -514,7 +516,7 @@ Negotiation-T/{type}-negotiation/{phase}/v1
   - `PromptComplianceCheckException` — 携带错误码与合规阶段（`getStage()`）的合规校验失败；由服务端合规流水线抛出，错误码为 `processed_prompt_parse_error`、`slot_validation_error` 与 `template_not_found`。
   - 其余处理失败 — 提示词生成（`PromptGenerationException`）、内容校验（`ContentValidationException`）、模板渲染（`TaskPromptRenderException`）、资源解析（`ResourceNotFoundException`、`ConfigFileNotFoundException`）、场景识别（`ScenarioRecognitionException`）与协商状态访问（`NegotiationStateException`）— 同属这棵树。
 
-编程错误 — 调用方的入参契约违反 — 刻意留在 `A2ATError` 树外，以标准 JDK 异常抛出，使通用的 `catch (A2ATError)` 处理器无法吞掉它们：null 入参抛出 `NullPointerException`；空白、格式错误或语义矛盾的入参（上下文 id 为空、模板 URI 格式错误、phase 或结论不匹配、不支持的语言）抛出 `IllegalArgumentException`。原先的 `NegotiationContentException` 已移除；它过去报告的违约现在以这些标准异常形式抛出，各门面方法均以 `@throws` 标签逐一注明。
+编程错误 — 调用方的入参契约违反 — 刻意留在 `A2ATError` 树外，以标准 JDK 异常抛出，使通用的 `catch (A2ATError)` 处理器无法吞掉它们：null 入参抛出 `NullPointerException`；空白或语义矛盾的入参（上下文 id 为空、传入 `TemplateUri` 构造器的段无效、phase 或结论不匹配、不支持的语言）抛出 `IllegalArgumentException`。原先的 `NegotiationContentException` 已移除；它过去报告的违约现在以这些标准异常形式抛出，各门面方法均以 `@throws` 标签逐一注明。
 
 错误码及其含义：
 
@@ -549,6 +551,7 @@ import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.exception.A2ATParamExtractionError;
+import net.openan.a2at.sdk.core.validation.StandardTemplates;
 import net.openan.a2at.sdk.negotiation.content.*;
 import net.openan.a2at.sdk.server.A2ATServer;
 
@@ -564,7 +567,7 @@ InfoProposeContent content = new InfoProposeContent(
 
 MetadataContent propose = client.generateNegotiationProposePromptFromData(
         new NegotiationProposeData(context, content),
-        "Negotiation-T/information-negotiation/propose/v1");
+        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
 
 // 这个两键映射随 A2A 消息 metadata 传输。
 Map<String, String> metadata = propose.buildMetadataContent();
@@ -583,7 +586,7 @@ Map<String, Object> schema = Map.of(
 
 try {
     FilledParamData params = server.validateAndFillingProposeData(
-            propose.promptText(), schema, "Negotiation-T/information-negotiation/propose/v1");
+            propose.promptText(), schema, StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
     // params.data() 持有提取的参数以及上下文参数。
 } catch (A2ATParamExtractionError failure) {
     // 按 failure.getCode() 分支处理：negotiation_invalid_input、negotiation_rule_violation、
@@ -597,11 +600,11 @@ InfoEndingContent ending = new InfoEndingContent(
 
 MetadataContent accept = server.generateNegotiationAcceptPromptFromData(
         new NegotiationEndingData(context, ending),
-        "Negotiation-T/information-negotiation/accept-reject/v1");
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
 
-// 客户端以相同方式、使用 accept-reject URI 校验该接受消息：
+// 客户端以相同方式、使用 accept-reject 模板校验该接受消息：
 // client.validateAndFillingAcceptData(accept.promptText(), schema,
-//         "Negotiation-T/information-negotiation/accept-reject/v1");
+//         StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
 ```
 
 修改协商内容层时，运行：


### PR DESCRIPTION
## Description

Branch: `refactor/standard-template-uri` — commit `0a9adb4` (`refactor(api): replace String templateUri with TemplateUri type on facade chain and add JSpecify nullness annotations`)

Follow-up to the already-merged `TemplateUri`/`StandardTemplates` groundwork and the URI layout reshape. This PR converts the public facade API surface from stringly-typed template URIs to the semantic value type and introduces JSpecify null-safety metadata.

### 1. `String templateUri` → `TemplateUri` on the facade chain

Every public method on `A2ATClient` / `A2ATServer` (and the internal chain it delegates to) now takes `net.openan.a2at.sdk.core.validation.TemplateUri` instead of a `String`:

- **Prompt generation**: `generateTaskPromptFromText`, `generateTaskPromptFromDataWithSchema`, `generateNotificationPromptFrom*`, `generateAuthPromptFrom*` (the `authorizationType` parameter is renamed to `templateUri` — it was always the template identifier).
- **Negotiation generation**: `generateNegotiation{Propose,Accept,Reject}PromptFrom{Data,Text}`.
- **Negotiation / content validation**: `validateAndFillingProposeData`, `validateAndFillingAcceptData`, `validateAndFillingRejectData`, `validateAndFillingTaskData`, `validateAndFillingNotificationData`, `validateAndFillingAuthData`.
- **Template queries**: `getPrompt(TemplateUri)`, `getNegotiationPrompt(TemplateUri)`.

Internal conversion points:

- `ContentValidator.validate(prompt, schema, TemplateUri)` (a2a-t-core interface); `DefaultContentValidator` drops its hand-rolled string parsing — the type guarantees what the blank/format/segment checks used to enforce; only the per-extension prefix expectation and supported-version check remain.
- `TemplateQueryService.getPrompt(TemplateUri)` / `PromptTemplateCatalog.load(TemplateUri)`: the "malformed URI → empty result" branch disappears (malformed URIs are now unrepresentable); the never-throws contract for missing templates is unchanged.
- `NegotiationReference.fromTemplateUri(TemplateUri, NegotiationPhase, String)`: new structural factory (extension name, exactly two path segments, valid type segment, phase match, default version). `NegotiationReference.tryParse(String, ...)` stays for flows that read a URI string out of prompt text (server compliance chain).
- `DefaultClientPromptGenerationOrchestrator`: the `TEMPLATE_IDENTIFIER_PATTERN` gate and `requireValidTemplateIdentifier` are deleted — `TemplateUri`'s constructor is the validation. The String-identifier loader APIs remain untouched because they also serve the bare-scenario-code recognition flow.
- `MetadataContent.templateUri` stays `String` by design: it is output metadata rendered into transport maps, not an address.

Javadoc: all stale URI examples were corrected to the current layout (`Negotiation-T/information-negotiation/propose/v1`, `Task-T/network-layer/energy-saving/v1`), and "URI is blank or malformed" `@throws IllegalArgumentException` clauses were removed where the parameter type now makes them impossible (NullPointerException clauses kept).

### 2. JSpecify nullness annotations

`org.jspecify:jspecify` was already a global provided dependency with NullAway configured in JSpecify mode (`OnlyNullMarked`); this PR lands the actual annotations:

- `@NullMarked` package-info added for the two facade packages `net.openan.a2at.sdk.client` and `net.openan.a2at.sdk.server` — the entry points, and the only packages statically checked by NullAway.
- `@NonNull` on public parameters/returns guarded by `Objects.requireNonNull` across the core value types (`TemplateUri`, `StandardTemplates`, `ValidationPipeline`, `SemanticValidator`, `PathSegments`, model and exception types) and the public services (`NegotiationContentService`, `NegotiationReference`, `TemplateQueryService`, `PromptTemplateCatalog`).
- `@Nullable` only where null genuinely flows, e.g. `TemplateUri.parse(@Nullable String)`, `NegotiationReference.tryParse(@Nullable String, ...)`, and the optional `schema` map on schema-guided extraction APIs.
- Optional-returning methods are left unannotated.

### 3. Tests, sample, docs

- Tests across all modules migrated to `StandardTemplates` constants / `TemplateUri.of(...)`; facade-level malformed-string-URI assertions rewritten to typed non-addressing URIs (wrong extension/version/type/phase) since constructor-level validation tests already exist in a2a-t-core.
- Sample code (`ClientSampleMain` / `ServerSampleMain` and sample API tests) passes `StandardTemplates` constants directly.
- Developer guide updated in both languages (snippets pass `StandardTemplates.<CONSTANT>`, prose describes the `TemplateUri` parameter).

### Verification

- `mvn -B clean test` — green across all 10 modules (incl. NullAway at ERROR level in the two `@NullMarked` packages).
- `python tools/template_lint.py --resource-root a2a-t-resources/src/main/resources/prompt_resources` — passed.
- Grep confirms no `String templateUri` remains on `A2ATClient`, `A2ATServer`, `NegotiationContentService`, or `ContentValidator`.

### Breaking change note

Intentional API break on the pre-1.0 facade: callers pass `StandardTemplates.ENERGY_SAVING` (or any `TemplateUri`) instead of a `"Task-T/network-layer/energy-saving/v1"` string. Language binding is unchanged: still resolved from global runtime config, never part of the URI.

## Related Issue(s)

None
<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here. -->