### PR TITLE
fix: prompt validation pipeline defects (filename, pass condition, retry, thread safety) and FromDataWithSchema schema contract

### DIFF
--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
@@ -13,17 +13,16 @@ import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.PromptTemplate;
 import net.openan.a2at.sdk.core.model.TemplateUri;
-import net.openan.a2at.sdk.negotiation.generation.NegotiationContentService;
 import net.openan.a2at.sdk.negotiation.content.NegotiationAbortData;
 import net.openan.a2at.sdk.negotiation.content.NegotiationEndingData;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
+import net.openan.a2at.sdk.negotiation.generation.NegotiationContentService;
 import net.openan.a2at.sdk.negotiation.runtime.RoleBoundNegotiationOrchestrator;
 import net.openan.a2at.sdk.negotiation.types.model.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.types.model.NegotiationStatus;
 import net.openan.a2at.sdk.negotiation.types.model.NegotiationType;
 import net.openan.a2at.sdk.prompt.resources.catalog.TemplateQueryService;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 
 /**
  * High-level client facade for prompt generation and negotiation APIs. The caller provides the `.env` file path
@@ -48,13 +47,14 @@ public final class A2ATClient {
      */
     public A2ATClient(Path envPath) {
         Path resolvedEnvPath = envPath.toAbsolutePath().normalize();
-        A2ATConfig config =
-                NegotiationContentService.resolvePromptResourceLocalRootDir(A2ATConfig.load(resolvedEnvPath), resolvedEnvPath);
+        A2ATConfig config = NegotiationContentService.resolvePromptResourceLocalRootDir(
+                A2ATConfig.load(resolvedEnvPath), resolvedEnvPath);
         DefaultA2ATClientBuilder builder =
                 DefaultA2ATClientBuilder.builder().envPath(resolvedEnvPath).config(config);
         this.promptGenerationOrchestrator = builder.buildPromptGenerationOrchestrator();
         this.negotiationOrchestrator = builder.buildNegotiationOrchestrator();
-        this.negotiationContentService = new NegotiationContentService(builder.buildNegotiationGenerationOrchestrator());
+        this.negotiationContentService =
+                new NegotiationContentService(builder.buildNegotiationGenerationOrchestrator());
         this.templateQueryService = builder.buildTemplateQueryService();
     }
 
@@ -75,35 +75,35 @@ public final class A2ATClient {
      * @param text natural-language task input
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the template URI is null
-     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code
-     *     {@code template_not_found}, {@code prompt_resource_load_error}, {@code slot_schema_not_found},
-     *     {@code llm_invocation_failed}, {@code render_failed} or {@code slot_validation_error} when generating the
-     *     prompt fails
+     * @throws NullPointerException if the text or template URI is null
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
+     *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
      */
     public MetadataContent generateTaskPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(text, "text");
         Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateTaskPromptFromText(text, templateUri);
     }
 
     /**
-     * Generates a task prompt with metadata from structured input and an optional data schema using the template
-     * identified by the template URI, bypassing scenario recognition.
+     * Generates a task prompt with metadata from structured input and a data schema using the template identified by
+     * the template URI, bypassing scenario recognition.
      *
      * @param data structured task input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction; null disables schema-guided extraction
+     * @param schema data schema map describing the meaning of each input field; must not be null or empty
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the template URI is null
-     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code
-     *     {@code template_not_found}, {@code prompt_resource_load_error}, {@code slot_schema_not_found},
-     *     {@code llm_invocation_failed}, {@code render_failed} or {@code slot_validation_error} when generating the
-     *     prompt fails
+     * @throws NullPointerException if the template URI, data or schema is null
+     * @throws IllegalArgumentException if the schema is empty
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
+     *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
      */
     public MetadataContent generateTaskPromptFromDataWithSchema(
-            @NonNull Map<String, Object> data,
-            @Nullable Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
+            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(data, "data");
+        Objects.requireNonNull(schema, "schema");
         Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateTaskPromptFromDataWithSchema(data, schema, templateUri);
     }
@@ -119,39 +119,39 @@ public final class A2ATClient {
      * @param text natural-language authorization input
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the template URI is null
-     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code
-     *     {@code template_not_found}, {@code prompt_resource_load_error}, {@code slot_schema_not_found},
-     *     {@code llm_invocation_failed}, {@code render_failed} or {@code slot_validation_error} when generating the
-     *     prompt fails
+     * @throws NullPointerException if the text or template URI is null
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
+     *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
      */
     public MetadataContent generateAuthPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(text, "text");
         Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateAuthPromptFromText(text, templateUri);
     }
 
     /**
-     * Generates an authorization prompt with metadata from structured input and an optional data schema using the
-     * template identified by the template URI, bypassing scenario recognition.
+     * Generates an authorization prompt with metadata from structured input and a data schema using the template
+     * identified by the template URI, bypassing scenario recognition.
      *
      * <p><b>Experimental:</b> Authorization-T template resources (such as {@code authz-policy-mgr}) are bundled and
      * discovered automatically, but Authorization-T slot schemas are not yet bundled, so template-driven slot
      * extraction fails until Authorization-T slot resources are added or provided through the local resource root.
      *
      * @param data structured authorization input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction; null disables schema-guided extraction
+     * @param schema data schema map describing the meaning of each input field; must not be null or empty
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the template URI is null
-     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code
-     *     {@code template_not_found}, {@code prompt_resource_load_error}, {@code slot_schema_not_found},
-     *     {@code llm_invocation_failed}, {@code render_failed} or {@code slot_validation_error} when generating the
-     *     prompt fails
+     * @throws NullPointerException if the template URI, data or schema is null
+     * @throws IllegalArgumentException if the schema is empty
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
+     *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
      */
     public MetadataContent generateAuthPromptFromDataWithSchema(
-            @NonNull Map<String, Object> data,
-            @Nullable Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
+            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(data, "data");
+        Objects.requireNonNull(schema, "schema");
         Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateAuthPromptFromDataWithSchema(data, schema, templateUri);
     }
@@ -163,35 +163,35 @@ public final class A2ATClient {
      * @param text natural-language notification input
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the template URI is null
-     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code
-     *     {@code template_not_found}, {@code prompt_resource_load_error}, {@code slot_schema_not_found},
-     *     {@code llm_invocation_failed}, {@code render_failed} or {@code slot_validation_error} when generating the
-     *     prompt fails
+     * @throws NullPointerException if the text or template URI is null
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
+     *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
      */
     public MetadataContent generateNotificationPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(text, "text");
         Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateNotificationPromptFromText(text, templateUri);
     }
 
     /**
-     * Generates a notification prompt with metadata from structured input and an optional data schema using the
-     * template identified by the template URI, bypassing scenario recognition.
+     * Generates a notification prompt with metadata from structured input and a data schema using the template
+     * identified by the template URI, bypassing scenario recognition.
      *
      * @param data structured notification input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction; null disables schema-guided extraction
+     * @param schema data schema map describing the meaning of each input field; must not be null or empty
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the template URI is null
-     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code
-     *     {@code template_not_found}, {@code prompt_resource_load_error}, {@code slot_schema_not_found},
-     *     {@code llm_invocation_failed}, {@code render_failed} or {@code slot_validation_error} when generating the
-     *     prompt fails
+     * @throws NullPointerException if the template URI, data or schema is null
+     * @throws IllegalArgumentException if the schema is empty
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
+     *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
      */
     public MetadataContent generateNotificationPromptFromDataWithSchema(
-            @NonNull Map<String, Object> data,
-            @Nullable Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
+            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+        Objects.requireNonNull(data, "data");
+        Objects.requireNonNull(schema, "schema");
         Objects.requireNonNull(templateUri, "templateUri");
         return promptGenerationOrchestrator.generateNotificationPromptFromDataWithSchema(data, schema, templateUri);
     }
@@ -261,8 +261,8 @@ public final class A2ATClient {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its
-     *     phase segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its phase
+     *     segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data or its context is null
      * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
@@ -284,8 +284,8 @@ public final class A2ATClient {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its
-     *     phase segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its phase
+     *     segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data or its context is null
      * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
@@ -361,8 +361,8 @@ public final class A2ATClient {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its
-     *     phase segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its phase
+     *     segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context is null
      * @throws IllegalArgumentException if the template URI phase contradicts the method
@@ -390,8 +390,8 @@ public final class A2ATClient {
      *
      * @param text free-text input describing the message content
      * @param context negotiation context injected into the rendered message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its
-     *     phase segment must be {@code accept-reject}
+     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its phase
+     *     segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context is null
      * @throws IllegalArgumentException if the template URI phase contradicts the method
@@ -442,8 +442,8 @@ public final class A2ATClient {
      * Lists every template available for the configured language across all A2A-T extensions.
      *
      * <p>This query never throws: the extension directories are discovered from the bundled resource tree itself, so
-     * templates of extensions added later are included automatically. Templates that exist nowhere for the language
-     * are skipped and an empty list is returned when no template can be loaded at all.
+     * templates of extensions added later are included automatically. Templates that exist nowhere for the language are
+     * skipped and an empty list is returned when no template can be loaded at all.
      *
      * @return loadable templates of the configured language across all extensions, sorted by template URI; empty when
      *     none can be loaded
@@ -499,8 +499,8 @@ public final class A2ATClient {
      *
      * <p>The pipeline first runs the deterministic rule gate (recognition of the negotiation context section and its
      * strong constraints) before any LLM call, then performs one LLM semantic validation call that also extracts the
-     * parameters, and finally merges the parameters with the context parameters taking precedence. The semantic step
-     * is retried up to the configured attempt limit on the retryable LLM infrastructure failure code.
+     * parameters, and finally merges the parameters with the context parameters taking precedence. The semantic step is
+     * retried up to the configured attempt limit on the retryable LLM infrastructure failure code.
      *
      * @param prompt rendered negotiation message text to validate
      * @param schema caller-provided parameter JSON schema describing the parameters to extract

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/ClientPromptGenerationOrchestrator.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/ClientPromptGenerationOrchestrator.java
@@ -1,8 +1,8 @@
 package net.openan.a2at.sdk.client.prompt.orchestration;
 
 import java.util.Map;
-import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
+import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.TemplateUri;
 
 /**
@@ -27,17 +27,20 @@ public interface ClientPromptGenerationOrchestrator {
      * @param text natural-language task input
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     * @throws NullPointerException if the text or template URI is null
      */
     MetadataContent generateTaskPromptFromText(String text, TemplateUri templateUri);
 
     /**
-     * Generates a task prompt with metadata from structured input and an optional data schema using the template
-     * identified by the template URI, bypassing scenario recognition.
+     * Generates a task prompt with metadata from structured input and a data schema using the template identified by
+     * the template URI, bypassing scenario recognition.
      *
      * @param data structured task input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction
+     * @param schema data schema map describing the meaning of each input field; must not be null or empty
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     * @throws NullPointerException if the template URI, data or schema is null
+     * @throws IllegalArgumentException if the schema is empty
      */
     MetadataContent generateTaskPromptFromDataWithSchema(
             Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri);
@@ -49,17 +52,20 @@ public interface ClientPromptGenerationOrchestrator {
      * @param text natural-language authorization input
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     * @throws NullPointerException if the text or template URI is null
      */
     MetadataContent generateAuthPromptFromText(String text, TemplateUri templateUri);
 
     /**
-     * Generates an authorization prompt with metadata from structured input and an optional data schema using the
-     * template identified by the template URI, bypassing scenario recognition.
+     * Generates an authorization prompt with metadata from structured input and a data schema using the template
+     * identified by the template URI, bypassing scenario recognition.
      *
      * @param data structured authorization input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction
+     * @param schema data schema map describing the meaning of each input field; must not be null or empty
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     * @throws NullPointerException if the template URI, data or schema is null
+     * @throws IllegalArgumentException if the schema is empty
      */
     MetadataContent generateAuthPromptFromDataWithSchema(
             Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri);
@@ -71,17 +77,20 @@ public interface ClientPromptGenerationOrchestrator {
      * @param text natural-language notification input
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     * @throws NullPointerException if the text or template URI is null
      */
     MetadataContent generateNotificationPromptFromText(String text, TemplateUri templateUri);
 
     /**
-     * Generates a notification prompt with metadata from structured input and an optional data schema using the
-     * template identified by the template URI, bypassing scenario recognition.
+     * Generates a notification prompt with metadata from structured input and a data schema using the template
+     * identified by the template URI, bypassing scenario recognition.
      *
      * @param data structured notification input as a string-to-object map
-     * @param schema optional data schema map for schema-guided extraction
+     * @param schema data schema map describing the meaning of each input field; must not be null or empty
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
+     * @throws NullPointerException if the template URI, data or schema is null
+     * @throws IllegalArgumentException if the schema is empty
      */
     MetadataContent generateNotificationPromptFromDataWithSchema(
             Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri);

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestrator.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestrator.java
@@ -164,6 +164,7 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
 
     private MetadataContent generateFromTemplateUriWithMetadata(
             String userInput, TemplateUri templateUri, String extensionUri) {
+        Objects.requireNonNull(userInput, "userInput");
         Objects.requireNonNull(templateUri, "templateUri");
         String templateIdentifier = templateUri.uri();
         final String templateText;
@@ -199,6 +200,11 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
             String extensionUri) {
         Objects.requireNonNull(templateUri, "templateUri");
         String templateIdentifier = templateUri.uri();
+        Objects.requireNonNull(schema, "schema");
+        if (schema.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Data schema must not be empty; it describes the meaning of each input field.");
+        }
         final String templateText;
         try {
             templateText = templateLoader.loadTemplate(templateIdentifier, language);

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultStructuredClientSlotValueExtractorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultStructuredClientSlotValueExtractorTest.java
@@ -24,10 +24,12 @@ class DefaultStructuredClientSlotValueExtractorTest {
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
                         List.of(
-                                new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null),
                                 new PromptSlotDefinition(
-                                        "additional_notes", false, "string", null, null, null, null, null),
-                                new PromptSlotDefinition("limit", false, "integer", null, 1.0d, 10.0d, null, null),
+                                        "site", true, "string", "^Site .+", null, null, null, null, null),
+                                new PromptSlotDefinition(
+                                        "additional_notes", false, "string", null, null, null, null, null, null),
+                                new PromptSlotDefinition(
+                                        "limit", false, "integer", null, 1.0d, 10.0d, null, null, null),
                                 new PromptSlotDefinition(
                                         "severity",
                                         false,
@@ -36,6 +38,7 @@ class DefaultStructuredClientSlotValueExtractorTest {
                                         null,
                                         null,
                                         List.of("low", "medium", "high"),
+                                        null,
                                         null))),
                 "Extract slots from the input.",
                 "Return slots as JSON.");
@@ -70,10 +73,12 @@ class DefaultStructuredClientSlotValueExtractorTest {
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
                         List.of(
-                                new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null),
                                 new PromptSlotDefinition(
-                                        "additional_notes", false, "string", null, null, null, null, null),
-                                new PromptSlotDefinition("limit", false, "integer", null, 1.0d, 10.0d, null, null),
+                                        "site", true, "string", "^Site .+", null, null, null, null, null),
+                                new PromptSlotDefinition(
+                                        "additional_notes", false, "string", null, null, null, null, null, null),
+                                new PromptSlotDefinition(
+                                        "limit", false, "integer", null, 1.0d, 10.0d, null, null, null),
                                 new PromptSlotDefinition(
                                         "severity",
                                         false,
@@ -82,6 +87,7 @@ class DefaultStructuredClientSlotValueExtractorTest {
                                         null,
                                         null,
                                         List.of("low", "medium", "high"),
+                                        null,
                                         null))),
                 "Extract slots from the input.",
                 "Return slots as JSON.");
@@ -107,18 +113,18 @@ class DefaultStructuredClientSlotValueExtractorTest {
 
     @Test
     void extractSlotsWithSchemaWithNullSchemaStillWorks() {
-        RecordingClient llmClient = new RecordingClient(
-                "{\"slots\":{\"site\":\"Site A\"},\"slot_errors\":[]}");
+        RecordingClient llmClient = new RecordingClient("{\"slots\":{\"site\":\"Site A\"},\"slot_errors\":[]}");
         DefaultStructuredClientSlotValueExtractor extractor = new DefaultStructuredClientSlotValueExtractor(
                 llmClient,
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
-                        List.of(new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null))),
+                        List.of(new PromptSlotDefinition(
+                                "site", true, "string", "^Site .+", null, null, null, null, null))),
                 "Extract slots.",
                 "Return slots.");
 
-        Map<String, String> slots = extractor.extractSlotsWithSchema(
-                "Analyze Site A.", "scenario", "en", "Site: {site}", null);
+        Map<String, String> slots =
+                extractor.extractSlotsWithSchema("Analyze Site A.", "scenario", "en", "Site: {site}", null);
 
         assertEquals(Map.of("site", "Site A"), slots);
         assertFalse(llmClient.lastMessages().get(1).get("content").contains("[data_schema]"));

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultTemplateDrivenSlotValueExtractorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/extractor/DefaultTemplateDrivenSlotValueExtractorTest.java
@@ -15,9 +15,10 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
         DefaultTemplateDrivenSlotValueExtractor extractor =
                 new DefaultTemplateDrivenSlotValueExtractor((scenarioCode, language) -> schema(
                         scenarioCode,
-                        new PromptSlotDefinition("site", true, "string", null, null, null, null, null),
-                        new PromptSlotDefinition("additional_notes", false, "string", null, null, null, null, null),
-                        new PromptSlotDefinition("ignored", false, "string", null, null, null, null, null)));
+                        new PromptSlotDefinition("site", true, "string", null, null, null, null, null, null),
+                        new PromptSlotDefinition(
+                                "additional_notes", false, "string", null, null, null, null, null, null),
+                        new PromptSlotDefinition("ignored", false, "string", null, null, null, null, null, null)));
 
         Map<String, String> slots = extractor.extractSlots(
                 Map.of("site", "Site A", "additional_notes", "critical", "ignored", "value"),
@@ -32,7 +33,8 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
     void extractSlotsMapsStringInputToSchemaDefinedInputSlot() {
         DefaultTemplateDrivenSlotValueExtractor extractor =
                 new DefaultTemplateDrivenSlotValueExtractor((scenarioCode, language) -> schema(
-                        scenarioCode, new PromptSlotDefinition("input", true, "string", null, null, null, null, null)));
+                        scenarioCode,
+                        new PromptSlotDefinition("input", true, "string", null, null, null, null, null, null)));
 
         Map<String, String> slots = extractor.extractSlots("Analyze Site A.", "free-text", "en-US", "Input: {input}");
 
@@ -44,9 +46,10 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
         DefaultTemplateDrivenSlotValueExtractor extractor =
                 new DefaultTemplateDrivenSlotValueExtractor((scenarioCode, language) -> schema(
                         scenarioCode,
-                        new PromptSlotDefinition("topic", false, "string", null, null, null, null, null),
-                        new PromptSlotDefinition("condition", false, "string", null, null, null, null, null),
-                        new PromptSlotDefinition("report_format", false, "string", null, null, null, null, null)));
+                        new PromptSlotDefinition("topic", false, "string", null, null, null, null, null, null),
+                        new PromptSlotDefinition("condition", false, "string", null, null, null, null, null, null),
+                        new PromptSlotDefinition(
+                                "report_format", false, "string", null, null, null, null, null, null)));
 
         Map<String, String> slots = extractor.extractSlots(
                 Map.of(
@@ -70,8 +73,9 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
         DefaultTemplateDrivenSlotValueExtractor extractor =
                 new DefaultTemplateDrivenSlotValueExtractor((scenarioCode, language) -> schema(
                         scenarioCode,
-                        new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null),
-                        new PromptSlotDefinition("additional_notes", false, "string", null, null, null, null, null)));
+                        new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null, null),
+                        new PromptSlotDefinition(
+                                "additional_notes", false, "string", null, null, null, null, null, null)));
 
         Map<String, String> slots = extractor.extractSlots(
                 Map.of("site", "invalid", "additional_notes", "critical"),
@@ -87,9 +91,10 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
         DefaultTemplateDrivenSlotValueExtractor extractor =
                 new DefaultTemplateDrivenSlotValueExtractor((scenarioCode, language) -> schema(
                         scenarioCode,
-                        new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null),
-                        new PromptSlotDefinition("additional_notes", false, "string", null, null, null, null, null),
-                        new PromptSlotDefinition("limit", false, "integer", null, 1.0d, 10.0d, null, null),
+                        new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null, null),
+                        new PromptSlotDefinition(
+                                "additional_notes", false, "string", null, null, null, null, null, null),
+                        new PromptSlotDefinition("limit", false, "integer", null, 1.0d, 10.0d, null, null, null),
                         new PromptSlotDefinition(
                                 "severity",
                                 false,
@@ -98,6 +103,7 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
                                 null,
                                 null,
                                 List.of("low", "medium", "high"),
+                                null,
                                 null)));
 
         Map<String, String> slots = extractor.extractSlots(
@@ -124,9 +130,10 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
         DefaultTemplateDrivenSlotValueExtractor extractor =
                 new DefaultTemplateDrivenSlotValueExtractor((scenarioCode, language) -> schema(
                         scenarioCode,
-                        new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null),
-                        new PromptSlotDefinition("additional_notes", false, "string", null, null, null, null, null),
-                        new PromptSlotDefinition("limit", false, "integer", null, 1.0d, 10.0d, null, null),
+                        new PromptSlotDefinition("site", true, "string", "^Site .+", null, null, null, null, null),
+                        new PromptSlotDefinition(
+                                "additional_notes", false, "string", null, null, null, null, null, null),
+                        new PromptSlotDefinition("limit", false, "integer", null, 1.0d, 10.0d, null, null, null),
                         new PromptSlotDefinition(
                                 "severity",
                                 false,
@@ -135,6 +142,7 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
                                 null,
                                 null,
                                 List.of("low", "medium", "high"),
+                                null,
                                 null)));
 
         Map<String, String> slots = extractor.extractSlots(
@@ -165,9 +173,10 @@ class DefaultTemplateDrivenSlotValueExtractorTest {
         DefaultTemplateDrivenSlotValueExtractor extractor =
                 new DefaultTemplateDrivenSlotValueExtractor((scenarioCode, language) -> schema(
                         scenarioCode,
-                        new PromptSlotDefinition("site", true, "string", null, null, null, null, null),
-                        new PromptSlotDefinition("additional_notes", false, "string", null, null, null, null, null),
-                        new PromptSlotDefinition("ignored", false, "string", null, null, null, null, null)));
+                        new PromptSlotDefinition("site", true, "string", null, null, null, null, null, null),
+                        new PromptSlotDefinition(
+                                "additional_notes", false, "string", null, null, null, null, null, null),
+                        new PromptSlotDefinition("ignored", false, "string", null, null, null, null, null, null)));
 
         Map<String, String> slots = extractor.extractSlotsWithSchema(
                 Map.of("site", "Site A", "additional_notes", "critical", "ignored", "value"),

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
@@ -8,8 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
-import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.SlotValidationError;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 import net.openan.a2at.sdk.client.prompt.extractor.ClientSlotValueExtractor;
 import net.openan.a2at.sdk.client.prompt.loader.ClientSlotSchemaLoader;
@@ -19,6 +17,8 @@ import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
+import net.openan.a2at.sdk.core.model.MetadataContent;
+import net.openan.a2at.sdk.core.model.SlotValidationError;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
 import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMRuntimeError;
@@ -34,8 +34,7 @@ class DefaultClientPromptGenerationOrchestratorTest {
     private static final ClientSlotSchemaLoader EMPTY_SCHEMA_LOADER =
             (scenarioCode, language) -> new PromptSlotSchema(scenarioCode, List.of());
 
-    private static final TemplateUri AUTH_DATABASE_READ =
-            TemplateUri.of("Authorization-T", "database_read");
+    private static final TemplateUri AUTH_DATABASE_READ = TemplateUri.of("Authorization-T", "database_read");
 
     @Test
     void generateTaskPromptLoadsTemplateAndRendersExtractedSlotsWhenScenarioIsMatched() {
@@ -168,7 +167,7 @@ class DefaultClientPromptGenerationOrchestratorTest {
         assertEquals("generation", result.failure().stage());
     }
 
-private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestrator(
+    private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestrator(
             ClientScenarioRecognizer recognizer,
             ClientTemplateLoader templateLoader,
             ClientSlotValueExtractor slotValueExtractor) {
@@ -269,7 +268,10 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
 
         @Override
         public Map<String, String> extractSlotsWithSchema(
-                Object userInput, String scenarioCode, String language, String templateText,
+                Object userInput,
+                String scenarioCode,
+                String language,
+                String templateText,
                 Map<String, Object> dataSchema) {
             this.lastUserInput = userInput;
             this.lastScenarioCode = scenarioCode;
@@ -295,7 +297,10 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
 
         @Override
         public Map<String, String> extractSlotsWithSchema(
-                Object userInput, String scenarioCode, String language, String templateText,
+                Object userInput,
+                String scenarioCode,
+                String language,
+                String templateText,
                 Map<String, Object> dataSchema) {
             throw exception;
         }
@@ -310,7 +315,8 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent result = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
+        MetadataContent result =
+                orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
 
         assertEquals(StandardTemplates.ENERGY_SAVING.uri(), result.templateUri());
         assertEquals("Site: Site A", result.promptText());
@@ -321,8 +327,8 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
     void generateFromTemplateUriWithMetadataScenarioRecognizerIsNotInvoked() {
         RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
         FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
-        DefaultClientPromptGenerationOrchestrator orchestrator =
-                newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                recognizer, templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
         orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
 
@@ -344,6 +350,18 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
     }
 
     @Test
+    void generateTaskPromptFromTextRejectsNullText() {
+        RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
+        CountingFailingTemplateLoader templateLoader = new CountingFailingTemplateLoader();
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of()));
+
+        assertThrows(
+                NullPointerException.class,
+                () -> orchestrator.generateTaskPromptFromText(null, StandardTemplates.ENERGY_SAVING));
+    }
+
+    @Test
     void generateFromTemplateUriWithMetadataPropagatesResourceNotFoundException() {
         DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
                 new RecordingScenarioRecognizer(),
@@ -352,7 +370,8 @@ private static DefaultClientPromptGenerationOrchestrator newTemplateUriOrchestra
                 },
                 new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
-PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("template_not_found", ex.getCode());
     }
@@ -364,7 +383,8 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 new FakeTemplateLoader("Site: {site}\nMissing: {missing_slot}"),
                 new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
-PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("render_failed", ex.getCode());
     }
@@ -378,7 +398,8 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                     throw new LLMRuntimeError("LLM invocation failed.");
                 });
 
-PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("llm_invocation_failed", ex.getCode());
     }
@@ -410,7 +431,8 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
         Map<String, Object> schema = Map.of("site", "string", "count", "number");
-        orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), schema, StandardTemplates.ENERGY_SAVING);
+        orchestrator.generateTaskPromptFromDataWithSchema(
+                Map.of("site", "Site A"), schema, StandardTemplates.ENERGY_SAVING);
 
         assertEquals(schema, slotValueExtractor.lastSchema);
         assertEquals(StandardTemplates.ENERGY_SAVING.uri(), slotValueExtractor.lastScenarioCode);
@@ -418,33 +440,33 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
     }
 
     @Test
-    void generateFromDataWithSchemaNullSchemaHandledGracefully() {
+    void generateTaskPromptFromDataWithSchemaRejectsNullSchema() {
         FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
         FakeSlotValueExtractorWithSchema slotValueExtractor =
                 new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A"));
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), null, StandardTemplates.ENERGY_SAVING);
-
-        assertEquals("Site: Site A", result.promptText());
-        assertEquals(null, slotValueExtractor.lastSchema);
+        NullPointerException ex = assertThrows(
+                NullPointerException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(
+                        Map.of("site", "Site A"), null, StandardTemplates.ENERGY_SAVING));
+        assertEquals("schema", ex.getMessage());
     }
 
     @Test
-    void generateFromDataWithSchemaEmptySchemaHandledSameAsNull() {
+    void generateTaskPromptFromDataWithSchemaRejectsEmptySchema() {
         FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
         FakeSlotValueExtractorWithSchema slotValueExtractor =
                 new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A"));
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent result = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
-
-        assertEquals("Site: Site A", result.promptText());
-        assertEquals(Map.of(), slotValueExtractor.lastSchema);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(
+                        Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
+        assertTrue(ex.getMessage().contains("Data schema must not be empty"));
     }
 
     @Test
@@ -456,8 +478,10 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 },
                 new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A")));
 
-PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(
+                        Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING));
         assertEquals("template_not_found", ex.getCode());
     }
 
@@ -468,8 +492,10 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 new FakeTemplateLoader("Site: {site}\nMissing: {missing_slot}"),
                 new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A")));
 
-PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(
+                        Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING));
         assertEquals("render_failed", ex.getCode());
     }
 
@@ -480,8 +506,10 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 new FakeTemplateLoader("Site: {site}"),
                 new FailingExtractSlotsWithSchema(new LLMRuntimeError("LLM invocation failed.")));
 
-PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(
+                        Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING));
         assertEquals("llm_invocation_failed", ex.getCode());
     }
 
@@ -493,8 +521,10 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
                 new FailingExtractSlotsWithSchema(
                         new ResourceNotFoundException("Slot schema file does not exist.", "energy-saving")));
 
-PromptGenerationException ex = assertThrows(PromptGenerationException.class,
-                () -> orchestrator.generateTaskPromptFromDataWithSchema(Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING));
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
+                () -> orchestrator.generateTaskPromptFromDataWithSchema(
+                        Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_schema_not_found", ex.getCode());
     }
 
@@ -508,15 +538,17 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
         DefaultClientPromptGenerationOrchestrator orchestrator =
                 newTemplateUriOrchestrator(new RecordingScenarioRecognizer(), templateLoader, slotValueExtractor);
 
-        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
+        MetadataContent taskText =
+                orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
         MetadataContent taskData = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
+                Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING);
         MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", AUTH_DATABASE_READ);
         MetadataContent authData = orchestrator.generateAuthPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), AUTH_DATABASE_READ);
-        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING);
+                Map.of("site", "Site A"), Map.of("site", "string"), AUTH_DATABASE_READ);
+        MetadataContent notifText =
+                orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING);
         MetadataContent notifData = orchestrator.generateNotificationPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
+                Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING);
 
         assertTrue(taskText.promptText().contains("Site A"));
         assertTrue(taskData.promptText().contains("Site A"));
@@ -530,17 +562,21 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
     void eachMetadataEntryPointUsesCorrectExtensionUri() {
         FakeTemplateLoader templateLoader = new FakeTemplateLoader("Site: {site}");
         DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
-                new RecordingScenarioRecognizer(), templateLoader, new FakeSlotValueExtractor(Map.of("site", "Site A")));
+                new RecordingScenarioRecognizer(),
+                templateLoader,
+                new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
-        MetadataContent taskText = orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
+        MetadataContent taskText =
+                orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING);
         MetadataContent taskData = orchestrator.generateTaskPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
+                Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING);
         MetadataContent authText = orchestrator.generateAuthPromptFromText("Grant access.", AUTH_DATABASE_READ);
         MetadataContent authData = orchestrator.generateAuthPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), AUTH_DATABASE_READ);
-        MetadataContent notifText = orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING);
+                Map.of("site", "Site A"), Map.of("site", "string"), AUTH_DATABASE_READ);
+        MetadataContent notifText =
+                orchestrator.generateNotificationPromptFromText("Report finished.", StandardTemplates.ENERGY_SAVING);
         MetadataContent notifData = orchestrator.generateNotificationPromptFromDataWithSchema(
-                Map.of("site", "Site A"), Map.of(), StandardTemplates.ENERGY_SAVING);
+                Map.of("site", "Site A"), Map.of("site", "string"), StandardTemplates.ENERGY_SAVING);
 
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskText.extensionUri());
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskData.extensionUri());
@@ -579,17 +615,22 @@ PromptGenerationException ex = assertThrows(PromptGenerationException.class,
 
     @Test
     void validateRequiredSlotsThrowsSlotValidationErrorWhenRequiredSlotsMissing() {
-ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlotSchema(
-                scenarioCode, List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, "Site name")));
-            DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
+        ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlotSchema(
+                scenarioCode,
+                List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, "Site name", null)));
+        DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
                 new RecordingScenarioRecognizer(),
                 List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
-                "en-US", "", "", new FakeTemplateLoader("Site: {site}"),
+                "en-US",
+                "",
+                "",
+                new FakeTemplateLoader("Site: {site}"),
                 new FakeSlotValueExtractor(Map.of()),
                 new TaskPromptRenderer(),
                 schemaLoader);
 
-        PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_validation_error", ex.getCode());
         List<SlotValidationError> failed = ex.failedParameters();
@@ -600,19 +641,24 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
 
     @Test
     void validateRequiredSlotsThrowsSlotValidationErrorWhenMultipleRequiredSlotsMissing() {
-        ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlotSchema(scenarioCode,
+        ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlotSchema(
+                scenarioCode,
                 List.of(
-                        new PromptSlotDefinition("site", true, "string", null, null, null, null, "Site name"),
-                        new PromptSlotDefinition("target", true, "string", null, null, null, null, "Target")));
+                        new PromptSlotDefinition("site", true, "string", null, null, null, null, "Site name", null),
+                        new PromptSlotDefinition("target", true, "string", null, null, null, null, "Target", null)));
         DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
                 new RecordingScenarioRecognizer(),
                 List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
-                "en-US", "", "", new FakeTemplateLoader("Site: {site}\nTarget: {target}"),
+                "en-US",
+                "",
+                "",
+                new FakeTemplateLoader("Site: {site}\nTarget: {target}"),
                 new FakeSlotValueExtractor(Map.of("site", "Site A")),
                 new TaskPromptRenderer(),
                 schemaLoader);
 
-        PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_validation_error", ex.getCode());
         assertEquals(1, ex.failedParameters().size());
@@ -624,14 +670,18 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
         DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
                 new RecordingScenarioRecognizer(),
                 List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
-                "en-US", "", "", new FakeTemplateLoader("Site: {site}"),
+                "en-US",
+                "",
+                "",
+                new FakeTemplateLoader("Site: {site}"),
                 new FakeSlotValueExtractor(Map.of("site", "Site A")),
                 new TaskPromptRenderer(),
                 (scenarioCode, language) -> {
                     throw new A2ATError("Schema file is corrupt.");
                 });
 
-        PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_schema_not_found", ex.getCode());
     }
@@ -641,14 +691,18 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
         DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
                 new RecordingScenarioRecognizer(),
                 List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
-                "en-US", "", "", new FakeTemplateLoader("Site: {site}"),
+                "en-US",
+                "",
+                "",
+                new FakeTemplateLoader("Site: {site}"),
                 (userInput, scenarioCode, language, templateText) -> {
                     throw new ResourceNotFoundException("Slot schema file does not exist.", scenarioCode);
                 },
                 new TaskPromptRenderer(),
                 EMPTY_SCHEMA_LOADER);
 
-        PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("slot_schema_not_found", ex.getCode());
     }
@@ -658,14 +712,18 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
         DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
                 new RecordingScenarioRecognizer(),
                 List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
-                "en-US", "", "", (scenarioCode, language) -> {
+                "en-US",
+                "",
+                "",
+                (scenarioCode, language) -> {
                     throw new A2ATError("Template file is corrupt.");
                 },
                 new FakeSlotValueExtractor(Map.of("site", "Site A")),
                 new TaskPromptRenderer(),
                 EMPTY_SCHEMA_LOADER);
 
-        PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("prompt_resource_load_error", ex.getCode());
     }
@@ -675,14 +733,18 @@ ClientSlotSchemaLoader schemaLoader = (scenarioCode, language) -> new PromptSlot
         DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
                 new RecordingScenarioRecognizer(),
                 List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
-                "en-US", "", "", new FakeTemplateLoader("Site: {site}"),
+                "en-US",
+                "",
+                "",
+                new FakeTemplateLoader("Site: {site}"),
                 (userInput, scenarioCode, language, templateText) -> {
                     throw new A2ATError("Unparseable LLM response.");
                 },
                 new TaskPromptRenderer(),
                 EMPTY_SCHEMA_LOADER);
 
-        PromptGenerationException ex = assertThrows(PromptGenerationException.class,
+        PromptGenerationException ex = assertThrows(
+                PromptGenerationException.class,
                 () -> orchestrator.generateTaskPromptFromText("Analyze Site A.", StandardTemplates.ENERGY_SAVING));
         assertEquals("llm_invocation_failed", ex.getCode());
     }

--- a/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/providers/OpenAIClient.java
+++ b/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/providers/OpenAIClient.java
@@ -48,8 +48,7 @@ public class OpenAIClient implements LLMClient {
     }
 
     OpenAIClient(
-            LLMClientConfig config,
-            BiFunction<LLMClientConfig, ChatCompletionCreateParams, ChatCompletion> executor) {
+            LLMClientConfig config, BiFunction<LLMClientConfig, ChatCompletionCreateParams, ChatCompletion> executor) {
         if (config.apiKey() == null || config.apiKey().isBlank()) {
             throw new LLMConfigError(config.provider() + " client requires a non-empty api_key");
         }
@@ -64,7 +63,8 @@ public class OpenAIClient implements LLMClient {
             throw new LLMConfigError(config.provider() + " client requires a non-empty base_url");
         }
         try {
-            return parseResponse(executor.apply(config, buildStructuredParams(messages, jsonSchema, temperature, maxTokens)));
+            return parseResponse(
+                    executor.apply(config, buildStructuredParams(messages, jsonSchema, temperature, maxTokens)));
         } catch (LLMConfigError | LLMRuntimeError error) {
             throw error;
         } catch (Exception error) {
@@ -125,7 +125,8 @@ public class OpenAIClient implements LLMClient {
     }
 
     private LLMResponse parseResponse(ChatCompletion response) {
-        return new LLMResponse(extractJsonObjectString(response), response.model(), mapUsage(response), mapMetadata(response));
+        return new LLMResponse(
+                extractJsonObjectString(response), response.model(), mapUsage(response), mapMetadata(response));
     }
 
     private String extractJsonObjectString(ChatCompletion response) {
@@ -147,8 +148,12 @@ public class OpenAIClient implements LLMClient {
         if (response.choices().isEmpty()) {
             throw new LLMRuntimeError(config.provider() + " response did not include any choices");
         }
-        return response.choices().get(0).message().content().orElseThrow(
-                () -> new LLMRuntimeError(config.provider() + " response did not include message content"));
+        return response.choices()
+                .get(0)
+                .message()
+                .content()
+                .orElseThrow(
+                        () -> new LLMRuntimeError(config.provider() + " response did not include message content"));
     }
 
     private static Map<String, Integer> mapUsage(ChatCompletion response) {
@@ -159,8 +164,11 @@ public class OpenAIClient implements LLMClient {
             usage.put("total_tokens", 0);
             return usage;
         }
-        usage.put("prompt_tokens", Math.toIntExact(response.usage().orElseThrow().promptTokens()));
-        usage.put("completion_tokens", Math.toIntExact(response.usage().orElseThrow().completionTokens()));
+        usage.put(
+                "prompt_tokens", Math.toIntExact(response.usage().orElseThrow().promptTokens()));
+        usage.put(
+                "completion_tokens",
+                Math.toIntExact(response.usage().orElseThrow().completionTokens()));
         usage.put("total_tokens", Math.toIntExact(response.usage().orElseThrow().totalTokens()));
         return usage;
     }
@@ -177,16 +185,15 @@ public class OpenAIClient implements LLMClient {
     }
 
     @SuppressWarnings("deprecation")
-    private com.openai.client.OpenAIClient sdkClient(LLMClientConfig runtimeConfig) {
-        if (sdkClient != null) {
-            return sdkClient;
+    private synchronized com.openai.client.OpenAIClient sdkClient(LLMClientConfig runtimeConfig) {
+        if (sdkClient == null) {
+            OpenAIOkHttpClient.Builder builder =
+                    OpenAIOkHttpClient.builder().apiKey(runtimeConfig.apiKey()).baseUrl(runtimeConfig.baseUrl());
+            if (runtimeConfig.timeoutSeconds() != null && runtimeConfig.timeoutSeconds() > 0.0d) {
+                builder.timeout(Duration.ofMillis(Math.max(1L, Math.round(runtimeConfig.timeoutSeconds() * 1000.0d))));
+            }
+            sdkClient = builder.build();
         }
-        OpenAIOkHttpClient.Builder builder =
-                OpenAIOkHttpClient.builder().apiKey(runtimeConfig.apiKey()).baseUrl(runtimeConfig.baseUrl());
-        if (runtimeConfig.timeoutSeconds() != null && runtimeConfig.timeoutSeconds() > 0.0d) {
-            builder.timeout(Duration.ofMillis(Math.max(1L, Math.round(runtimeConfig.timeoutSeconds() * 1000.0d))));
-        }
-        sdkClient = builder.build();
         return sdkClient;
     }
 }

--- a/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/providers/OpenAIClientTest.java
+++ b/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/providers/OpenAIClientTest.java
@@ -11,10 +11,15 @@ import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessage;
 import com.openai.models.completions.CompletionUsage;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import net.openan.a2at.sdk.llm.LLMClientConfig;
 import net.openan.a2at.sdk.llm.LLMConfigError;
@@ -26,7 +31,8 @@ class OpenAIClientTest {
 
     @Test
     void rejectsBlankApiKeyOnConstruction() {
-        LLMConfigError error = assertThrows(LLMConfigError.class, () -> new OpenAIClient(config("   ", "https://api.example.test/v1")));
+        LLMConfigError error = assertThrows(
+                LLMConfigError.class, () -> new OpenAIClient(config("   ", "https://api.example.test/v1")));
 
         assertTrue(error.getMessage().contains("api_key"));
     }
@@ -37,11 +43,10 @@ class OpenAIClientTest {
             throw new AssertionError("executor should not run without baseUrl");
         });
 
-        LLMConfigError error = assertThrows(LLMConfigError.class, () -> client.structured(
-                List.of(Map.of("role", "user", "content", "extract")),
-                Map.of("type", "object"),
-                null,
-                null));
+        LLMConfigError error = assertThrows(
+                LLMConfigError.class,
+                () -> client.structured(
+                        List.of(Map.of("role", "user", "content", "extract")), Map.of("type", "object"), null, null));
 
         assertTrue(error.getMessage().contains("base_url"));
     }
@@ -49,9 +54,8 @@ class OpenAIClientTest {
     @Test
     void structuredBuildsJsonModePayloadAndParsesJsonObjectResponse() {
         AtomicReference<ChatCompletionCreateParams> capturedParams = new AtomicReference<>();
-        OpenAIClient client = new OpenAIClient(
-                config("sk-test", "https://api.example.test/v1"),
-                (runtimeConfig, requestParams) -> {
+        OpenAIClient client =
+                new OpenAIClient(config("sk-test", "https://api.example.test/v1"), (runtimeConfig, requestParams) -> {
                     capturedParams.set(requestParams);
                     return chatCompletion("{\"device_type\":\"router\"}");
                 });
@@ -77,30 +81,24 @@ class OpenAIClientTest {
         assertEquals(0.25d, params.temperature().orElseThrow());
         assertEquals(9L, maxTokens(params).orElseThrow());
         assertTrue(params.responseFormat().orElseThrow().isJsonObject());
-        assertEquals("json_object", params.responseFormat().orElseThrow().asJsonObject()._type().convert(String.class));
+        assertEquals(
+                "json_object",
+                params.responseFormat().orElseThrow().asJsonObject()._type().convert(String.class));
         assertEquals(3, params.messages().size());
         assertTrue(params.messages().get(0).isSystem());
         assertTrue(params.messages().get(0).asSystem().content().asText().contains("JSON"));
         assertTrue(params.messages().get(1).isSystem());
         assertTrue(params.messages().get(1).asSystem().content().asText().contains("device_type"));
         assertTrue(params.messages().get(2).isUser());
-        assertEquals("extract router", params.messages().get(2).asUser().content().asText());
+        assertEquals(
+                "extract router", params.messages().get(2).asUser().content().asText());
     }
 
     @Test
     void structuredFallsBackToConfigTemperatureAndMaxTokens() {
         AtomicReference<ChatCompletionCreateParams> capturedParams = new AtomicReference<>();
         LLMClientConfig config = new LLMClientConfig(
-                "openai",
-                "gpt-4o-mini",
-                "sk-test",
-                "https://api.example.test/v1",
-                10,
-                128,
-                0.4d,
-                null,
-                300,
-                100);
+                "openai", "gpt-4o-mini", "sk-test", "https://api.example.test/v1", 10, 128, 0.4d, null, 300, 100);
         OpenAIClient client = new OpenAIClient(config, (runtimeConfig, requestParams) -> {
             capturedParams.set(requestParams);
             return chatCompletion("{}");
@@ -115,10 +113,11 @@ class OpenAIClientTest {
     @Test
     void structuredOmitsTemperatureAndMaxTokensWhenUnset() {
         AtomicReference<ChatCompletionCreateParams> capturedParams = new AtomicReference<>();
-        OpenAIClient client = new OpenAIClient(config("sk-test", "https://api.example.test/v1"), (runtimeConfig, requestParams) -> {
-            capturedParams.set(requestParams);
-            return chatCompletion("{}");
-        });
+        OpenAIClient client =
+                new OpenAIClient(config("sk-test", "https://api.example.test/v1"), (runtimeConfig, requestParams) -> {
+                    capturedParams.set(requestParams);
+                    return chatCompletion("{}");
+                });
 
         client.structured(List.of(Map.of("role", "user", "content", "extract")), Map.of("type", "object"), null, null);
 
@@ -128,17 +127,15 @@ class OpenAIClientTest {
 
     @Test
     void wrapsProviderFailuresAsRuntimeErrors() {
-        OpenAIClient client = new OpenAIClient(
-                config("sk-test", "https://api.example.test/v1"),
-                (runtimeConfig, requestParams) -> {
+        OpenAIClient client =
+                new OpenAIClient(config("sk-test", "https://api.example.test/v1"), (runtimeConfig, requestParams) -> {
                     throw new IllegalStateException("provider unavailable");
                 });
 
-        LLMRuntimeError error = assertThrows(LLMRuntimeError.class, () -> client.structured(
-                List.of(Map.of("role", "user", "content", "extract")),
-                Map.of("type", "object"),
-                null,
-                null));
+        LLMRuntimeError error = assertThrows(
+                LLMRuntimeError.class,
+                () -> client.structured(
+                        List.of(Map.of("role", "user", "content", "extract")), Map.of("type", "object"), null, null));
 
         assertTrue(error.getMessage().contains("openai"));
         assertInstanceOf(IllegalStateException.class, error.getCause());
@@ -150,11 +147,59 @@ class OpenAIClientTest {
                 config("sk-test", "https://api.example.test/v1"),
                 (runtimeConfig, requestParams) -> chatCompletion("[\"not-object\"]"));
 
-        assertThrows(LLMRuntimeError.class, () -> client.structured(
-                List.of(Map.of("role", "user", "content", "extract")),
-                Map.of("type", "object"),
-                null,
-                null));
+        assertThrows(
+                LLMRuntimeError.class,
+                () -> client.structured(
+                        List.of(Map.of("role", "user", "content", "extract")), Map.of("type", "object"), null, null));
+    }
+
+    @Test
+    void concurrentStructuredCallsAllSucceed() throws Exception {
+        AtomicInteger invocations = new AtomicInteger();
+        AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+        OpenAIClient client =
+                new OpenAIClient(config("sk-test", "https://api.example.test/v1"), (runtimeConfig, requestParams) -> {
+                    if (invocations.getAndIncrement() == 0) {
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException error) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException(error);
+                        }
+                    }
+                    return chatCompletion("{}");
+                });
+
+        int threadCount = 8;
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        List<java.util.concurrent.Future<?>> futures = new ArrayList<>();
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(pool.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                        client.structured(
+                                List.of(Map.of("role", "user", "content", "hi")), Map.of("type", "object"), null, null);
+                    } catch (Throwable error) {
+                        firstFailure.compareAndSet(null, error);
+                    }
+                    return null;
+                }));
+            }
+            ready.await();
+            start.countDown();
+            for (java.util.concurrent.Future<?> future : futures) {
+                future.get();
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertEquals(null, firstFailure.get());
+        assertEquals(8, invocations.get());
     }
 
     private static LLMClientConfig config(String apiKey, String baseUrl) {

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/analysis/impl/DefaultStructuredPromptSlotValueExtractor.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/analysis/impl/DefaultStructuredPromptSlotValueExtractor.java
@@ -1,13 +1,14 @@
 package net.openan.a2at.sdk.prompt.analysis.impl;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.model.PromptMessage;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -25,6 +26,10 @@ import net.openan.a2at.sdk.prompt.resources.model.PromptSlotSchema;
 public final class DefaultStructuredPromptSlotValueExtractor implements PromptSlotValueExtractor {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final ObjectWriter SLOT_SERIALIZER = new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter();
 
     private final LLMClient llmClient;
 
@@ -67,11 +72,17 @@ public final class DefaultStructuredPromptSlotValueExtractor implements PromptSl
     }
 
     private List<PromptMessage> buildMessages(
-            Object userInput, String scenarioCode, String language, PromptSlotSchema slotSchema,
+            Object userInput,
+            String scenarioCode,
+            String language,
+            PromptSlotSchema slotSchema,
             Map<String, Object> dataSchema) {
-        String slotLines = slotSchema.slotDefinitions().stream()
-                .map(slot -> "- name: " + slot.name() + "\n  required: " + slot.required())
-                .collect(Collectors.joining("\n"));
+        String slotLines;
+        try {
+            slotLines = SLOT_SERIALIZER.writeValueAsString(slotSchema.slotDefinitions());
+        } catch (JsonProcessingException error) {
+            throw new A2ATError("Failed to serialize slot definitions.", error);
+        }
         String content = userPrompt
                 + "\n\n[scenario_code]\n"
                 + scenarioCode

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/model/PromptSlotDefinition.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/model/PromptSlotDefinition.java
@@ -14,6 +14,7 @@ import java.util.List;
  * @param maximum optional numeric maximum
  * @param allowedValues optional enum constraint
  * @param description slot description
+ * @param valueConstraint human-readable value constraint description
  * @since 2026-06
  */
 public record PromptSlotDefinition(
@@ -24,4 +25,5 @@ public record PromptSlotDefinition(
         @JsonProperty("minimum") Double minimum,
         @JsonProperty("maximum") Double maximum,
         @JsonProperty("enum") List<String> allowedValues,
-        @JsonProperty("description") String description) {}
+        @JsonProperty("description") String description,
+        @JsonProperty("x-a2at-value-constraint") String valueConstraint) {}

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/model/PromptSlotJsonProperty.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/model/PromptSlotJsonProperty.java
@@ -1,6 +1,5 @@
 package net.openan.a2at.sdk.prompt.resources.model;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
@@ -14,6 +13,7 @@ import java.util.List;
  * @param maximum optional numeric maximum
  * @param allowedValues optional enum values
  * @param description slot description
+ * @param valueConstraint human-readable value constraint description
  * @since 2026-06
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -23,4 +23,5 @@ public record PromptSlotJsonProperty(
         @JsonProperty("minimum") Double minimum,
         @JsonProperty("maximum") Double maximum,
         @JsonProperty("enum") List<String> allowedValues,
-        @JsonAlias({"description", "x-a2at-value-constraint"}) @JsonProperty("description") String description) {}
+        @JsonProperty("description") String description,
+        @JsonProperty("x-a2at-value-constraint") String valueConstraint) {}

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/model/PromptSlotJsonSchema.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/resources/model/PromptSlotJsonSchema.java
@@ -34,7 +34,15 @@ public record PromptSlotJsonSchema(
             PromptSlotJsonProperty property = entry.getValue();
             if (property == null) {
                 slotDefinitions.add(new PromptSlotDefinition(
-                        entry.getKey(), requiredSlots.contains(entry.getKey()), null, null, null, null, null, null));
+                        entry.getKey(),
+                        requiredSlots.contains(entry.getKey()),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null));
                 continue;
             }
             slotDefinitions.add(new PromptSlotDefinition(
@@ -45,7 +53,8 @@ public record PromptSlotJsonSchema(
                     property.minimum(),
                     property.maximum(),
                     property.allowedValues(),
-                    property.description()));
+                    property.description(),
+                    property.valueConstraint()));
         }
         return new PromptSlotSchema(scenarioCode, List.copyOf(slotDefinitions));
     }

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
@@ -18,6 +18,7 @@ import net.openan.a2at.sdk.core.validation.SemanticValidator;
 import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ValidationResult;
 import net.openan.a2at.sdk.llm.LLMClient;
+import net.openan.a2at.sdk.llm.LLMError;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.prompt.resources.loader.PromptResourceAccess;
 import org.jspecify.annotations.NonNull;
@@ -56,8 +57,8 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
             @NonNull String language,
             @NonNull PromptResourceAccess promptResourceAccess) {
         this.llmClient = llmClient;
-        this.systemPrompt = promptResourceAccess.loadPrompt("content_validation", language, "system");
-        this.userPromptTemplate = promptResourceAccess.loadPrompt("content_validation", language, "user");
+        this.systemPrompt = promptResourceAccess.loadPrompt("content_validation", language, "system.md");
+        this.userPromptTemplate = promptResourceAccess.loadPrompt("content_validation", language, "user.md");
         this.jsonValueParser = new JacksonJsonValueParser();
     }
 
@@ -75,7 +76,15 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
         List<Map<String, String>> messages = toStructuredMessages(
                 List.of(new PromptMessage("system", systemPrompt), new PromptMessage("user", userPrompt)));
 
-        LLMResponse response = llmClient.structured(messages, outputSchema, null, null);
+        LLMResponse response;
+        try {
+            response = llmClient.structured(messages, outputSchema, null, null);
+        } catch (LLMError error) {
+            throw new ContentValidationException(
+                    A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR,
+                    "Semantic validation LLM invocation failed: " + error.getMessage(),
+                    error);
+        }
         Map<String, Object> parsed;
         try {
             parsed = jsonValueParser.parseObject(response.content());

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/analysis/impl/DefaultStructuredPromptSlotValueExtractorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/analysis/impl/DefaultStructuredPromptSlotValueExtractorTest.java
@@ -17,9 +17,8 @@ class DefaultStructuredPromptSlotValueExtractorTest {
 
     @Test
     void extractSlotsParsesFormattedStructuredJsonPayload() {
-        RecordingClient llmClient =
-                new RecordingClient(
-                        """
+        RecordingClient llmClient = new RecordingClient(
+                """
                 {
                   "slots": {
                     "site": "Site A",
@@ -35,10 +34,11 @@ class DefaultStructuredPromptSlotValueExtractorTest {
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
                         List.of(
-                                new PromptSlotDefinition("site", true, "string", null, null, null, null, null),
+                                new PromptSlotDefinition("site", true, "string", null, null, null, null, null, null),
                                 new PromptSlotDefinition(
-                                        "additional_notes", false, "string", null, null, null, null, null),
-                                new PromptSlotDefinition("limit", false, "integer", null, 1.0d, 10.0d, null, null),
+                                        "additional_notes", false, "string", null, null, null, null, null, null),
+                                new PromptSlotDefinition(
+                                        "limit", false, "integer", null, 1.0d, 10.0d, null, null, null),
                                 new PromptSlotDefinition(
                                         "severity",
                                         false,
@@ -47,6 +47,7 @@ class DefaultStructuredPromptSlotValueExtractorTest {
                                         null,
                                         null,
                                         List.of("low", "medium", "high"),
+                                        null,
                                         null))),
                 "Extract slots from the input.",
                 "Return slots as JSON.");
@@ -66,9 +67,8 @@ class DefaultStructuredPromptSlotValueExtractorTest {
 
     @Test
     void extractSlotsPreservesSlotTextContainingClosingBrace() {
-        RecordingClient llmClient =
-                new RecordingClient(
-                        """
+        RecordingClient llmClient = new RecordingClient(
+                """
                 {
                   "slots": {
                     "site": "Site A",
@@ -82,9 +82,9 @@ class DefaultStructuredPromptSlotValueExtractorTest {
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
                         List.of(
-                                new PromptSlotDefinition("site", true, "string", null, null, null, null, null),
+                                new PromptSlotDefinition("site", true, "string", null, null, null, null, null, null),
                                 new PromptSlotDefinition(
-                                        "additional_notes", false, "string", null, null, null, null, null))),
+                                        "additional_notes", false, "string", null, null, null, null, null, null))),
                 "Extract slots from the input.",
                 "Return slots as JSON.");
 
@@ -97,9 +97,8 @@ class DefaultStructuredPromptSlotValueExtractorTest {
 
     @Test
     void should_injectDataSchemaSection_When_schemaIsProvided() {
-        RecordingClient llmClient =
-                new RecordingClient(
-                        """
+        RecordingClient llmClient = new RecordingClient(
+                """
                 {
                   "slots": {
                     "site": "Site A"
@@ -111,7 +110,7 @@ class DefaultStructuredPromptSlotValueExtractorTest {
                 llmClient,
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
-                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null))),
+                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null, null))),
                 "Extract slots from the input.",
                 "Return slots as JSON.");
 
@@ -129,9 +128,8 @@ class DefaultStructuredPromptSlotValueExtractorTest {
 
     @Test
     void should_notIncludeDataSchemaSection_When_schemaIsNull() {
-        RecordingClient llmClient =
-                new RecordingClient(
-                        """
+        RecordingClient llmClient = new RecordingClient(
+                """
                 {
                   "slots": {
                     "site": "Site A"
@@ -143,7 +141,7 @@ class DefaultStructuredPromptSlotValueExtractorTest {
                 llmClient,
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
-                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null))),
+                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null, null))),
                 "Extract slots from the input.",
                 "Return slots as JSON.");
 
@@ -155,9 +153,8 @@ class DefaultStructuredPromptSlotValueExtractorTest {
 
     @Test
     void should_notIncludeDataSchemaSection_When_schemaIsEmpty() {
-        RecordingClient llmClient =
-                new RecordingClient(
-                        """
+        RecordingClient llmClient = new RecordingClient(
+                """
                 {
                   "slots": {
                     "site": "Site A"
@@ -169,7 +166,7 @@ class DefaultStructuredPromptSlotValueExtractorTest {
                 llmClient,
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
-                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null))),
+                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null, null))),
                 "Extract slots from the input.",
                 "Return slots as JSON.");
 
@@ -180,10 +177,9 @@ class DefaultStructuredPromptSlotValueExtractorTest {
     }
 
     @Test
-    void defaultExtractSlotsWithSchemaDelegatesToThreeArg() {
-        RecordingClient llmClient =
-                new RecordingClient(
-                        """
+    void buildMessagesIncludesFullSlotDescriptions() {
+        RecordingClient llmClient = new RecordingClient(
+                """
                 {
                   "slots": {
                     "site": "Site A"
@@ -195,15 +191,60 @@ class DefaultStructuredPromptSlotValueExtractorTest {
                 llmClient,
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
-                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null))),
+                        List.of(new PromptSlotDefinition(
+                                "site",
+                                true,
+                                "string",
+                                null,
+                                null,
+                                null,
+                                List.of("Site A", "Site B"),
+                                "The target site name",
+                                "The site must be a physical location"))),
                 "Extract slots from the input.",
                 "Return slots as JSON.");
 
-        PromptSlotValueExtractor lambdaExtractor = (input, code, lang) ->
-                extractor.extractSlots(input, code, lang);
+        extractor.extractSlots("Analyze Site A.", "energy-saving", "en-US");
 
-        StructuredSlotExtractionResult result = lambdaExtractor.extractSlots(
-                "Analyze Site A.", "energy-saving", "en-US", Map.of("site", "desc"));
+        String userMessage = llmClient.lastUserContent();
+        assertTrue(userMessage.contains("[slots]"));
+        assertTrue(userMessage.contains("\"name\""));
+        assertTrue(userMessage.contains("\"site\""));
+        assertTrue(userMessage.contains("\"required\""));
+        assertTrue(userMessage.contains("\"type\""));
+        assertTrue(userMessage.contains("\"string\""));
+        assertTrue(userMessage.contains("\"description\""));
+        assertTrue(userMessage.contains("\"The target site name\""));
+        assertTrue(userMessage.contains("\"enum\""));
+        assertTrue(userMessage.contains("\"Site A\""));
+        assertTrue(userMessage.contains("\"x-a2at-value-constraint\""));
+        assertTrue(userMessage.contains("\"The site must be a physical location\""));
+        assertTrue(userMessage.contains("["));
+    }
+
+    @Test
+    void defaultExtractSlotsWithSchemaDelegatesToThreeArg() {
+        RecordingClient llmClient = new RecordingClient(
+                """
+                {
+                  "slots": {
+                    "site": "Site A"
+                  },
+                  "slot_errors": []
+                }
+                """);
+        DefaultStructuredPromptSlotValueExtractor extractor = new DefaultStructuredPromptSlotValueExtractor(
+                llmClient,
+                (scenarioCode, language) -> new PromptSlotSchema(
+                        scenarioCode,
+                        List.of(new PromptSlotDefinition("site", true, "string", null, null, null, null, null, null))),
+                "Extract slots from the input.",
+                "Return slots as JSON.");
+
+        PromptSlotValueExtractor lambdaExtractor = (input, code, lang) -> extractor.extractSlots(input, code, lang);
+
+        StructuredSlotExtractionResult result =
+                lambdaExtractor.extractSlots("Analyze Site A.", "energy-saving", "en-US", Map.of("site", "desc"));
 
         String userMessage = llmClient.lastUserContent();
         assertFalse(userMessage.contains("[data_schema]"));

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptLoadersTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/resources/loader/ClasspathPromptLoadersTest.java
@@ -73,7 +73,7 @@ class ClasspathPromptLoadersTest {
                 schema.slotDefinitions().get(1).allowedValues());
         assertEquals(
                 "Business priority from 1 (highest urgency) to 5 (lowest urgency)",
-                schema.slotDefinitions().get(1).description());
+                schema.slotDefinitions().get(1).valueConstraint());
     }
 
     @Test

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/resources/loader/LocalFilePromptLoadersTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/resources/loader/LocalFilePromptLoadersTest.java
@@ -8,8 +8,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.exception.A2ATError;
+import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.prompt.resources.model.PromptSlotSchema;
 import net.openan.a2at.sdk.prompt.resources.model.ScenarioDefinition;
 import org.junit.jupiter.api.Test;
@@ -130,7 +130,7 @@ class LocalFilePromptLoadersTest {
         assertEquals(
                 List.of("1", "2", "3", "4", "5"),
                 schema.slotDefinitions().get(1).allowedValues());
-        assertEquals("Severity from 1 to 5", schema.slotDefinitions().get(1).description());
+        assertEquals("Severity from 1 to 5", schema.slotDefinitions().get(1).valueConstraint());
         assertEquals("note", schema.slotDefinitions().get(2).name());
     }
 
@@ -141,8 +141,9 @@ class LocalFilePromptLoadersTest {
                         .loadTemplate("incident_triage", "en"));
 
         String expected = (promptRootDir.resolve("templates").toString()
-                + "/*/network-layer/incident_triage/v1/en/template.md"
-                + " (or the layout without the network-layer segment)").replace('\\', '/');
+                        + "/*/network-layer/incident_triage/v1/en/template.md"
+                        + " (or the layout without the network-layer segment)")
+                .replace('\\', '/');
         assertEquals(expected, exception.resourcePath().replace('\\', '/'));
     }
 
@@ -159,9 +160,8 @@ class LocalFilePromptLoadersTest {
                         .resolve("slot.json"),
                 "{ \"required\": [\"severity\"], \"properties\": ");
 
-        A2ATError exception =
-                assertThrows(A2ATError.class, () -> new LocalFilePromptSlotSchemaLoader(promptRootDir)
-                        .loadSlotSchema("incident_triage", "en"));
+        A2ATError exception = assertThrows(A2ATError.class, () -> new LocalFilePromptSlotSchemaLoader(promptRootDir)
+                .loadSlotSchema("incident_triage", "en"));
 
         assertTrue(exception.getMessage().startsWith("Failed to read slot schema resource: "));
     }

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
@@ -1,0 +1,239 @@
+package net.openan.a2at.sdk.prompt.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
+import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
+import net.openan.a2at.sdk.core.model.FilledParamData;
+import net.openan.a2at.sdk.core.model.PromptRuntimeConfig;
+import net.openan.a2at.sdk.core.validation.ContentValidationException;
+import net.openan.a2at.sdk.core.validation.TemplateReference;
+import net.openan.a2at.sdk.core.validation.ValidationPipeline;
+import net.openan.a2at.sdk.core.validation.ValidationResult;
+import net.openan.a2at.sdk.llm.LLMClient;
+import net.openan.a2at.sdk.llm.LLMResponse;
+import net.openan.a2at.sdk.llm.LLMRuntimeError;
+import net.openan.a2at.sdk.prompt.resources.loader.PromptResourceAccess;
+import org.junit.jupiter.api.Test;
+
+class DefaultSemanticValidatorTest {
+
+    @Test
+    void validatesEnUSPromptAndExtractsParams() {
+        PromptResourceAccess resources =
+                PromptResourceAccess.create(new PromptRuntimeConfig("en-US", "classpath", null));
+
+        RecordingClient llmClient = new RecordingClient(
+                """
+                {
+                  "semantic_verdict": true,
+                  "errors": [],
+                  "params": {"site": "Site A"}
+                }
+                """);
+
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(llmClient, "en-US", resources);
+
+        TemplateReference reference = new TemplateReference() {
+            @Override
+            public String uri() {
+                return "Task-T/v1/energy-saving";
+            }
+
+            @Override
+            public String language() {
+                return "en-US";
+            }
+
+            @Override
+            public String extensionPrefix() {
+                return "Task-T";
+            }
+        };
+
+        ValidationResult result = validator.validate("Check Site A power usage.", Map.of("type", "object"), reference);
+
+        assertTrue(result.verdict());
+        assertEquals(Map.of("site", "Site A"), result.params());
+
+        String expectedSystemPrompt = resources.loadPrompt("content_validation", "en-US", "system.md");
+        assertEquals(expectedSystemPrompt, llmClient.lastSystemContent());
+    }
+
+    @Test
+    void loadsZhCnResourcesWithoutException() {
+        PromptResourceAccess resources =
+                PromptResourceAccess.create(new PromptRuntimeConfig("zh-CN", "classpath", null));
+
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(null, "zh-CN", resources);
+
+        assertNotNull(validator);
+    }
+
+    @Test
+    void throwsResourceNotFoundExceptionForMissingLanguage() {
+        PromptResourceAccess resources =
+                PromptResourceAccess.create(new PromptRuntimeConfig("fr-FR", "classpath", null));
+
+        ResourceNotFoundException exception = assertThrows(
+                ResourceNotFoundException.class, () -> new DefaultSemanticValidator(null, "fr-FR", resources));
+
+        assertTrue(exception.resourcePath().contains("content_validation"));
+    }
+
+    @Test
+    void validateRetriesLlmInfrastructureErrorThroughPipeline() {
+        PromptResourceAccess resources =
+                PromptResourceAccess.create(new PromptRuntimeConfig("en-US", "classpath", null));
+
+        FlakyClient flakyClient = new FlakyClient(
+                1,
+                """
+                {
+                  "semantic_verdict": true,
+                  "errors": [],
+                  "params": {"site": "Site A"}
+                }
+                """);
+
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(flakyClient, "en-US", resources);
+
+        ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
+
+        TemplateReference reference = new TemplateReference() {
+            @Override
+            public String uri() {
+                return "Task-T/v1/energy-saving";
+            }
+
+            @Override
+            public String language() {
+                return "en-US";
+            }
+
+            @Override
+            public String extensionPrefix() {
+                return "Task-T";
+            }
+        };
+
+        FilledParamData result = pipeline.validate("Check Site A power usage.", Map.of("type", "object"), reference);
+
+        assertEquals(Map.of("site", "Site A"), result.data());
+        assertEquals(2, flakyClient.invocations());
+    }
+
+    @Test
+    void validateExhaustsRetriesAndWrapsLlmError() {
+        PromptResourceAccess resources =
+                PromptResourceAccess.create(new PromptRuntimeConfig("en-US", "classpath", null));
+
+        FlakyClient flakyClient = new FlakyClient(
+                Integer.MAX_VALUE,
+                """
+                {
+                  "semantic_verdict": true,
+                  "errors": [],
+                  "params": {}
+                }
+                """);
+
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(flakyClient, "en-US", resources);
+
+        ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 3);
+
+        TemplateReference reference = new TemplateReference() {
+            @Override
+            public String uri() {
+                return "Task-T/v1/energy-saving";
+            }
+
+            @Override
+            public String language() {
+                return "en-US";
+            }
+
+            @Override
+            public String extensionPrefix() {
+                return "Task-T";
+            }
+        };
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> pipeline.validate("Check Site A power usage.", Map.of("type", "object"), reference));
+
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.code());
+        assertInstanceOf(LLMRuntimeError.class, exception.getCause().getCause());
+        assertEquals(3, flakyClient.invocations());
+    }
+
+    private static final class RecordingClient implements LLMClient {
+
+        private final String payload;
+
+        private List<Map<String, String>> lastMessages;
+
+        private RecordingClient(String payload) {
+            this.payload = payload;
+        }
+
+        @Override
+        public LLMResponse structured(
+                List<Map<String, String>> messages,
+                Map<String, Object> jsonSchema,
+                Double temperature,
+                Integer maxTokens) {
+            this.lastMessages = messages;
+            return new LLMResponse(payload, "test-model", Map.of("prompt_tokens", 1, "completion_tokens", 1), Map.of());
+        }
+
+        String lastSystemContent() {
+            for (Map<String, String> message : lastMessages) {
+                if ("system".equals(message.get("role"))) {
+                    return message.get("content");
+                }
+            }
+            return "";
+        }
+    }
+
+    private static final class FlakyClient implements LLMClient {
+
+        private final int failuresToSimulate;
+
+        private final String successPayload;
+
+        private final AtomicInteger counter = new AtomicInteger(0);
+
+        private FlakyClient(int failuresToSimulate, String successPayload) {
+            this.failuresToSimulate = failuresToSimulate;
+            this.successPayload = successPayload;
+        }
+
+        @Override
+        public LLMResponse structured(
+                List<Map<String, String>> messages,
+                Map<String, Object> jsonSchema,
+                Double temperature,
+                Integer maxTokens) {
+            int invocation = counter.incrementAndGet();
+            if (invocation <= failuresToSimulate) {
+                throw new LLMRuntimeError("network timeout");
+            }
+            return new LLMResponse(
+                    successPayload, "test-model", Map.of("prompt_tokens", 1, "completion_tokens", 1), Map.of());
+        }
+
+        int invocations() {
+            return counter.get();
+        }
+    }
+}

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
@@ -13,8 +13,8 @@ import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.PromptRuntimeConfig;
+import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
-import net.openan.a2at.sdk.core.validation.TemplateReference;
 import net.openan.a2at.sdk.core.validation.ValidationPipeline;
 import net.openan.a2at.sdk.core.validation.ValidationResult;
 import net.openan.a2at.sdk.llm.LLMClient;
@@ -41,24 +41,8 @@ class DefaultSemanticValidatorTest {
 
         DefaultSemanticValidator validator = new DefaultSemanticValidator(llmClient, "en-US", resources);
 
-        TemplateReference reference = new TemplateReference() {
-            @Override
-            public String uri() {
-                return "Task-T/v1/energy-saving";
-            }
-
-            @Override
-            public String language() {
-                return "en-US";
-            }
-
-            @Override
-            public String extensionPrefix() {
-                return "Task-T";
-            }
-        };
-
-        ValidationResult result = validator.validate("Check Site A power usage.", Map.of("type", "object"), reference);
+        ValidationResult result = validator.validate(
+                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"));
 
         assertTrue(result.verdict());
         assertEquals(Map.of("site", "Site A"), result.params());
@@ -107,24 +91,8 @@ class DefaultSemanticValidatorTest {
 
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
 
-        TemplateReference reference = new TemplateReference() {
-            @Override
-            public String uri() {
-                return "Task-T/v1/energy-saving";
-            }
-
-            @Override
-            public String language() {
-                return "en-US";
-            }
-
-            @Override
-            public String extensionPrefix() {
-                return "Task-T";
-            }
-        };
-
-        FilledParamData result = pipeline.validate("Check Site A power usage.", Map.of("type", "object"), reference);
+        FilledParamData result = pipeline.validate(
+                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"));
 
         assertEquals(Map.of("site", "Site A"), result.data());
         assertEquals(2, flakyClient.invocations());
@@ -149,28 +117,12 @@ class DefaultSemanticValidatorTest {
 
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 3);
 
-        TemplateReference reference = new TemplateReference() {
-            @Override
-            public String uri() {
-                return "Task-T/v1/energy-saving";
-            }
-
-            @Override
-            public String language() {
-                return "en-US";
-            }
-
-            @Override
-            public String extensionPrefix() {
-                return "Task-T";
-            }
-        };
-
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
-                () -> pipeline.validate("Check Site A power usage.", Map.of("type", "object"), reference));
+                () -> pipeline.validate(
+                        "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving")));
 
-        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.code());
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertInstanceOf(LLMRuntimeError.class, exception.getCause().getCause());
         assertEquals(3, flakyClient.invocations());
     }

--- a/a2a-t-resources/src/main/resources/prompt_resources/prompts/slot_extraction/en-US/system.md
+++ b/a2a-t-resources/src/main/resources/prompt_resources/prompts/slot_extraction/en-US/system.md
@@ -26,7 +26,7 @@ Return a JSON object with the following structure:
 ## Error Reporting Rules
 Report errors ONLY in `slot_errors` array with the following codes:
 - **missing_input**: Required slot cannot be extracted from input (value set to null)
-- **invalid_value**: Extracted value violates the slot's value_constraint (value set to null)
+- **invalid_value**: Extracted value violates the slot's constraints (enum, pattern, minimum, maximum, or x-a2at-value-constraint) (value set to null)
 
 ### Required vs Optional Slots
 - **Required slot missing**: Set value to null, add error with code="missing_input"
@@ -35,7 +35,7 @@ Report errors ONLY in `slot_errors` array with the following codes:
 
 ## Extraction Strategy
 1. Analyze the user input to identify explicit slot values
-2. Cross-reference with slot schema for value_constraint validation
+2. Cross-reference with slot schema for constraint validation (enum, pattern, minimum, maximum, x-a2at-value-constraint)
 3. Use template context to understand slot semantics and expected format
 4. For list-type slots, extract as JSON array string (e.g. "[\"item1\", \"item2\"]")
 

--- a/a2a-t-resources/src/main/resources/prompt_resources/prompts/slot_extraction/zh-CN/system.md
+++ b/a2a-t-resources/src/main/resources/prompt_resources/prompts/slot_extraction/zh-CN/system.md
@@ -30,7 +30,7 @@
 4. 若输入中出现显式字段锚点，应优先按字段锚点后的内容映射到对应 slot。
 5. 显式字段锚点可以表现为 slot 名称本身，或与 slot `description` 语义明确对应的字段标签，并常见于“字段名 + 为 / 是 / ： / : / 包括 / 包含”等结构，以及分段式、列表式字段标签。
 6. 对显式字段锚点后的值，即使它与场景默认语义、模板固定文案或其他上下文重复，也不要省略。
-7. 仅当某内容与 slot 的 `description` 或 `value_constraint` 明确对应时才提取。
+7. 仅当某内容与 slot 的 `description` 或 `x-a2at-value-constraint` 明确对应时才提取。
 8. 同一 slot 下若有多个明确并列约束，应尽量完整保留。
 9. 拿不准时返回 `null`，不要基于常识补值或猜测。
 10. 若同一 slot 的信息分散在多个子句中，且这些子句都在表达用户要写入任务的正向约束，应合并保留，不要只保留最后出现的一项。
@@ -40,7 +40,7 @@
 ## 错误报告规则
 仅在 `slot_errors` 数组中报告错误，使用以下错误码：
 - **missing_input**：无法从输入中提取必填 slot（值设为 null）
-- **invalid_value**：提取的值违反 slot 的 value_constraint（值设为 null）
+- **invalid_value**：提取的值违反 slot 的约束（enum、pattern、minimum、maximum 或 x-a2at-value-constraint）（值设为 null）
 
 ### 必填 vs 可选 Slot
 - **必填 slot 缺失**：值设为 null，添加错误 code="missing_input"

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/validation/LlmBackedPromptSemanticValidator.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/validation/LlmBackedPromptSemanticValidator.java
@@ -1,5 +1,6 @@
 package net.openan.a2at.sdk.server.validation;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,7 +23,8 @@ import net.openan.a2at.sdk.server.model.ProcessedPromptMetadata;
  */
 public final class LlmBackedPromptSemanticValidator implements ServerPromptSemanticValidator {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
     private final LLMClient llmClient;
 
@@ -131,7 +133,9 @@ public final class LlmBackedPromptSemanticValidator implements ServerPromptSeman
             return Optional.ofNullable(response).orElseGet(Map::of);
         } catch (JsonProcessingException error) {
             throw new PromptComplianceCheckException(
-                    A2ATErrorCodes.SLOT_VALIDATION_ERROR, "semantic validation returned invalid JSON", "slot_validation");
+                    A2ATErrorCodes.SLOT_VALIDATION_ERROR,
+                            "semantic validation returned invalid JSON",
+                            "slot_validation");
         }
     }
 

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/validation/LlmBackedPromptSemanticValidator.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/validation/LlmBackedPromptSemanticValidator.java
@@ -111,13 +111,13 @@ public final class LlmBackedPromptSemanticValidator implements ServerPromptSeman
 
     private void validateResponse(String payload) {
         Map<String, Object> response = parseResponse(payload);
-        Object passedValue = response.get("passed");
-        Object errorsValue = response.get("errors");
-        if (Boolean.TRUE.equals(passedValue) && errorsValue instanceof List<?>) {
+        boolean passed = Boolean.TRUE.equals(response.get("passed"));
+        boolean hasErrors = response.get("errors") instanceof List<?> errors && !errors.isEmpty();
+        if (passed && !hasErrors) {
             return;
         }
 
-        Optional<String> message = extractFirstMessage(errorsValue);
+        Optional<String> message = extractFirstMessage(response.get("errors"));
         throw new PromptComplianceCheckException(
                 A2ATErrorCodes.SLOT_VALIDATION_ERROR,
                 message.filter(text -> !text.isBlank()).orElse("Slot semantic validation failed."),

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/metadata/LlmBackedPromptMetadataExtractorTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/metadata/LlmBackedPromptMetadataExtractorTest.java
@@ -27,12 +27,13 @@ class LlmBackedPromptMetadataExtractorTest {
 
     @Test
     void extractResolvesScenarioLoadsTemplateAndReturnsExtractedSlots() {
-        LLMClient llmClient =
-                new RecordingClient("{\"matched\":true,\"scenario_code\":\"subscribe-incident\",\"error_message\":null}");
-        PromptTemplateTextLoader templateLoader = (scenarioCode, language) ->
-                "## notification_topic\n{{notification_topic}}\n";
+        LLMClient llmClient = new RecordingClient(
+                "{\"matched\":true,\"scenario_code\":\"subscribe-incident\",\"error_message\":null}");
+        PromptTemplateTextLoader templateLoader =
+                (scenarioCode, language) -> "## notification_topic\n{{notification_topic}}\n";
         PromptSlotSchemaLoader slotSchemaLoader = (scenarioCode, language) -> new PromptSlotSchema(
-                scenarioCode, List.of(new PromptSlotDefinition(SLOT_NAME, true, "string", null, null, null, null, null)));
+                scenarioCode,
+                List.of(new PromptSlotDefinition(SLOT_NAME, true, "string", null, null, null, null, null, null)));
         PromptSlotValueExtractor slotValueExtractor = (userInput, scenarioCode, language) ->
                 new StructuredSlotExtractionResult(Map.of(SLOT_NAME, "Incident"), List.of());
         LlmBackedPromptMetadataExtractor extractor = new LlmBackedPromptMetadataExtractor(
@@ -78,8 +79,8 @@ class LlmBackedPromptMetadataExtractorTest {
 
     @Test
     void extractReturnsSlotValidationErrorWhenStructuredExtractionReportsSlotErrors() {
-        LLMClient llmClient =
-                new RecordingClient("{\"matched\":true,\"scenario_code\":\"subscribe-incident\",\"error_message\":null}");
+        LLMClient llmClient = new RecordingClient(
+                "{\"matched\":true,\"scenario_code\":\"subscribe-incident\",\"error_message\":null}");
         LlmBackedPromptMetadataExtractor extractor = new LlmBackedPromptMetadataExtractor(
                 new ScenarioRecognizer(llmClient),
                 List.of(new ScenarioDefinition(
@@ -90,7 +91,8 @@ class LlmBackedPromptMetadataExtractorTest {
                 (scenarioCode, language) -> "template",
                 (scenarioCode, language) -> new PromptSlotSchema(
                         scenarioCode,
-                        List.of(new PromptSlotDefinition(SLOT_NAME, true, "string", null, null, null, null, null))),
+                        List.of(new PromptSlotDefinition(
+                                SLOT_NAME, true, "string", null, null, null, null, null, null))),
                 (userInput, scenarioCode, language) -> new StructuredSlotExtractionResult(
                         Map.of(SLOT_NAME, ""),
                         List.of(new StructuredSlotValidationError(SLOT_NAME, "missing_input", "topic is missing"))));
@@ -104,8 +106,8 @@ class LlmBackedPromptMetadataExtractorTest {
 
     @Test
     void extractPropagatesTemplateLoadErrorsAsGenerationFailures() {
-        LLMClient llmClient =
-                new RecordingClient("{\"matched\":true,\"scenario_code\":\"subscribe-incident\",\"error_message\":null}");
+        LLMClient llmClient = new RecordingClient(
+                "{\"matched\":true,\"scenario_code\":\"subscribe-incident\",\"error_message\":null}");
         LlmBackedPromptMetadataExtractor extractor = new LlmBackedPromptMetadataExtractor(
                 new ScenarioRecognizer(llmClient),
                 List.of(new ScenarioDefinition(

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/validation/LlmBackedPromptSemanticValidatorTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/validation/LlmBackedPromptSemanticValidatorTest.java
@@ -20,7 +20,8 @@ class LlmBackedPromptSemanticValidatorTest {
     private static final String SLOT_NAME = "notification_topic";
 
     private static final PromptSlotSchemaLoader SLOT_SCHEMA_LOADER = (scenarioCode, language) -> new PromptSlotSchema(
-            scenarioCode, List.of(new PromptSlotDefinition(SLOT_NAME, true, "string", null, null, null, null, null)));
+            scenarioCode,
+            List.of(new PromptSlotDefinition(SLOT_NAME, true, "string", null, null, null, null, null, null)));
 
     @Test
     void validatePassesWhenSemanticValidatorApprovesSlots() {
@@ -60,9 +61,8 @@ class LlmBackedPromptSemanticValidatorTest {
 
     @Test
     void validateReturnsSlotValidationErrorWhenSemanticValidatorRejectsSlots() {
-        LLMClient llmClient = new RecordingClient(
-                "{\"passed\":false,\"errors\":[{\"slot_name\":\"notification_topic\","
-                        + "\"code\":\"semantic_mismatch\",\"message\":\"topic does not match\"}]}");
+        LLMClient llmClient = new RecordingClient("{\"passed\":false,\"errors\":[{\"slot_name\":\"notification_topic\","
+                + "\"code\":\"semantic_mismatch\",\"message\":\"topic does not match\"}]}");
         LlmBackedPromptSemanticValidator validator =
                 new LlmBackedPromptSemanticValidator(llmClient, SLOT_SCHEMA_LOADER, "semantic system", "semantic user");
 
@@ -82,9 +82,8 @@ class LlmBackedPromptSemanticValidatorTest {
 
     @Test
     void validateRejectsWhenPassedTrueButErrorsNonEmpty() {
-        LLMClient llmClient = new RecordingClient(
-                "{\"passed\":true,\"errors\":[{\"slot_name\":\"notification_topic\","
-                        + "\"code\":\"semantic_mismatch\",\"message\":\"topic does not match\"}]}");
+        LLMClient llmClient = new RecordingClient("{\"passed\":true,\"errors\":[{\"slot_name\":\"notification_topic\","
+                + "\"code\":\"semantic_mismatch\",\"message\":\"topic does not match\"}]}");
         LlmBackedPromptSemanticValidator validator =
                 new LlmBackedPromptSemanticValidator(llmClient, SLOT_SCHEMA_LOADER, "semantic system", "semantic user");
 

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/validation/LlmBackedPromptSemanticValidatorTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/validation/LlmBackedPromptSemanticValidatorTest.java
@@ -80,6 +80,76 @@ class LlmBackedPromptSemanticValidatorTest {
         assertEquals("slot_validation", error.getStage());
     }
 
+    @Test
+    void validateRejectsWhenPassedTrueButErrorsNonEmpty() {
+        LLMClient llmClient = new RecordingClient(
+                "{\"passed\":true,\"errors\":[{\"slot_name\":\"notification_topic\","
+                        + "\"code\":\"semantic_mismatch\",\"message\":\"topic does not match\"}]}");
+        LlmBackedPromptSemanticValidator validator =
+                new LlmBackedPromptSemanticValidator(llmClient, SLOT_SCHEMA_LOADER, "semantic system", "semantic user");
+
+        PromptComplianceCheckException error = assertThrows(
+                PromptComplianceCheckException.class,
+                () -> validator.validate(
+                        "## notification_topic\nIncident\n",
+                        new ProcessedPromptMetadata(
+                                "subscribe-incident",
+                                "zh-CN",
+                                "## notification_topic\n{{notification_topic}}\n",
+                                Map.of(SLOT_NAME, "Incident"))));
+
+        assertEquals("slot_validation_error", error.getCode());
+        assertEquals("slot_validation", error.getStage());
+        assertEquals("topic does not match", error.getMessage());
+    }
+
+    @Test
+    void validatePassesWhenPassedTrueAndErrorsMissing() {
+        LLMClient llmClient = new RecordingClient("{\"passed\":true}");
+        LlmBackedPromptSemanticValidator validator =
+                new LlmBackedPromptSemanticValidator(llmClient, SLOT_SCHEMA_LOADER, "semantic system", "semantic user");
+
+        assertDoesNotThrow(() -> validator.validate(
+                "## notification_topic\nIncident\n",
+                new ProcessedPromptMetadata(
+                        "subscribe-incident",
+                        "zh-CN",
+                        "## notification_topic\n{{notification_topic}}\n",
+                        Map.of(SLOT_NAME, "Incident"))));
+    }
+
+    @Test
+    void validatePassesWhenPassedTrueAndErrorsNull() {
+        LLMClient llmClient = new RecordingClient("{\"passed\":true,\"errors\":null}");
+        LlmBackedPromptSemanticValidator validator =
+                new LlmBackedPromptSemanticValidator(llmClient, SLOT_SCHEMA_LOADER, "semantic system", "semantic user");
+
+        assertDoesNotThrow(() -> validator.validate(
+                "## notification_topic\nIncident\n",
+                new ProcessedPromptMetadata(
+                        "subscribe-incident",
+                        "zh-CN",
+                        "## notification_topic\n{{notification_topic}}\n",
+                        Map.of(SLOT_NAME, "Incident"))));
+    }
+
+    @Test
+    void validateRejectsWhenPassedFalseWithEmptyErrors() {
+        LLMClient llmClient = new RecordingClient("{\"passed\":false,\"errors\":[]}");
+        LlmBackedPromptSemanticValidator validator =
+                new LlmBackedPromptSemanticValidator(llmClient, SLOT_SCHEMA_LOADER, "semantic system", "semantic user");
+
+        assertThrows(
+                PromptComplianceCheckException.class,
+                () -> validator.validate(
+                        "## notification_topic\nIncident\n",
+                        new ProcessedPromptMetadata(
+                                "subscribe-incident",
+                                "zh-CN",
+                                "## notification_topic\n{{notification_topic}}\n",
+                                Map.of(SLOT_NAME, "Incident"))));
+    }
+
     private static final class RecordingClient implements LLMClient {
         private final String payload;
 


### PR DESCRIPTION
## Summary

Code review fixes for the prompt validation pipeline (client/server facades) plus one contract tightening. Four independent commits, each TDD-driven (failing test first) and independently reviewed.

### Commits

1. **fix: load content_validation prompts with .md extension and wrap LLM errors as retryable** (`76b8fe5`)
   - `DefaultSemanticValidator` constructor passed `"system"`/`"user"` instead of `"system.md"`/`"user.md"` to `loadPrompt`, so constructing the validator always threw `ResourceNotFoundException` — `validateAndFillingTaskData/NotificationData/AuthData` were broken on first call.
   - `llmClient.structured()` was called without a catch: `LLMError` (all OpenAI transport failures) bypassed `RetryUtil` (which only retries `ContentValidationException` with `VALIDATION_LLM_INFRASTRUCTURE_ERROR`), so `maxAttempts` was silently ineffective for the most common failure mode. The call is now wrapped into the retryable exception type.

2. **fix: reject prompt compliance when semantic errors are non-empty** (`818cddb`)
   - `LlmBackedPromptSemanticValidator.validateResponse` passed when `passed=true` regardless of a non-empty `errors` list, and threw when `passed=true` with `errors` missing/null. New truth table is fail-closed: pass iff `passed=true` **and** errors absent/null/empty.

3. **fix: make OpenAIClient lazy sdkClient init thread-safe** (`e39206c`)
   - Unsynchronized lazy init of the OpenAI SDK client: duplicate client builds and a JMM visibility hazard. Fixed with a method-level `synchronized` getter (simple and sufficient: the lock guards a nanosecond null-check, never the HTTP call).

4. **fix: require data schema in FromDataWithSchema and send full slot descriptions to LLM** (`5aedd29`)
   - The three `*FromDataWithSchema` methods now treat null/empty `schema` as a caller contract violation: `NullPointerException` for null, `IllegalArgumentException` for empty — consistent with `templateUri` handling and with `A2ATError`'s documented philosophy (contract violations are NPE/IAE, outside the A2ATError tree). Facade entry points add `requireNonNull` for `data`/`schema`/`text`, mirroring `templateUri`.
   - The slot-extraction user prompt previously carried only slot `name`/`required` even though the system prompt instructs the LLM to judge against slot descriptions and constraints. The `[slots]` section now serializes the full slot definitions as pretty-printed JSON (name/required/type/pattern/minimum/maximum/enum/description/x-a2at-value-constraint, null fields omitted) — the same key vocabulary the bundled `slot.json` resources use.
   - Model fix: `x-a2at-value-constraint` was previously aliased onto `description` and silently overwritten by it (Jackson alias last-wins), dropping the constraint text for every bundled resource. It is now an independent `valueConstraint` field that flows to the LLM in both the extraction prompt and the server-side semantic-validation prompt.
   - `slot_extraction` system prompts (zh-CN/en-US) now reference the actual constraint keys (`enum`, `pattern`, `minimum`, `maximum`, `x-a2at-value-constraint`) instead of a non-existent `value_constraint` vocabulary.

### Design docs

`design/spec/client-spec.md` and `design/impl/*.md` updated first per repo rules (schema contract + error-code mapping + slot message format). Docs are not part of this PR (they live untracked in the author's workspace pending the design directory rollout).

## Verification

- TDD: every behavioral change landed with a failing test first; RED/GREEN evidence captured per commit.
- Full clean reactor runs green on top of latest `main` (rebased): `mvn -pl a2a-t-server -am clean test`, `-pl a2a-t-client -am clean test`, `-pl a2a-t-sample -am clean test` — all BUILD SUCCESS.
- No new spotless violations relative to the base for the files this PR touches.
- Known pre-existing main failures: none found once stale `target/classes` were cleaned (the `StandardTemplatesTest` drift seen initially was a local stale-build artifact, not reproducible on a clean tree).

## Notes for reviewers

- **Breaking contract change** (commit 4): callers passing null/empty schema to `FromDataWithSchema` previously got a silent LLM round-trip without schema guidance; they now get NPE/IAE. The javadoc previously said "optional", but the extraction step's design intent is schema-guided; docs and annotations (`@Nullable` → `@NonNull`) were updated to match.
- **LLM-visible input changes** (commit 4): the `[slots]` block switched from a hand-rolled YAML-ish format to JSON, and the previously-dropped constraint text now reaches the LLM. All tests mock the LLM, so extraction-quality impact cannot be proven by unit tests; a real-model spot check is planned post-merge (tracked internally).
- The `OpenAIClient` concurrency test exercises concurrent `structured()` dispatch through the executor seam; the lazy-init path itself is not covered by tests (its correctness rests on the trivial synchronized pattern — noted honestly).
