### PR TITLE
docs(core,negotiation): fix @since month to 2026-08 for newly added classes

### DIFF
--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATError.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATError.java
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
  * {@code null}. Caller contract violations (null, blank or otherwise malformed arguments) are programming errors raised
  * as {@link NullPointerException} or {@link IllegalArgumentException} and intentionally stay outside this tree.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public class A2ATError extends RuntimeException {
 

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATErrorCodes.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATErrorCodes.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 /**
  * Centralized machine-readable error code constants shared across A2A-T SDK processing failures.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class A2ATErrorCodes {

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATParamExtractionError.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATParamExtractionError.java
@@ -11,7 +11,7 @@ import org.jspecify.annotations.NonNull;
  * machine-readable error code is carried by the root {@link A2ATError} and is never null; subclasses pass a more
  * specific code when one is available.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public class A2ATParamExtractionError extends A2ATError {
 

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/SlotValidationError.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/SlotValidationError.java
@@ -9,6 +9,6 @@ package net.openan.a2at.sdk.core.model;
  * @param slotName name of the slot the error refers to
  * @param code machine-readable error code for the error
  * @param message human-readable explanation of the error
- * @since 2026-06
+ * @since 2026-08
  */
 public record SlotValidationError(String slotName, String code, String message) {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/FeasibilityEndingContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/FeasibilityEndingContent.java
@@ -5,7 +5,7 @@ package net.openan.a2at.sdk.negotiation.content;
  *
  * @param conclusion terminal conclusion of the feasibility negotiation
  * @param feasibilitySummary required summary of the feasibility evaluation result
- * @since 2026-06
+ * @since 2026-08
  */
 public record FeasibilityEndingContent(NegotiationConclusion conclusion, String feasibilitySummary)
         implements NegotiationEndingContent {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/FeasibilityProposeContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/FeasibilityProposeContent.java
@@ -11,7 +11,7 @@ import java.util.List;
  *     {@link NegotiationAction#REQUEST_FEASIBILITY_EVALUATION})
  * @param infeasibilityDetailsAndProposal infeasibility details and an alternative proposal; null or empty omits the
  *     section (only for {@link NegotiationAction#PROPOSE_ALTERNATIVE_ON_FAILURE})
- * @since 2026-06
+ * @since 2026-08
  */
 public record FeasibilityProposeContent(
         String feasibilityNegotiationDescription,

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/InformationEndingContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/InformationEndingContent.java
@@ -7,7 +7,7 @@ import java.util.List;
  *
  * @param conclusion terminal conclusion of the information negotiation
  * @param items information items delivered with the terminal message
- * @since 2026-06
+ * @since 2026-08
  */
 public record InformationEndingContent(NegotiationConclusion conclusion, List<NegotiationItem> items)
         implements NegotiationEndingContent {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/InformationProposeContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/InformationProposeContent.java
@@ -7,7 +7,7 @@ import java.util.List;
  *
  * @param items information items the requester is missing
  * @param relationship free-form description of how the missing items relate to each other; null when there is none
- * @since 2026-06
+ * @since 2026-08
  */
 public record InformationProposeContent(List<NegotiationItem> items, String relationship)
         implements NegotiationProposeContent {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationAction.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationAction.java
@@ -6,7 +6,7 @@ package net.openan.a2at.sdk.negotiation.content;
  * <p>The action is not rendered into the message; it selects which conditional sections of the feasibility propose
  * template are emitted.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public enum NegotiationAction {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationConclusion.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationConclusion.java
@@ -6,7 +6,7 @@ package net.openan.a2at.sdk.negotiation.content;
  * <p>Only {@code ACCEPT} and {@code REJECT} are renderable conclusions; {@code ABORT} exists in the model but no
  * bundled template carries it, so generation methods reject it as a programming error.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public enum NegotiationConclusion {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationContent.java
@@ -7,6 +7,6 @@ package net.openan.a2at.sdk.negotiation.content;
  * {@link NegotiationEndingContent} for terminal messages. Generators and content extractors accept this common
  * supertype and dispatch on the exact runtime type.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public sealed interface NegotiationContent permits NegotiationProposeContent, NegotiationEndingContent {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationContext.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationContext.java
@@ -9,7 +9,7 @@ package net.openan.a2at.sdk.negotiation.content;
  * @param id unique identifier of the negotiation session, expected to be a UUID
  * @param round current negotiation round, 1-based
  * @param maxRounds maximum number of rounds before the negotiation must end
- * @since 2026-06
+ * @since 2026-08
  */
 public record NegotiationContext(String id, int round, int maxRounds) {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationEndingContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationEndingContent.java
@@ -3,7 +3,7 @@ package net.openan.a2at.sdk.negotiation.content;
 /**
  * Marker for the typed content of a terminal (accept or reject) negotiation message.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public sealed interface NegotiationEndingContent extends NegotiationContent
         permits InformationEndingContent, TargetEndingContent, FeasibilityEndingContent {

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationEndingData.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationEndingData.java
@@ -10,6 +10,6 @@ package net.openan.a2at.sdk.negotiation.content;
  *
  * @param context negotiation session context
  * @param content typed terminal content matching the negotiation type addressed by the template URI
- * @since 2026-06
+ * @since 2026-08
  */
 public record NegotiationEndingData(NegotiationContext context, NegotiationEndingContent content) {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationGenerationException.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationGenerationException.java
@@ -3,7 +3,7 @@ package net.openan.a2at.sdk.negotiation.content;
 /**
  * Raised when generating a negotiation message fails at runtime.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public class NegotiationGenerationException extends NegotiationProcessingException {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationItem.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationItem.java
@@ -5,6 +5,6 @@ package net.openan.a2at.sdk.negotiation.content;
  *
  * @param name item name such as a field path or identifier; never blank in valid content
  * @param value free-form explanation of the item such as meaning, format, example or reason; may be null
- * @since 2026-06
+ * @since 2026-08
  */
 public record NegotiationItem(String name, String value) {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationParamExtractionException.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationParamExtractionException.java
@@ -7,7 +7,7 @@ import net.openan.a2at.sdk.core.model.SlotValidationError;
 /**
  * Raised when validating a negotiation message and extracting parameters from it fails.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public class NegotiationParamExtractionException extends A2ATParamExtractionError {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationPhase.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationPhase.java
@@ -7,7 +7,7 @@ package net.openan.a2at.sdk.negotiation.content;
  * and {@code reject} share the {@code accept-reject} template, differing only in the conclusion value filled into the
  * template slot.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public enum NegotiationPhase {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationProcessingException.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationProcessingException.java
@@ -10,7 +10,7 @@ import net.openan.a2at.sdk.core.exception.A2ATError;
  * parameter-extraction branch ({@code NegotiationParamExtractionException}) is deliberately not a subtype; catch
  * {@link A2ATError} for full negotiation failure coverage.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public class NegotiationProcessingException extends A2ATError {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationProposeContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationProposeContent.java
@@ -3,7 +3,7 @@ package net.openan.a2at.sdk.negotiation.content;
 /**
  * Marker for the typed content of a propose-phase negotiation message.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public sealed interface NegotiationProposeContent extends NegotiationContent
         permits InformationProposeContent, TargetProposeContent, FeasibilityProposeContent {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationProposeData.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationProposeData.java
@@ -5,6 +5,6 @@ package net.openan.a2at.sdk.negotiation.content;
  *
  * @param context negotiation session context
  * @param content typed propose content matching the negotiation type addressed by the template URI
- * @since 2026-06
+ * @since 2026-08
  */
 public record NegotiationProposeData(NegotiationContext context, NegotiationProposeContent content) {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationType.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationType.java
@@ -6,7 +6,7 @@ package net.openan.a2at.sdk.negotiation.content;
  * <p>The enum also owns the hyphenated URI segment used both in template URIs and in template resource paths, so that
  * URIs and on-disk locations can never drift apart.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public enum NegotiationType {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/TargetEndingContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/TargetEndingContent.java
@@ -9,7 +9,7 @@ package net.openan.a2at.sdk.negotiation.content;
  * @param conclusion terminal conclusion of the target negotiation
  * @param confirmedIntent confirmed intent for an accept conclusion; null otherwise
  * @param failureReason reason for a reject conclusion; null otherwise
- * @since 2026-06
+ * @since 2026-08
  */
 public record TargetEndingContent(NegotiationConclusion conclusion, String confirmedIntent, String failureReason)
         implements NegotiationEndingContent {}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/TargetProposeContent.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/TargetProposeContent.java
@@ -11,7 +11,7 @@ import java.util.List;
  * @param alignmentAndClarification alignment statements and clarifications; null or empty omits the section (later
  *     rounds only)
  * @param requestForClarification open clarification requests; null or empty omits the section
- * @since 2026-06
+ * @since 2026-08
  */
 public record TargetProposeContent(
         String targetNegotiationDescription,

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/Vocabulary.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/Vocabulary.java
@@ -39,7 +39,7 @@ import org.jspecify.annotations.Nullable;
  * context classloader (jar bytes are immutable), while a local resource root is re-resolved on every call so that
  * overriding, editing or removing a local vocabulary file takes effect immediately.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public final class Vocabulary {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/DefaultNegotiationContentExtractor.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/DefaultNegotiationContentExtractor.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * non-retryable {@code negotiation_slot_missing}, and content that contradicts the addressed phase or action maps to
  * {@code negotiation_invalid_input}.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class DefaultNegotiationContentExtractor implements NegotiationContentExtractor {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/FeasibilityEndingGenerator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/FeasibilityEndingGenerator.java
@@ -14,7 +14,7 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
  * <p>The message carries the terminal conclusion literal and the required feasibility summary. The summary slot name
  * differs from its section title, so the vocabulary exception key is used.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class FeasibilityEndingGenerator extends AbstractNegotiationGenerator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/FeasibilityProposeGenerator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/FeasibilityProposeGenerator.java
@@ -17,7 +17,7 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
  * to evaluate, while proposing an alternative after an infeasible outcome renders the infeasibility details and
  * proposal. Exactly one of the two sections is always present.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class FeasibilityProposeGenerator extends AbstractNegotiationGenerator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/InformationEndingGenerator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/InformationEndingGenerator.java
@@ -13,7 +13,7 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
  *
  * <p>The message carries the terminal conclusion literal and the information items delivered with it.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class InformationEndingGenerator extends AbstractNegotiationGenerator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/InformationProposeGenerator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/InformationProposeGenerator.java
@@ -14,7 +14,7 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
  * <p>The message carries the requested information items and, when present, a free-form line describing how the missing
  * items relate to each other, appended after the item list.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class InformationProposeGenerator extends AbstractNegotiationGenerator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationContentExtractor.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationContentExtractor.java
@@ -10,7 +10,7 @@ import net.openan.a2at.sdk.negotiation.resources.NegotiationReference;
  * <p>Implementations decide how the text is understood; the returned content must already satisfy the generator input
  * rules so the deterministic rendering step can consume it directly.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public interface NegotiationContentExtractor {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * <p>Instances are created through {@link NegotiationGenerationOrchestratorBuilder}; the builder wires the default
  * collaborators and allows overriding each of them.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public final class NegotiationGenerationOrchestrator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilder.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilder.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
  * language and the optional local resource root (templates and negotiation vocabulary), and each of them can be
  * overridden for testing or customization.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public final class NegotiationGenerationOrchestratorBuilder {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerator.java
@@ -12,7 +12,7 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
  * delegate the final rendering step. The registry is the only supported dispatch path; it guarantees the exact runtime
  * type of the content before a generator is invoked.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 interface NegotiationGenerator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGeneratorRegistry.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGeneratorRegistry.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * and the content type must match the negotiation type. Subtype matching is deliberately not supported; new content
  * types must be registered explicitly.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class NegotiationGeneratorRegistry {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationItemFormatter.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationItemFormatter.java
@@ -9,7 +9,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
  * <p>Each item becomes one line {@code N. name<colon>value}; an item without a value becomes {@code N. name}. The
  * caller supplies the list punctuation from the negotiation vocabulary so the output matches the message language.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public final class NegotiationItemFormatter {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationJsonSchemaBuilder.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationJsonSchemaBuilder.java
@@ -15,7 +15,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationType;
  * (negotiation type, phase) pair with accept and reject sharing the terminal schema. The semantic validation schema
  * merges a caller-provided parameter schema into the fixed four-key output contract of the semantic validation step.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class NegotiationJsonSchemaBuilder {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationMessageBuilder.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationMessageBuilder.java
@@ -12,7 +12,7 @@ import java.util.Objects;
  * supplied for that token name; a supplied null value is replaced with an empty string and bracket tokens without a
  * supplied value are left unchanged.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class NegotiationMessageBuilder {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationPromptRenderer.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationPromptRenderer.java
@@ -20,7 +20,7 @@ import net.openan.a2at.sdk.prompt.taskrendering.SectionedTemplateRenderer;
  * null template text with the internal {@link NegotiationRenderException} instead of a {@code NullPointerException},
  * so the orchestration layer wraps the failure into a typed negotiation generation failure rather than letting it leak.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 class NegotiationPromptRenderer implements SectionedTemplateRenderer {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationPromptResourceLoader.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationPromptResourceLoader.java
@@ -15,7 +15,7 @@ import net.openan.a2at.sdk.core.resources.PathSegments;
  * {@code target_negotiation}, {@code feasibility_negotiation} and {@code negotiation_semantic_validation}, each with a
  * {@code system.md} and a {@code user.md} per language.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 class NegotiationPromptResourceLoader {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationRenderException.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationRenderException.java
@@ -6,7 +6,7 @@ package net.openan.a2at.sdk.negotiation.generation;
  * <p>This exception never bubbles out of the public API; the orchestration layer maps it to a typed negotiation failure
  * instead.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 class NegotiationRenderException extends RuntimeException {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/TargetEndingGenerator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/TargetEndingGenerator.java
@@ -15,7 +15,7 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
  * <p>The result content slot carries the confirmed intent for an accept conclusion or the failure reason for a reject
  * conclusion; the other field is ignored.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class TargetEndingGenerator extends AbstractNegotiationGenerator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/TargetProposeGenerator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/TargetProposeGenerator.java
@@ -15,7 +15,7 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
  * understanding section appears only on the first round, the alignment and clarification section only on later rounds,
  * and the clarification request section only when clarification items are present.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 final class TargetProposeGenerator extends AbstractNegotiationGenerator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/DefaultNegotiationTemplateLoader.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/DefaultNegotiationTemplateLoader.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * {@code templates/} tree. Only templates are taken from the local root; LLM prompt resources always come from the
  * classpath.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public final class DefaultNegotiationTemplateLoader implements NegotiationTemplateLoader {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReference.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationReference.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.Nullable;
  * @param type negotiation type addressed by the reference
  * @param phase API-level phase addressed by the reference; accept and reject share the same template
  * @param language locale identifier such as {@code zh-CN} or {@code en-US}
- * @since 2026-06
+ * @since 2026-08
  */
 public record NegotiationReference(NegotiationType type, NegotiationPhase phase, String language) {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationTemplateLoader.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/resources/NegotiationTemplateLoader.java
@@ -6,7 +6,7 @@ import net.openan.a2at.sdk.core.model.PromptTemplate;
 /**
  * Loads negotiation templates addressed by {@link NegotiationReference} keys.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public interface NegotiationTemplateLoader {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationComplianceChecker.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationComplianceChecker.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * are applied: the checker does not infer the negotiation type, does not validate conclusion values, does not require
  * ending result sections and does not check conditional-section exclusivity.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public final class DefaultNegotiationComplianceChecker implements NegotiationComplianceChecker {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidator.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * declared template and the message sections is part of the semantic tasks performed by the LLM and surfaces through
  * the returned errors.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public final class DefaultNegotiationSemanticValidator implements NegotiationSemanticValidator {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationComplianceChecker.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationComplianceChecker.java
@@ -12,7 +12,7 @@ import net.openan.a2at.sdk.negotiation.content.Vocabulary;
  * ending-section presence and conditional-section exclusivity are deliberately not checked here; they belong to the
  * semantic validation step.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public interface NegotiationComplianceChecker {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationRuleCheckResult.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationRuleCheckResult.java
@@ -19,7 +19,7 @@ import net.openan.a2at.sdk.negotiation.content.NegotiationContext;
  *     message or when every rule passes
  * @param context parsed negotiation context; {@code null} unless the text is a negotiation message whose context is
  *     fully valid
- * @since 2026-06
+ * @since 2026-08
  */
 public record NegotiationRuleCheckResult(
         boolean passed, boolean isNegotiation, List<SlotValidationError> errors, NegotiationContext context) {

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationSemanticValidator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationSemanticValidator.java
@@ -18,7 +18,7 @@ import net.openan.a2at.sdk.negotiation.resources.NegotiationReference;
  * the four required keys or has the wrong shape is a validation infrastructure failure signalled through the internal
  * {@link NegotiationValidationException}.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public interface NegotiationSemanticValidator extends SemanticValidator<NegotiationReference> {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationValidationException.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationValidationException.java
@@ -8,7 +8,7 @@ package net.openan.a2at.sdk.negotiation.validation;
  * the orchestration layer converts it into a parameter-extraction failure carrying the retryable LLM infrastructure
  * error code.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public class NegotiationValidationException extends RuntimeException {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/ParamExtractor.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/ParamExtractor.java
@@ -19,7 +19,7 @@ import net.openan.a2at.sdk.negotiation.resources.NegotiationReference;
  * {@link RuleChecker} adapter and a {@link SemanticValidator} adapter bridge the negotiation types to the core
  * validation contracts.
  *
- * @since 2026-06
+ * @since 2026-08
  */
 public final class ParamExtractor {
 

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/SemanticValidationResult.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/SemanticValidationResult.java
@@ -18,7 +18,7 @@ import net.openan.a2at.sdk.core.model.SlotValidationError;
  * @param errors structured semantic errors using language-neutral {@code section.*} slot names; empty when the verdict
  *     is true
  * @param params parameters extracted from the message per the caller-provided schema
- * @since 2026-06
+ * @since 2026-08
  */
 public record SemanticValidationResult(
         boolean verdict, String negotiationType, List<SlotValidationError> errors, Map<String, Object> params) {


### PR DESCRIPTION
## Description

### Overview

Corrects the Javadoc `@since` version month on Java classes newly added to `src/main` after commit `417aba2d`. All of these classes were actually created during August 2026 (2026-08-19/20) but were annotated `@since 2026-06`.

### Changes

- Fixed `@since 2026-06` → `@since 2026-08` in **54 files** across:
    - `a2a-t-core` — exception/error-code unification types (`A2ATError`, `A2ATErrorCodes`, `A2ATParamExtractionError`), `SlotValidationError`
    - `a2a-t-negotiation` — the whole Negotiation-T content layer (`content/`, `generation/`, `resources/`, `validation/` packages)
- **Left untouched** (moved, not new development): `a2a-t-sample` `ClientSampleMain` / `SampleClientRuntime` (`@since 2026-05`), which were relocated from pre-existing code originally created in June 2026.
- Line endings (mixed CRLF/LF in the repo) preserved; each file is a single-line Javadoc-only diff.
- Commit signed off (DCO `-s`).

### Verification

- `git diff` per file: 1 insertion + 1 deletion each; no line-ending noise.
- `@since` distribution across added files now: 83 × `2026-08`, 2 × `2026-05` (moved sample).


## Related Issue(s)
None
<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here. -->
