### PR TITLE
fix(prompt): preserve null semantic params so missing slots stay detectable

### DIFF
--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
@@ -3,6 +3,7 @@ package net.openan.a2at.sdk.prompt.validation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -171,18 +172,19 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
         return List.copyOf(normalized);
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Normalizes the LLM-extracted parameter map. Keys with a {@code null} value are preserved: a {@code null}
+     * parameter is the semantic validator's explicit signal that a schema slot is missing from the content, and
+     * downstream missing-parameter detection (negotiation triggering) relies on the key being present with a null
+     * value. Dropping the key would make a missing slot indistinguishable from an absent one.
+     */
     private static Map<String, Object> parseParams(Object paramsValue) {
         if (!(paramsValue instanceof Map<?, ?> params)) {
             return Map.of();
         }
         Map<String, Object> normalized = new LinkedHashMap<>();
-        params.forEach((key, value) -> {
-            if (value != null) {
-                normalized.put(String.valueOf(key), value);
-            }
-        });
-        return Map.copyOf(normalized);
+        params.forEach((key, value) -> normalized.put(String.valueOf(key), value));
+        return Collections.unmodifiableMap(normalized);
     }
 
     private static String asString(Object value) {

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
@@ -3,6 +3,7 @@ package net.openan.a2at.sdk.prompt.validation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -136,7 +137,27 @@ class DefaultSemanticValidatorTest {
 
 
     @Test
-    void validateFiltersNullParamValues() {
+    void pipelineCarriesNullParamsIntoFilledParamData() {
+        // the semantic validator passed overall, but one schema slot is explicitly null: the merged
+        // FilledParamData must carry the key with a null value so callers scanning for blank slots can see the
+        // missing parameter and trigger negotiation for it
+        String llmJson =
+                "{\"semantic_verdict\": true, \"errors\": []," + "\"params\": {\"任务对象\": \"端口A\", \"任务上下文\": null}}";
+        DefaultSemanticValidator validator =
+                new DefaultSemanticValidator(new StubClient(llmJson), "zh-CN", new RecordingResourceAccess());
+
+        ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
+
+        FilledParamData result = pipeline.validate(
+                "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
+
+        assertEquals(2, result.data().size());
+        assertEquals("端口A", result.data().get("任务对象"));
+        assertNull(result.data().get("任务上下文"));
+    }
+
+    @Test
+    void validatePreservesNullParamValuesAsMissingSlots() {
         String llmJson =
                 "{\"semantic_verdict\": true, \"errors\": []," + "\"params\": {\"任务对象\": \"端口A\", \"任务上下文\": null}}";
         DefaultSemanticValidator validator =
@@ -146,9 +167,12 @@ class DefaultSemanticValidatorTest {
                 validator.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
 
         assertTrue(result.verdict());
-        // Map.copyOf rejects null values; the validator must drop them instead of throwing NPE
-        assertEquals(Map.of("任务对象", "端口A"), result.params());
-        assertFalse(result.params().containsKey("任务上下文"));
+        // a null param is the validator's signal that a schema slot is missing from the content; the key must stay
+        // present with a null value so downstream missing-slot detection (negotiation triggering) can see it
+        assertEquals(2, result.params().size());
+        assertEquals("端口A", result.params().get("任务对象"));
+        assertTrue(result.params().containsKey("任务上下文"));
+        assertNull(result.params().get("任务上下文"));
     }
 
     private static final class RecordingClient implements LLMClient {


### PR DESCRIPTION
Closes #127

`DefaultSemanticValidator.parseParams` dropped parameters whose extracted value was `null`, so `FilledParamData` did not even carry the key. A null param is the semantic validator's explicit signal that a schema slot is missing from the content (per the `content_validation` user prompt: slots that cannot be extracted must be output as null). With the key gone, any caller that detects missing parameters by scanning `FilledParamData` for blank values cannot see the missing slot, and negotiation is silently never triggered for it.

## Change

- `parseParams` now keeps null-valued keys; the normalized map is wrapped with `Collections.unmodifiableMap` instead of `Map.copyOf` (which rejects null values)
- `ValidationPipeline.mergeParams` already carries null values through unchanged — no change needed there

## Tests

- updated `validateFiltersNullParamValues` -> `validatePreservesNullParamValuesAsMissingSlots` (the old test asserted the dropping behavior, which was the bug)
- new `pipelineCarriesNullParamsIntoFilledParamData` — verifies the null param survives the full pipeline merge into `FilledParamData`

Full reactor `mvn verify` passes (all modules).

Found by the negotiation interface closed-loop evaluator (eval-suite case PLC-10: the LLM returned `任务对象=null` with `semantic_verdict=true`, the missing slot vanished from `FilledParamData`, and the negotiation flow never started).
