### PR TITLE
feat(llm): support A2AT_LLM_REASONING_EFFORT and guard against empty responses

### DIFF
--- a/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/LLMClientConfig.java
+++ b/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/LLMClientConfig.java
@@ -13,6 +13,7 @@ package net.openan.a2at.sdk.llm;
  * @param timeoutSeconds optional provider timeout in seconds
  * @param sessionMaxTotal reserved total session limit
  * @param sessionMaxPerProvider reserved per-provider session limit
+ * @param reasoningEffort optional reasoning effort for reasoning models (none/low/medium/high)
  * @since 2026-06
  */
 public record LLMClientConfig(
@@ -25,4 +26,5 @@ public record LLMClientConfig(
         Double temperature,
         Double timeoutSeconds,
         int sessionMaxTotal,
-        int sessionMaxPerProvider) {}
+        int sessionMaxPerProvider,
+        String reasoningEffort) {}

--- a/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/LLMClientConfig.java
+++ b/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/LLMClientConfig.java
@@ -13,7 +13,8 @@ package net.openan.a2at.sdk.llm;
  * @param timeoutSeconds optional provider timeout in seconds
  * @param sessionMaxTotal reserved total session limit
  * @param sessionMaxPerProvider reserved per-provider session limit
- * @param reasoningEffort optional reasoning effort for reasoning models (none/low/medium/high)
+ * @param reasoningEffort optional reasoning effort for reasoning models (none/minimal/low/medium/high/xhigh); null
+ *     leaves the parameter unset
  * @since 2026-06
  */
 public record LLMClientConfig(

--- a/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/LLMConfigLoader.java
+++ b/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/LLMConfigLoader.java
@@ -50,9 +50,8 @@ public final class LLMConfigLoader {
                 DEFAULT_SESSION_MAX_PER_PROVIDER,
                 MAX_SESSION_MAX_PER_PROVIDER);
         if (sessionMaxTotal < sessionMaxPerProvider) {
-            throw new LLMConfigError(
-                    "A2AT_LLM_SESSION_MAX_TOTAL must be greater than or equal to "
-                            + "A2AT_LLM_SESSION_MAX_PER_PROVIDER");
+            throw new LLMConfigError("A2AT_LLM_SESSION_MAX_TOTAL must be greater than or equal to "
+                    + "A2AT_LLM_SESSION_MAX_PER_PROVIDER");
         }
 
         OptionalInt maxTokens = parseOptionalInt(values.get("A2AT_LLM_MAX_TOKENS"), "A2AT_LLM_MAX_TOKENS");
@@ -70,7 +69,8 @@ public final class LLMConfigLoader {
                 temperature.isPresent() ? temperature.getAsDouble() : null,
                 timeoutSeconds.isPresent() ? timeoutSeconds.getAsDouble() : null,
                 sessionMaxTotal,
-                sessionMaxPerProvider);
+                sessionMaxPerProvider,
+                optional(values.get("A2AT_LLM_REASONING_EFFORT")).orElse(null));
     }
 
     private static String required(Map<String, String> values, String key) {

--- a/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/LLMConfigLoader.java
+++ b/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/LLMConfigLoader.java
@@ -26,6 +26,10 @@ public final class LLMConfigLoader {
 
     private static final int MAX_SESSION_MAX_PER_PROVIDER = 1000;
 
+    /** Reasoning effort levels accepted by A2AT_LLM_REASONING_EFFORT (mirrors the OpenAI API enum). */
+    private static final java.util.Set<String> REASONING_EFFORT_VALUES =
+            java.util.Set.of("none", "minimal", "low", "medium", "high", "xhigh");
+
     private LLMConfigLoader() {}
 
     public static LLMClientConfig load(Path envPath) {
@@ -70,7 +74,7 @@ public final class LLMConfigLoader {
                 timeoutSeconds.isPresent() ? timeoutSeconds.getAsDouble() : null,
                 sessionMaxTotal,
                 sessionMaxPerProvider,
-                optional(values.get("A2AT_LLM_REASONING_EFFORT")).orElse(null));
+                parseReasoningEffort(values.get("A2AT_LLM_REASONING_EFFORT")));
     }
 
     private static String required(Map<String, String> values, String key) {
@@ -129,5 +133,26 @@ public final class LLMConfigLoader {
             throw new LLMConfigError(key + " must be less than or equal to " + maxValue);
         }
         return parsed;
+    }
+
+    /**
+     * Parses the optional reasoning effort level.
+     *
+     * @param rawValue raw value of A2AT_LLM_REASONING_EFFORT; null or blank means the key is not set
+     * @return the validated effort level, or null when the key is not set
+     * @throws LLMConfigError when the value is not one of the supported levels; failing at config load time beats
+     *     discovering a bad value through a provider 400 on the first LLM call
+     */
+    private static String parseReasoningEffort(String rawValue) {
+        Optional<String> value = optional(rawValue);
+        if (!value.isPresent()) {
+            return null;
+        }
+        String effort = value.orElseThrow().toLowerCase(java.util.Locale.ROOT);
+        if (!REASONING_EFFORT_VALUES.contains(effort)) {
+            throw new LLMConfigError(
+                    "A2AT_LLM_REASONING_EFFORT must be one of " + REASONING_EFFORT_VALUES + " but was " + effort);
+        }
+        return effort;
     }
 }

--- a/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/providers/OpenAIClient.java
+++ b/a2a-t-llm/src/main/java/net/openan/a2at/sdk/llm/providers/OpenAIClient.java
@@ -3,6 +3,7 @@ package net.openan.a2at.sdk.llm.providers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.ReasoningEffort;
 import com.openai.models.ResponseFormatJsonObject;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
@@ -87,6 +88,9 @@ public class OpenAIClient implements LLMClient {
         if (resolvedMaxTokens != null) {
             builder.maxTokens(resolvedMaxTokens);
         }
+        if (config.reasoningEffort() != null && !config.reasoningEffort().isBlank()) {
+            builder.reasoningEffort(ReasoningEffort.of(config.reasoningEffort()));
+        }
         return builder.build();
     }
 
@@ -132,6 +136,9 @@ public class OpenAIClient implements LLMClient {
     private String extractJsonObjectString(ChatCompletion response) {
         String rawContent = extractMessageText(response);
         try {
+            if (rawContent == null || rawContent.isBlank()) {
+                throw new LLMRuntimeError(config.provider() + " returned empty content (rate limit or model timeout)");
+            }
             Object parsed = OBJECT_MAPPER.readValue(rawContent, Object.class);
             if (!(parsed instanceof Map<?, ?>)) {
                 throw new LLMRuntimeError(config.provider() + " must return a JSON object string");

--- a/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/LLMClientConfigTest.java
+++ b/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/LLMClientConfigTest.java
@@ -18,7 +18,8 @@ class LLMClientConfigTest {
                 0.2d,
                 15.5d,
                 300,
-                100);
+                100,
+                "none");
 
         assertEquals("openai", config.provider());
         assertEquals("gpt-4o-mini", config.model());
@@ -30,5 +31,6 @@ class LLMClientConfigTest {
         assertEquals(15.5d, config.timeoutSeconds());
         assertEquals(300, config.sessionMaxTotal());
         assertEquals(100, config.sessionMaxPerProvider());
+        assertEquals("none", config.reasoningEffort());
     }
 }

--- a/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/LLMClientFactoryTest.java
+++ b/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/LLMClientFactoryTest.java
@@ -82,7 +82,7 @@ class LLMClientFactoryTest {
     }
 
     private static LLMClientConfig buildConfig(String provider) {
-        return new LLMClientConfig(provider, "test-model", "sk-test", null, 10, null, null, null, 300, 100);
+        return new LLMClientConfig(provider, "test-model", "sk-test", null, 10, null, null, null, 300, 100, null);
     }
 
     public static final class CustomClient implements LLMClient {

--- a/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/LLMConfigLoaderTest.java
+++ b/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/LLMConfigLoaderTest.java
@@ -18,7 +18,8 @@ class LLMConfigLoaderTest {
 
     @Test
     void loadsRequiredValuesAndDefaultsFromEnvFile() throws IOException {
-        Path envFile = writeEnv("""
+        Path envFile = writeEnv(
+                """
                 A2AT_LLM_PROVIDER=openai
                 A2AT_LLM_MODEL=gpt-4o-mini
                 A2AT_LLM_API_KEY=sk-test
@@ -40,7 +41,8 @@ class LLMConfigLoaderTest {
 
     @Test
     void loadsOptionalValuesFromEnvFile() throws IOException {
-        Path envFile = writeEnv("""
+        Path envFile = writeEnv(
+                """
                 A2AT_LLM_PROVIDER=openai
                 A2AT_LLM_MODEL=gpt-4o-mini
                 A2AT_LLM_API_KEY=sk-test
@@ -66,7 +68,8 @@ class LLMConfigLoaderTest {
 
     @Test
     void rejectsMissingRequiredValues() throws IOException {
-        Path envFile = writeEnv("""
+        Path envFile = writeEnv(
+                """
                 A2AT_LLM_PROVIDER=openai
                 A2AT_LLM_API_KEY=sk-test
                 """);
@@ -79,7 +82,8 @@ class LLMConfigLoaderTest {
 
     @Test
     void rejectsInvalidOptionalNumber() throws IOException {
-        Path envFile = writeEnv("""
+        Path envFile = writeEnv(
+                """
                 A2AT_LLM_PROVIDER=openai
                 A2AT_LLM_MODEL=gpt-4o-mini
                 A2AT_LLM_API_KEY=sk-test
@@ -94,7 +98,8 @@ class LLMConfigLoaderTest {
 
     @Test
     void rejectsOutOfRangeReservedValues() throws IOException {
-        Path envFile = writeEnv("""
+        Path envFile = writeEnv(
+                """
                 A2AT_LLM_PROVIDER=openai
                 A2AT_LLM_MODEL=gpt-4o-mini
                 A2AT_LLM_API_KEY=sk-test
@@ -109,7 +114,8 @@ class LLMConfigLoaderTest {
 
     @Test
     void rejectsSessionTotalSmallerThanPerProviderLimit() throws IOException {
-        Path envFile = writeEnv("""
+        Path envFile = writeEnv(
+                """
                 A2AT_LLM_PROVIDER=openai
                 A2AT_LLM_MODEL=gpt-4o-mini
                 A2AT_LLM_API_KEY=sk-test
@@ -121,6 +127,52 @@ class LLMConfigLoaderTest {
 
         assertTrue(error.getMessage().contains("A2AT_LLM_SESSION_MAX_TOTAL"));
         assertTrue(error.getMessage().contains("A2AT_LLM_SESSION_MAX_PER_PROVIDER"));
+    }
+
+    @Test
+    void loadsReasoningEffortAndNormalizesCase() throws IOException {
+        Path envFile = writeEnv(
+                """
+                A2AT_LLM_PROVIDER=openai
+                A2AT_LLM_MODEL=gpt-4o-mini
+                A2AT_LLM_API_KEY=sk-test
+                A2AT_LLM_REASONING_EFFORT=HIGH
+                """);
+
+        LLMClientConfig config = LLMConfigLoader.load(envFile);
+
+        assertEquals("high", config.reasoningEffort());
+    }
+
+    @Test
+    void leavesReasoningEffortUnsetWhenKeyIsBlank() throws IOException {
+        Path envFile = writeEnv(
+                """
+                A2AT_LLM_PROVIDER=openai
+                A2AT_LLM_MODEL=gpt-4o-mini
+                A2AT_LLM_API_KEY=sk-test
+                A2AT_LLM_REASONING_EFFORT=
+                """);
+
+        LLMClientConfig config = LLMConfigLoader.load(envFile);
+
+        assertNull(config.reasoningEffort());
+    }
+
+    @Test
+    void rejectsUnknownReasoningEffortValue() throws IOException {
+        Path envFile = writeEnv(
+                """
+                A2AT_LLM_PROVIDER=openai
+                A2AT_LLM_MODEL=gpt-4o-mini
+                A2AT_LLM_API_KEY=sk-test
+                A2AT_LLM_REASONING_EFFORT=middle
+                """);
+
+        LLMConfigError error = assertThrows(LLMConfigError.class, () -> LLMConfigLoader.load(envFile));
+
+        assertTrue(error.getMessage().contains("A2AT_LLM_REASONING_EFFORT"));
+        assertTrue(error.getMessage().contains("middle"));
     }
 
     private Path writeEnv(String content) throws IOException {

--- a/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/providers/OpenAIClientTest.java
+++ b/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/providers/OpenAIClientTest.java
@@ -98,8 +98,7 @@ class OpenAIClientTest {
     void structuredFallsBackToConfigTemperatureAndMaxTokens() {
         AtomicReference<ChatCompletionCreateParams> capturedParams = new AtomicReference<>();
         LLMClientConfig config = new LLMClientConfig(
-                "openai", "gpt-4o-mini", "sk-test", "https://api.example.test/v1", 10, 128, 0.4d, null, 300, 100,
-                null);
+                "openai", "gpt-4o-mini", "sk-test", "https://api.example.test/v1", 10, 128, 0.4d, null, 300, 100, null);
         OpenAIClient client = new OpenAIClient(config, (runtimeConfig, requestParams) -> {
             capturedParams.set(requestParams);
             return chatCompletion("{}");

--- a/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/providers/OpenAIClientTest.java
+++ b/a2a-t-llm/src/test/java/net/openan/a2at/sdk/llm/providers/OpenAIClientTest.java
@@ -98,7 +98,8 @@ class OpenAIClientTest {
     void structuredFallsBackToConfigTemperatureAndMaxTokens() {
         AtomicReference<ChatCompletionCreateParams> capturedParams = new AtomicReference<>();
         LLMClientConfig config = new LLMClientConfig(
-                "openai", "gpt-4o-mini", "sk-test", "https://api.example.test/v1", 10, 128, 0.4d, null, 300, 100);
+                "openai", "gpt-4o-mini", "sk-test", "https://api.example.test/v1", 10, 128, 0.4d, null, 300, 100,
+                null);
         OpenAIClient client = new OpenAIClient(config, (runtimeConfig, requestParams) -> {
             capturedParams.set(requestParams);
             return chatCompletion("{}");
@@ -203,7 +204,7 @@ class OpenAIClientTest {
     }
 
     private static LLMClientConfig config(String apiKey, String baseUrl) {
-        return new LLMClientConfig("openai", "gpt-4o-mini", apiKey, baseUrl, 10, null, null, null, 300, 100);
+        return new LLMClientConfig("openai", "gpt-4o-mini", apiKey, baseUrl, 10, null, null, null, 300, 100, null);
     }
 
     private static ChatCompletion chatCompletion(String content) {

--- a/docs/en/developer_guide.md
+++ b/docs/en/developer_guide.md
@@ -116,6 +116,11 @@ A2AT_LLM_API_KEY={your_api_key}
 A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
 ```
 
+For reasoning models, the optional `A2AT_LLM_REASONING_EFFORT` key tunes the reasoning effort passed to the
+provider: one of `none`, `minimal`, `low`, `medium`, `high`, `xhigh` (case-insensitive). Leave the key unset for
+non-reasoning models — the parameter is then not sent at all. An unsupported value fails at configuration load
+time with an `LLMConfigError` instead of surfacing as a provider error on the first LLM call.
+
 
 ## 1.6 SDK Basic Usage
 

--- a/docs/zh/开发指南.md
+++ b/docs/zh/开发指南.md
@@ -116,6 +116,10 @@ A2AT_LLM_API_KEY={your_api_key}
 A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
 ```
 
+推理模型可选用 `A2AT_LLM_REASONING_EFFORT` 调整传递给提供方的推理力度，取值为 `none`、`minimal`、`low`、
+`medium`、`high`、`xhigh` 之一（大小写不敏感）。非推理模型保持该键不设即可——此时不会向提供方发送该参数。
+取值不受支持时会在配置加载阶段以 `LLMConfigError` 快速失败，而不是等到首次 LLM 调用才报提供方错误。
+
 
 ## 1.6 SDK 基本用法
 


### PR DESCRIPTION
## Summary

Two `a2a-t-llm` improvements needed while building the negotiation end-to-end sample:

1. **Optional reasoning effort** — `LLMClientConfig` gains a `reasoningEffort` component loaded from the new `A2AT_LLM_REASONING_EFFORT` env key (`none`/`low`/`medium`/`high`). When set, `OpenAIClient` passes it to the chat-completions API so reasoning models (DeepSeek-R1 style) can be tuned per deployment. Absent key = no behavior change.
2. **Empty-response guard** — providers occasionally return empty content under rate limiting or model timeout; `extractJsonObjectString` now fails fast with `LLMRuntimeError` carrying an actionable message instead of letting the JSON parser throw a bare parse error.

## Note

`LLMClientConfig` is a public record, so adding a component is a source-level breaking change for callers that use the canonical constructor — the provided tests were updated accordingly.

## Testing

- `a2a-t-llm` module suite passes (config, factory, OpenAIClient tests updated for the new component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)