### PR TITLE
fix(prompt): keep single-brace example text verbatim instead of failing as unknown slot

### DIFF
--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
@@ -127,7 +127,7 @@ class DefaultClientPromptGenerationOrchestratorTest {
                 "en-US",
                 "Identify the best matching scenario.",
                 "Choose from the provided scenario list.",
-                (scenarioCode, language) -> "Scenario: {scenario}\nMissing: {missing_slot}",
+                (scenarioCode, language) -> "Scenario: {scenario}\nMissing: {{missing_slot}}",
                 (userInput, scenarioCode, language, templateText) -> Map.of("scenario", scenarioCode),
                 new TaskPromptRenderer(),
                 EMPTY_SCHEMA_LOADER);
@@ -380,7 +380,7 @@ class DefaultClientPromptGenerationOrchestratorTest {
     void generateFromTemplateUriWithMetadataPropagatesRenderException() {
         DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
                 new RecordingScenarioRecognizer(),
-                new FakeTemplateLoader("Site: {site}\nMissing: {missing_slot}"),
+                new FakeTemplateLoader("Site: {site}\nMissing: {{missing_slot}}"),
                 new FakeSlotValueExtractor(Map.of("site", "Site A")));
 
         PromptGenerationException ex = assertThrows(
@@ -489,7 +489,7 @@ class DefaultClientPromptGenerationOrchestratorTest {
     void generateFromDataWithSchemaPropagatesRenderException() {
         DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
                 new RecordingScenarioRecognizer(),
-                new FakeTemplateLoader("Site: {site}\nMissing: {missing_slot}"),
+                new FakeTemplateLoader("Site: {site}\nMissing: {{missing_slot}}"),
                 new FakeSlotValueExtractorWithSchema(Map.of("site", "Site A")));
 
         PromptGenerationException ex = assertThrows(

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRenderer.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRenderer.java
@@ -18,6 +18,15 @@ import net.openan.a2at.sdk.prompt.taskrendering.exception.TaskPromptRenderExcept
 public final class TaskPromptRenderer implements SectionedTemplateRenderer {
 
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{?\\s*([^{}]+?)\\s*\\}\\}?");
+
+    /**
+     * Matches the literal single-brace example values a template may carry in its requirement prose (for example
+     * {@code {00:00~06:00,2Mbps}}). Such text is never a slot placeholder; skipping it keeps example values verbatim
+     * in the rendered prompt instead of failing with an unknown-slot error.
+     */
+    private static boolean isKnownSlotPlaceholder(String candidate, Map<String, String> slots) {
+        return slots.containsKey(candidate);
+    }
     private static final Pattern SECTION_HEADER_PATTERN = Pattern.compile("^##\\s+.+$");
     private static final Pattern STANDALONE_SLOT_LINE_PATTERN = Pattern.compile(
             "^\\s*(\\{\\{?\\s*[^{}]+?\\s*\\}\\}?)(?:\\s*(?:\\(Required\\)|\\(Optional\\)|（必选）|（可选）))?\\s*$");
@@ -41,7 +50,12 @@ public final class TaskPromptRenderer implements SectionedTemplateRenderer {
         StringBuffer rendered = new StringBuffer();
         while (matcher.find()) {
             String slotName = matcher.group(1).trim();
+            boolean doubleBraced = matcher.group(0).startsWith("{{");
             if (!safeSlots.containsKey(slotName)) {
+                if (!doubleBraced && !isKnownSlotPlaceholder(slotName, safeSlots)) {
+                    // single-brace text that is not a slot is example prose (e.g. {00:00~06:00,2Mbps}); keep verbatim
+                    continue;
+                }
                 throw new TaskPromptRenderException("Unknown slot referenced by template: " + slotName);
             }
             String replacement = safeSlots.get(slotName);

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRendererTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRendererTest.java
@@ -106,7 +106,15 @@ class TaskPromptRendererTest {
     void renderRaisesWhenTemplateReferencesUnknownSlot() {
         assertThrows(
                 TaskPromptRenderException.class,
-                () -> renderer.render("Site: {site}\nTime Range: {time_range}", Map.of("site", "Site A")));
+                () -> renderer.render("Site: {{site}}\nTime Range: {{time_range}}", Map.of("site", "Site A")));
+    }
+
+    @Test
+    void renderKeepsSingleBraceExampleTextVerbatim() {
+        // example prose such as "{00:00~06:00,2Mbps}" inside requirement text is not a slot placeholder
+        String prompt = renderer.render(
+                "Rate target: {00:00~06:00,2Mbps}\nSite: {{site}}", Map.of("site", "Site A"));
+        assertEquals("Rate target: {00:00~06:00,2Mbps}\nSite: Site A", prompt);
     }
 
     @Test


### PR DESCRIPTION
Fixes #117

## Summary

`TaskPromptRenderer.PLACEHOLDER_PATTERN` accepted both `{{slot}}` and `{slot}` forms, so example prose in requirement sections — such as the energy-saving template's rate-guarantee examples `{00:00~06:00,2Mbps}` — was misread as an unknown slot placeholder. Every `generateTaskPromptFromText` / `generateTaskPromptFromData` call for the energy-saving scenario failed with `Unknown slot referenced by template: 00:00~06:00,2Mbps`; the template could never render.

## Fix

- Single-brace text that does **not** match a known slot name is now kept verbatim in the rendered prompt (it is example prose)
- Only `{{slot}}` placeholders and single-brace names matching a known slot are substituted
- Unknown **double-braced** placeholders still fail fast (the unknown-slot regression test now pins the double-braced form)
- New regression test renders the rate-guarantee example line verbatim

## Testing

- `a2a-t-prompt` module: 36/36 tests pass (including the new regression test)
- Verified end-to-end: energy-saving prompt generation now renders (was 10/10 failures before the fix, discovered by a cross-scenario negotiation eval)

Based on #113 (same a2a-t-prompt fix branch lineage).

Generated with [Claude Code](https://claude.com/claude-code)