### PR TITLE
fix(validation): load content_validation prompts from classpath and enforce LLM output contract

### DIFF
--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
@@ -5,9 +5,9 @@ import java.util.Objects;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.FilledParamData;
+import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.core.validation.ContentValidator;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ValidationPipeline;
 import net.openan.a2at.sdk.llm.LLMClient;
 import org.jspecify.annotations.NonNull;
@@ -75,14 +75,12 @@ public final class DefaultContentValidator implements ContentValidator {
         Objects.requireNonNull(templateUri, "templateUri");
 
         if (!extensionName.equals(templateUri.extensionName())) {
-            throw new IllegalArgumentException(
-                    "Template URI extension '" + templateUri.extensionName()
-                            + "' does not match expected extension '" + extensionName + "'.");
+            throw new IllegalArgumentException("Template URI extension '" + templateUri.extensionName()
+                    + "' does not match expected extension '" + extensionName + "'.");
         }
 
         if (!TemplateUri.DEFAULT_TEMPLATE_VERSION.equals(templateUri.templateVersion())) {
-            throw new IllegalArgumentException(
-                    "Unsupported template URI version: " + templateUri.templateVersion());
+            throw new IllegalArgumentException("Unsupported template URI version: " + templateUri.templateVersion());
         }
 
         return pipeline().validate(prompt, schema, templateUri);
@@ -99,9 +97,7 @@ public final class DefaultContentValidator implements ContentValidator {
                                 prompt -> Map.of(), new DefaultSemanticValidator(llmClient, language), maxAttempts);
                     } catch (ResourceNotFoundException exception) {
                         throw new ContentValidationException(
-                                A2ATErrorCodes.VALIDATION_PROMPT_RESOURCE_NOT_FOUND,
-                                exception.getMessage(),
-                                exception);
+                                A2ATErrorCodes.VALIDATION_PROMPT_RESOURCE_NOT_FOUND, exception.getMessage(), exception);
                     }
                     pipeline = p;
                 }

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
@@ -2,12 +2,14 @@ package net.openan.a2at.sdk.prompt.validation;
 
 import java.util.Map;
 import java.util.Objects;
+import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
+import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.FilledParamData;
+import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.core.validation.ContentValidator;
 import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ValidationPipeline;
 import net.openan.a2at.sdk.llm.LLMClient;
-import net.openan.a2at.sdk.prompt.resources.loader.PromptResourceAccess;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -17,7 +19,8 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>The semantic validator is initialised lazily on the first {@link #validate} call so that constructing the
  * validator never loads prompt resources — the facade builders can wire the validator eagerly without requiring the
- * content_validation prompt resources to be present at startup.
+ * content_validation prompt resources to be present at startup. The content_validation prompt resources are internal
+ * LLM instructions loaded from the classpath regardless of the configured prompt source type.
  *
  * @since 2026-08
  */
@@ -27,7 +30,6 @@ public final class DefaultContentValidator implements ContentValidator {
     private final String language;
     private final int maxAttempts;
     private final LLMClient llmClient;
-    private final PromptResourceAccess promptResourceAccess;
 
     private volatile ValidationPipeline pipeline;
 
@@ -43,19 +45,13 @@ public final class DefaultContentValidator implements ContentValidator {
      * @param llmClient LLM client for semantic validation; may be {@code null}, in which case the first
      *     {@link #validate} call fails with {@code ContentValidationException} carrying
      *     {@code VALIDATION_LLM_INFRASTRUCTURE_ERROR}; there is no late injection point
-     * @param promptResourceAccess prompt resource access for loading validation prompts
      */
     public DefaultContentValidator(
-            @NonNull String extensionName,
-            @NonNull String language,
-            int maxAttempts,
-            @Nullable LLMClient llmClient,
-            @NonNull PromptResourceAccess promptResourceAccess) {
+            @NonNull String extensionName, @NonNull String language, int maxAttempts, @Nullable LLMClient llmClient) {
         this.extensionName = extensionName;
         this.language = language;
         this.maxAttempts = maxAttempts;
         this.llmClient = llmClient;
-        this.promptResourceAccess = promptResourceAccess;
     }
 
     /**
@@ -69,7 +65,9 @@ public final class DefaultContentValidator implements ContentValidator {
      * @throws NullPointerException if the prompt, schema or template URI is null
      * @throws IllegalArgumentException if the prompt is blank, the template URI addresses another extension than the
      *     one this validator is configured for, or the template URI version is unsupported
-     * @throws net.openan.a2at.sdk.core.validation.ContentValidationException if the validation fails at any stage
+     * @throws ContentValidationException if the validation fails at any stage, including
+     *     {@code VALIDATION_PROMPT_RESOURCE_NOT_FOUND} when the content_validation prompt resources of the configured
+     *     language are missing on the classpath
      */
     @Override
     public FilledParamData validate(
@@ -96,10 +94,15 @@ public final class DefaultContentValidator implements ContentValidator {
             synchronized (this) {
                 p = pipeline;
                 if (p == null) {
-                    p = new ValidationPipeline(
-                            prompt -> Map.of(),
-                            new DefaultSemanticValidator(llmClient, language, promptResourceAccess),
-                            maxAttempts);
+                    try {
+                        p = new ValidationPipeline(
+                                prompt -> Map.of(), new DefaultSemanticValidator(llmClient, language), maxAttempts);
+                    } catch (ResourceNotFoundException exception) {
+                        throw new ContentValidationException(
+                                A2ATErrorCodes.VALIDATION_PROMPT_RESOURCE_NOT_FOUND,
+                                exception.getMessage(),
+                                exception);
+                    }
                     pipeline = p;
                 }
             }

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
@@ -18,10 +18,10 @@ import net.openan.a2at.sdk.core.json.JacksonJsonValueParser;
 import net.openan.a2at.sdk.core.json.JsonValueParser;
 import net.openan.a2at.sdk.core.model.PromptMessage;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
+import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.resources.ClasspathResourceStreams;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.core.validation.SemanticValidator;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ValidationResult;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMError;
@@ -56,18 +56,35 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
     /**
      * Creates a semantic validator backed by the given LLM client and prompt resources for the specified language.
      *
-     * @param llmClient LLM client for structured calls; may be {@code null}, in which case {@link #validate}
-     *     fails with {@code ContentValidationException} carrying
-     *     {@code VALIDATION_LLM_INFRASTRUCTURE_ERROR}; there is no late injection point
+     * @param llmClient LLM client for structured calls; may be {@code null}, in which case {@link #validate} fails with
+     *     {@code ContentValidationException} carrying {@code VALIDATION_LLM_INFRASTRUCTURE_ERROR}; there is no late
+     *     injection point
      * @param language language code for prompt resource loading
-     * @throws ResourceNotFoundException if the content_validation prompt resources of the given language are missing
-     *     on the classpath
+     * @throws ResourceNotFoundException if the content_validation prompt resources of the given language are missing on
+     *     the classpath
      */
     DefaultSemanticValidator(@Nullable LLMClient llmClient, @NonNull String language) {
+        this(llmClient, language, new JacksonJsonValueParser());
+    }
+
+    /**
+     * Creates a semantic validator backed by the given LLM client, prompt resources for the specified language and a
+     * shared JSON value parser abstraction.
+     *
+     * @param llmClient LLM client for structured calls; may be {@code null}, in which case {@link #validate} fails with
+     *     {@code ContentValidationException} carrying {@code VALIDATION_LLM_INFRASTRUCTURE_ERROR}; there is no late
+     *     injection point
+     * @param language language code for prompt resource loading
+     * @param jsonValueParser shared JSON value parser abstraction
+     * @throws ResourceNotFoundException if the content_validation prompt resources of the given language are missing on
+     *     the classpath
+     */
+    DefaultSemanticValidator(
+            @Nullable LLMClient llmClient, @NonNull String language, @NonNull JsonValueParser jsonValueParser) {
         this.llmClient = llmClient;
         this.systemPrompt = loadPromptResource("system.md", language);
         this.userPromptTemplate = loadPromptResource("user.md", language);
-        this.jsonValueParser = new JacksonJsonValueParser();
+        this.jsonValueParser = jsonValueParser;
     }
 
     @Override
@@ -237,7 +254,6 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
         return new ContentValidationException(
                 A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR,
                 "Semantic validation LLM response violates the output contract: " + message,
-                List.of(new SlotValidationError(
-                        "_llm", A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, message)));
+                List.of(new SlotValidationError("_llm", A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, message)));
     }
 }

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
@@ -2,6 +2,9 @@ package net.openan.a2at.sdk.prompt.validation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -10,10 +13,12 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
+import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.json.JacksonJsonValueParser;
 import net.openan.a2at.sdk.core.json.JsonValueParser;
 import net.openan.a2at.sdk.core.model.PromptMessage;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
+import net.openan.a2at.sdk.core.resources.ClasspathResourceStreams;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.core.validation.SemanticValidator;
 import net.openan.a2at.sdk.core.model.TemplateUri;
@@ -21,7 +26,6 @@ import net.openan.a2at.sdk.core.validation.ValidationResult;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMError;
 import net.openan.a2at.sdk.llm.LLMResponse;
-import net.openan.a2at.sdk.prompt.resources.loader.PromptResourceAccess;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -31,12 +35,18 @@ import org.slf4j.LoggerFactory;
  * Default LLM-backed semantic validator that delegates to a structured LLM call for content validation and parameter
  * extraction.
  *
+ * <p>The content_validation prompt resources are internal LLM instructions. Like the negotiation semantic validation
+ * prompts, they are always loaded from the classpath regardless of the configured prompt source type — the local
+ * resource root only overrides business resources (templates, slots, scenarios).
+ *
  * @since 2026-08
  */
 final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSemanticValidator.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String PROMPT_RESOURCE_ROOT = "prompt_resources/prompts/content_validation/";
 
     private final LLMClient llmClient;
     private final String systemPrompt;
@@ -50,16 +60,13 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
      *     fails with {@code ContentValidationException} carrying
      *     {@code VALIDATION_LLM_INFRASTRUCTURE_ERROR}; there is no late injection point
      * @param language language code for prompt resource loading
-     * @param promptResourceAccess prompt resource access for loading validation prompts
-     * @throws net.openan.a2at.sdk.core.exception.ResourceNotFoundException if prompt resources are missing
+     * @throws ResourceNotFoundException if the content_validation prompt resources of the given language are missing
+     *     on the classpath
      */
-    DefaultSemanticValidator(
-            @Nullable LLMClient llmClient,
-            @NonNull String language,
-            @NonNull PromptResourceAccess promptResourceAccess) {
+    DefaultSemanticValidator(@Nullable LLMClient llmClient, @NonNull String language) {
         this.llmClient = llmClient;
-        this.systemPrompt = promptResourceAccess.loadPrompt("content_validation", language, "system.md");
-        this.userPromptTemplate = promptResourceAccess.loadPrompt("content_validation", language, "user.md");
+        this.systemPrompt = loadPromptResource("system.md", language);
+        this.userPromptTemplate = loadPromptResource("user.md", language);
         this.jsonValueParser = new JacksonJsonValueParser();
     }
 
@@ -98,7 +105,7 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
                     exception);
         }
 
-        boolean verdict = Boolean.TRUE.equals(parsed.get("semantic_verdict"));
+        boolean verdict = parseVerdict(parsed);
         List<SlotValidationError> errors = parseErrors(parsed.get("errors"));
         Map<String, Object> params = parseParams(parsed.get("params"));
 
@@ -108,6 +115,22 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
                 errors.size(),
                 params.size());
         return new ValidationResult(verdict, errors, params);
+    }
+
+    private static String loadPromptResource(String fileName, String language) {
+        String classpathPath = PROMPT_RESOURCE_ROOT + language + "/" + fileName;
+        InputStream stream = ClasspathResourceStreams.open(classpathPath);
+        if (stream == null) {
+            throw new ResourceNotFoundException(
+                    "Content validation prompt resource does not exist for language " + language
+                            + "; set A2AT_LANGUAGE to a language with bundled prompt resources (zh-CN or en-US).",
+                    classpathPath);
+        }
+        try (stream) {
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new A2ATError("Failed to read content validation prompt: " + classpathPath, exception);
+        }
     }
 
     private String fillUserPrompt(String prompt, Map<String, Object> schema, TemplateUri reference) {
@@ -135,8 +158,17 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
         verdictProp.put("type", "boolean");
         properties.put("semantic_verdict", verdictProp);
 
+        Map<String, Object> errorItemProperties = new LinkedHashMap<>();
+        errorItemProperties.put("slot_name", Map.of("type", "string"));
+        errorItemProperties.put("code", Map.of("type", "string"));
+        errorItemProperties.put("message", Map.of("type", "string"));
+        Map<String, Object> errorItem = new LinkedHashMap<>();
+        errorItem.put("type", "object");
+        errorItem.put("properties", errorItemProperties);
+        errorItem.put("required", List.of("slot_name", "code", "message"));
         Map<String, Object> errorsProp = new LinkedHashMap<>();
         errorsProp.put("type", "array");
+        errorsProp.put("items", errorItem);
         properties.put("errors", errorsProp);
 
         Map<String, Object> paramsProp = new LinkedHashMap<>();
@@ -144,7 +176,8 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
         properties.put("params", paramsProp);
 
         schema.put("properties", properties);
-        schema.put("required", List.of("semantic_verdict"));
+        schema.put("required", List.of("semantic_verdict", "errors", "params"));
+        schema.put("additionalProperties", false);
         return schema;
     }
 
@@ -154,19 +187,27 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
                 .toList();
     }
 
-    @SuppressWarnings("unchecked")
+    private static boolean parseVerdict(Map<String, Object> parsed) {
+        if (!(parsed.get("semantic_verdict") instanceof Boolean verdict)) {
+            throw contractViolation("semantic_verdict must be a boolean.");
+        }
+        return verdict;
+    }
+
     private static List<SlotValidationError> parseErrors(Object errorsValue) {
         if (!(errorsValue instanceof List<?> errors)) {
-            return List.of();
+            throw contractViolation("errors must be an array.");
         }
         List<SlotValidationError> normalized = new ArrayList<>();
         for (Object errorValue : errors) {
             if (!(errorValue instanceof Map<?, ?> errorMap)) {
-                continue;
+                throw contractViolation("errors must be objects with slot_name, code and message.");
             }
-            String slotName = asString(errorMap.get("slot_name"));
-            String code = asString(errorMap.get("code"));
-            String message = asString(errorMap.get("message"));
+            if (!(errorMap.get("slot_name") instanceof String slotName)
+                    || !(errorMap.get("code") instanceof String code)
+                    || !(errorMap.get("message") instanceof String message)) {
+                throw contractViolation("errors must carry string slot_name, code and message values.");
+            }
             normalized.add(new SlotValidationError(slotName, code, message));
         }
         return List.copyOf(normalized);
@@ -180,14 +221,23 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
      */
     private static Map<String, Object> parseParams(Object paramsValue) {
         if (!(paramsValue instanceof Map<?, ?> params)) {
-            return Map.of();
+            throw contractViolation("params must be an object.");
         }
         Map<String, Object> normalized = new LinkedHashMap<>();
-        params.forEach((key, value) -> normalized.put(String.valueOf(key), value));
+        for (Map.Entry<?, ?> entry : params.entrySet()) {
+            if (!(entry.getKey() instanceof String key)) {
+                throw contractViolation("params keys must be strings.");
+            }
+            normalized.put(key, entry.getValue());
+        }
         return Collections.unmodifiableMap(normalized);
     }
 
-    private static String asString(Object value) {
-        return value instanceof String text ? text : "";
+    private static ContentValidationException contractViolation(String message) {
+        return new ContentValidationException(
+                A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR,
+                "Semantic validation LLM response violates the output contract: " + message,
+                List.of(new SlotValidationError(
+                        "_llm", A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, message)));
     }
 }

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidatorTest.java
@@ -15,6 +15,7 @@ import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
+import net.openan.a2at.sdk.llm.LLMRuntimeError;
 import org.junit.jupiter.api.Test;
 
 class DefaultContentValidatorTest {
@@ -23,10 +24,10 @@ class DefaultContentValidatorTest {
 
     @Test
     void validatesSuccessfullyOnFirstCall() {
-        DefaultContentValidator validator =
-                new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
 
-        FilledParamData result = assertDoesNotThrow(() -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+        FilledParamData result =
+                assertDoesNotThrow(() -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
 
         assertNotNull(result);
         assertEquals(Map.of("site", "Site A"), result.data());
@@ -34,11 +35,11 @@ class DefaultContentValidatorTest {
 
     @Test
     void rejectsMismatchedExtensionName() {
-        DefaultContentValidator validator =
-                new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
 
-        assertThrows(IllegalArgumentException.class, () ->
-                validator.validate(
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> validator.validate(
                         "task prompt",
                         Map.of("type", "object"),
                         TemplateUri.of("Notification-T", "network-layer", "service-recovery")));
@@ -49,7 +50,8 @@ class DefaultContentValidatorTest {
         DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient());
 
         ContentValidationException exception = assertThrows(
-                ContentValidationException.class, () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+                ContentValidationException.class,
+                () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
 
         assertEquals("validation_prompt_resource_not_found", exception.getCode());
         assertInstanceOf(ResourceNotFoundException.class, exception.getCause());
@@ -57,11 +59,45 @@ class DefaultContentValidatorTest {
     }
 
     @Test
+    void missingPromptResourceKeepsPipelineNullSoNextCallRetries() {
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient());
+
+        // first call fails on the missing resource; the pipeline must stay uninitialised so the next
+        // call re-attempts the construction (transient failures can heal)
+        assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+        ContentValidationException second = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+
+        assertEquals("validation_prompt_resource_not_found", second.getCode());
+    }
+
+    @Test
+    void succeedsOnSecondCallAfterTransientResourceFailureHeals() {
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient());
+
+        assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+
+        // switching the language is impossible on this class; the healing path is instead proven by a
+        // fresh validator with a supported language constructed after the failing one
+        DefaultContentValidator healed = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
+        FilledParamData result =
+                assertDoesNotThrow(() -> healed.validate("task prompt", Map.of("type", "object"), TASK_URI));
+
+        assertNotNull(result);
+    }
+
+    @Test
     void retryableFailureAfterResourceLoadStillMapsLlmInfrastructureError() {
         DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 1, new FailingClient());
 
         ContentValidationException exception = assertThrows(
-                ContentValidationException.class, () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+                ContentValidationException.class,
+                () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
 
         assertEquals("validation_llm_infrastructure_error", exception.getCode());
     }
@@ -96,7 +132,7 @@ class DefaultContentValidatorTest {
                 Map<String, Object> jsonSchema,
                 Double temperature,
                 Integer maxTokens) {
-            throw new net.openan.a2at.sdk.llm.LLMRuntimeError("network timeout");
+            throw new LLMRuntimeError("network timeout");
         }
     }
 }

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidatorTest.java
@@ -1,0 +1,102 @@
+package net.openan.a2at.sdk.prompt.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
+import net.openan.a2at.sdk.core.model.FilledParamData;
+import net.openan.a2at.sdk.core.model.TemplateUri;
+import net.openan.a2at.sdk.core.validation.ContentValidationException;
+import net.openan.a2at.sdk.llm.LLMClient;
+import net.openan.a2at.sdk.llm.LLMResponse;
+import org.junit.jupiter.api.Test;
+
+class DefaultContentValidatorTest {
+
+    private static final TemplateUri TASK_URI = TemplateUri.of("Task-T", "network-layer", "energy-saving");
+
+    @Test
+    void validatesSuccessfullyOnFirstCall() {
+        DefaultContentValidator validator =
+                new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
+
+        FilledParamData result = assertDoesNotThrow(() -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+
+        assertNotNull(result);
+        assertEquals(Map.of("site", "Site A"), result.data());
+    }
+
+    @Test
+    void rejectsMismatchedExtensionName() {
+        DefaultContentValidator validator =
+                new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
+
+        assertThrows(IllegalArgumentException.class, () ->
+                validator.validate(
+                        "task prompt",
+                        Map.of("type", "object"),
+                        TemplateUri.of("Notification-T", "network-layer", "service-recovery")));
+    }
+
+    @Test
+    void missingPromptResourceFailsWithValidationPromptResourceNotFound() {
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient());
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class, () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+
+        assertEquals("validation_prompt_resource_not_found", exception.getCode());
+        assertInstanceOf(ResourceNotFoundException.class, exception.getCause());
+        assertTrue(exception.getMessage().contains("zh-CN or en-US"));
+    }
+
+    @Test
+    void retryableFailureAfterResourceLoadStillMapsLlmInfrastructureError() {
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 1, new FailingClient());
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class, () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+
+        assertEquals("validation_llm_infrastructure_error", exception.getCode());
+    }
+
+    private static final class StubClient implements LLMClient {
+
+        @Override
+        public LLMResponse structured(
+                List<Map<String, String>> messages,
+                Map<String, Object> jsonSchema,
+                Double temperature,
+                Integer maxTokens) {
+            return new LLMResponse(
+                    """
+                    {
+                      "semantic_verdict": true,
+                      "errors": [],
+                      "params": {"site": "Site A"}
+                    }
+                    """,
+                    "stub-llm",
+                    Map.of(),
+                    Map.of());
+        }
+    }
+
+    private static final class FailingClient implements LLMClient {
+
+        @Override
+        public LLMResponse structured(
+                List<Map<String, String>> messages,
+                Map<String, Object> jsonSchema,
+                Double temperature,
+                Integer maxTokens) {
+            throw new net.openan.a2at.sdk.llm.LLMRuntimeError("network timeout");
+        }
+    }
+}

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
@@ -13,7 +13,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.FilledParamData;
-import net.openan.a2at.sdk.core.model.PromptRuntimeConfig;
 import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.core.validation.ValidationPipeline;
@@ -21,81 +20,53 @@ import net.openan.a2at.sdk.core.validation.ValidationResult;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.llm.LLMRuntimeError;
-import net.openan.a2at.sdk.prompt.resources.loader.PromptResourceAccess;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import net.openan.a2at.sdk.prompt.resources.loader.PromptSlotSchemaLoader;
-import net.openan.a2at.sdk.prompt.resources.loader.PromptTemplateTextLoader;
-import net.openan.a2at.sdk.prompt.resources.model.ScenarioDefinition;
-import net.openan.a2at.sdk.resources.ClasspathPromptResourceLoader;
 import org.junit.jupiter.api.Test;
 
 class DefaultSemanticValidatorTest {
 
+    private static final String VALID_RESPONSE = """
+            {
+              "semantic_verdict": true,
+              "errors": [],
+              "params": {"site": "Site A"}
+            }
+            """;
+
     @Test
     void validatesEnUSPromptAndExtractsParams() {
-        PromptResourceAccess resources =
-                PromptResourceAccess.create(new PromptRuntimeConfig("en-US", "classpath", null));
+        RecordingClient llmClient = new RecordingClient(VALID_RESPONSE);
 
-        RecordingClient llmClient = new RecordingClient(
-                """
-                {
-                  "semantic_verdict": true,
-                  "errors": [],
-                  "params": {"site": "Site A"}
-                }
-                """);
-
-        DefaultSemanticValidator validator = new DefaultSemanticValidator(llmClient, "en-US", resources);
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(llmClient, "en-US");
 
         ValidationResult result = validator.validate(
                 "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"));
 
         assertTrue(result.verdict());
         assertEquals(Map.of("site", "Site A"), result.params());
-
-        String expectedSystemPrompt = resources.loadPrompt("content_validation", "en-US", "system.md");
-        assertEquals(expectedSystemPrompt, llmClient.lastSystemContent());
+        assertTrue(llmClient.lastSystemContent().contains("validation"));
     }
 
     @Test
     void loadsZhCnResourcesWithoutException() {
-        PromptResourceAccess resources =
-                PromptResourceAccess.create(new PromptRuntimeConfig("zh-CN", "classpath", null));
-
-        DefaultSemanticValidator validator = new DefaultSemanticValidator(null, "zh-CN", resources);
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(null, "zh-CN");
 
         assertNotNull(validator);
     }
 
     @Test
     void throwsResourceNotFoundExceptionForMissingLanguage() {
-        PromptResourceAccess resources =
-                PromptResourceAccess.create(new PromptRuntimeConfig("fr-FR", "classpath", null));
-
-        ResourceNotFoundException exception = assertThrows(
-                ResourceNotFoundException.class, () -> new DefaultSemanticValidator(null, "fr-FR", resources));
+        ResourceNotFoundException exception =
+                assertThrows(ResourceNotFoundException.class, () -> new DefaultSemanticValidator(null, "fr-FR"));
 
         assertTrue(exception.resourcePath().contains("content_validation"));
+        assertTrue(exception.getMessage().contains("zh-CN or en-US"));
     }
 
     @Test
     void validateRetriesLlmInfrastructureErrorThroughPipeline() {
-        PromptResourceAccess resources =
-                PromptResourceAccess.create(new PromptRuntimeConfig("en-US", "classpath", null));
+        FlakyClient flakyClient = new FlakyClient(1, VALID_RESPONSE);
 
-        FlakyClient flakyClient = new FlakyClient(
-                1,
-                """
-                {
-                  "semantic_verdict": true,
-                  "errors": [],
-                  "params": {"site": "Site A"}
-                }
-                """);
-
-        DefaultSemanticValidator validator = new DefaultSemanticValidator(flakyClient, "en-US", resources);
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(flakyClient, "en-US");
 
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
 
@@ -108,12 +79,7 @@ class DefaultSemanticValidatorTest {
 
     @Test
     void validateExhaustsRetriesAndWrapsLlmError() {
-        PromptResourceAccess resources =
-                PromptResourceAccess.create(new PromptRuntimeConfig("en-US", "classpath", null));
-
-        FlakyClient flakyClient = new FlakyClient(
-                Integer.MAX_VALUE,
-                """
+        FlakyClient flakyClient = new FlakyClient(Integer.MAX_VALUE, """
                 {
                   "semantic_verdict": true,
                   "errors": [],
@@ -121,7 +87,7 @@ class DefaultSemanticValidatorTest {
                 }
                 """);
 
-        DefaultSemanticValidator validator = new DefaultSemanticValidator(flakyClient, "en-US", resources);
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(flakyClient, "en-US");
 
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 3);
 
@@ -135,7 +101,6 @@ class DefaultSemanticValidatorTest {
         assertEquals(3, flakyClient.invocations());
     }
 
-
     @Test
     void pipelineCarriesNullParamsIntoFilledParamData() {
         // the semantic validator passed overall, but one schema slot is explicitly null: the merged
@@ -143,8 +108,7 @@ class DefaultSemanticValidatorTest {
         // missing parameter and trigger negotiation for it
         String llmJson =
                 "{\"semantic_verdict\": true, \"errors\": []," + "\"params\": {\"任务对象\": \"端口A\", \"任务上下文\": null}}";
-        DefaultSemanticValidator validator =
-                new DefaultSemanticValidator(new StubClient(llmJson), "zh-CN", new RecordingResourceAccess());
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(new StubClient(llmJson), "zh-CN");
 
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
 
@@ -160,8 +124,7 @@ class DefaultSemanticValidatorTest {
     void validatePreservesNullParamValuesAsMissingSlots() {
         String llmJson =
                 "{\"semantic_verdict\": true, \"errors\": []," + "\"params\": {\"任务对象\": \"端口A\", \"任务上下文\": null}}";
-        DefaultSemanticValidator validator =
-                new DefaultSemanticValidator(new StubClient(llmJson), "zh-CN", new RecordingResourceAccess());
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(new StubClient(llmJson), "zh-CN");
 
         ValidationResult result =
                 validator.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
@@ -173,6 +136,123 @@ class DefaultSemanticValidatorTest {
         assertEquals("端口A", result.params().get("任务对象"));
         assertTrue(result.params().containsKey("任务上下文"));
         assertNull(result.params().get("任务上下文"));
+    }
+
+    @Test
+    void missingVerdictKeyFailsWithInfrastructureError() {
+        DefaultSemanticValidator validator =
+                new DefaultSemanticValidator(new StubClient("{\"errors\": [], \"params\": {}}"), "en-US");
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate(
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
+        assertTrue(exception.getMessage().contains("semantic_verdict"));
+    }
+
+    @Test
+    void stringVerdictValueFailsWithInfrastructureError() {
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(
+                new StubClient("{\"semantic_verdict\": \"true\", \"errors\": [], \"params\": {}}"), "en-US");
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate(
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
+        assertTrue(exception.getMessage().contains("semantic_verdict"));
+    }
+
+    @Test
+    void nonListErrorsFailsWithInfrastructureError() {
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(
+                new StubClient("{\"semantic_verdict\": true, \"errors\": {}, \"params\": {}}"), "en-US");
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate(
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
+        assertTrue(exception.getMessage().contains("errors"));
+    }
+
+    @Test
+    void malformedErrorElementFailsWithInfrastructureError() {
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(
+                new StubClient("{\"semantic_verdict\": false, \"errors\": [\"oops\"], \"params\": {}}"), "en-US");
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate(
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
+        assertTrue(exception.getMessage().contains("errors"));
+    }
+
+    @Test
+    void nonMapParamsFailsWithInfrastructureError() {
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(
+                new StubClient("{\"semantic_verdict\": true, \"errors\": [], \"params\": []}"), "en-US");
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate(
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
+        assertTrue(exception.getMessage().contains("params"));
+    }
+
+    @Test
+    void nonStringParamKeyFailsWithInfrastructureError() {
+        // JSON object keys are strings by definition; this simulates a parser that produced non-string keys
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(
+                new StubClient("{\"semantic_verdict\": true, \"errors\": [], \"params\": {\"site\": \"Site A\"}}"), "en-US");
+
+        // string keys pass the contract; a valid response must not fail
+        ValidationResult result = validator.validate(
+                "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
+
+        assertTrue(result.verdict());
+    }
+
+    @Test
+    void contractViolationRetriesAndRecoversThroughPipeline() {
+        FlakyPayloadClient client = new FlakyPayloadClient(
+                "{\"semantic_verdict\": \"true\", \"errors\": [], \"params\": {}}", VALID_RESPONSE);
+
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(client, "en-US");
+        ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
+
+        FilledParamData result = pipeline.validate(
+                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"));
+
+        // first attempt violates the output contract (string verdict) → retryable infra error → second attempt
+        // returns a compliant response and the pipeline succeeds
+        assertEquals(Map.of("site", "Site A"), result.data());
+        assertEquals(2, client.invocations());
+    }
+
+    @Test
+    void contractViolationExhaustsRetriesThroughPipeline() {
+        FlakyPayloadClient client = new FlakyPayloadClient(
+                "{\"semantic_verdict\": \"true\", \"errors\": [], \"params\": {}}", null);
+
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(client, "en-US");
+        ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 3);
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> pipeline.validate(
+                        "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving")));
+
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
+        assertEquals(3, client.invocations());
     }
 
     private static final class RecordingClient implements LLMClient {
@@ -256,45 +336,35 @@ class DefaultSemanticValidatorTest {
         }
     }
 
-    /** Resource access recording loadPrompt calls and returning stub prompt text. */
-    private static final class RecordingResourceAccess implements PromptResourceAccess {
+    /** LLM client returning a malformed payload first, then a compliant one (or always malformed when success is null). */
+    private static final class FlakyPayloadClient implements LLMClient {
 
-        private final List<String[]> calls = new ArrayList<>();
+        private final String malformedPayload;
 
-        @Override
-        public boolean classpath() {
-            return false;
+        private final String successPayload;
+
+        private final AtomicInteger counter = new AtomicInteger(0);
+
+        private FlakyPayloadClient(String malformedPayload, String successPayload) {
+            this.malformedPayload = malformedPayload;
+            this.successPayload = successPayload;
         }
 
         @Override
-        public ClasspathPromptResourceLoader classpathResourceLoader() {
-            throw new UnsupportedOperationException("Not used in this test.");
+        public LLMResponse structured(
+                List<Map<String, String>> messages,
+                Map<String, Object> jsonSchema,
+                Double temperature,
+                Integer maxTokens) {
+            int invocation = counter.incrementAndGet();
+            if (invocation == 1 || successPayload == null) {
+                return new LLMResponse(malformedPayload, "test-model", Map.of(), Map.of());
+            }
+            return new LLMResponse(successPayload, "test-model", Map.of(), Map.of());
         }
 
-        @Override
-        public Path localRootDir() {
-            return Path.of(".");
-        }
-
-        @Override
-        public List<ScenarioDefinition> loadScenarios(String language) {
-            return List.of();
-        }
-
-        @Override
-        public PromptTemplateTextLoader templateLoader() {
-            throw new UnsupportedOperationException("Not used in this test.");
-        }
-
-        @Override
-        public PromptSlotSchemaLoader slotSchemaLoader() {
-            throw new UnsupportedOperationException("Not used in this test.");
-        }
-
-        @Override
-        public String loadPrompt(String promptCategory, String language, String fileName) {
-            calls.add(new String[] {promptCategory, language, fileName});
-            return "stub prompt for " + promptCategory + "/" + fileName;
+        int invocations() {
+            return counter.get();
         }
     }
 }

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -24,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class DefaultSemanticValidatorTest {
 
-    private static final String VALID_RESPONSE = """
+    private static final String VALID_RESPONSE =
+            """
             {
               "semantic_verdict": true,
               "errors": [],
@@ -79,7 +81,9 @@ class DefaultSemanticValidatorTest {
 
     @Test
     void validateExhaustsRetriesAndWrapsLlmError() {
-        FlakyClient flakyClient = new FlakyClient(Integer.MAX_VALUE, """
+        FlakyClient flakyClient = new FlakyClient(
+                Integer.MAX_VALUE,
+                """
                 {
                   "semantic_verdict": true,
                   "errors": [],
@@ -94,7 +98,9 @@ class DefaultSemanticValidatorTest {
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> pipeline.validate(
-                        "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving")));
+                        "Check Site A power usage.",
+                        Map.of("type", "object"),
+                        TemplateUri.of("Task-T", "energy-saving")));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertInstanceOf(LLMRuntimeError.class, exception.getCause().getCause());
@@ -112,8 +118,8 @@ class DefaultSemanticValidatorTest {
 
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
 
-        FilledParamData result = pipeline.validate(
-                "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
+        FilledParamData result =
+                pipeline.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
 
         assertEquals(2, result.data().size());
         assertEquals("端口A", result.data().get("任务对象"));
@@ -209,16 +215,37 @@ class DefaultSemanticValidatorTest {
     }
 
     @Test
-    void nonStringParamKeyFailsWithInfrastructureError() {
-        // JSON object keys are strings by definition; this simulates a parser that produced non-string keys
+    void stringParamKeysPassTheContract() {
         DefaultSemanticValidator validator = new DefaultSemanticValidator(
-                new StubClient("{\"semantic_verdict\": true, \"errors\": [], \"params\": {\"site\": \"Site A\"}}"), "en-US");
+                new StubClient("{\"semantic_verdict\": true, \"errors\": [], \"params\": {\"site\": \"Site A\"}}"),
+                "en-US");
 
-        // string keys pass the contract; a valid response must not fail
-        ValidationResult result = validator.validate(
-                "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
+        ValidationResult result =
+                validator.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
 
         assertTrue(result.verdict());
+    }
+
+    @Test
+    void nonStringParamKeyFailsWithInfrastructureError() {
+        // JSON object keys are strings by definition, so the negative path is driven through a parser
+        // stub that produces a non-string key
+        Map<Object, Object> rawParams = new LinkedHashMap<>();
+        rawParams.put(42, "Site A");
+        Map<String, Object> parsed = new LinkedHashMap<>();
+        parsed.put("semantic_verdict", Boolean.TRUE);
+        parsed.put("errors", List.of());
+        parsed.put("params", rawParams);
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(
+                new StubClient("payload content is irrelevant"), "en-US", prompt -> parsed);
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate(
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+
+        assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
+        assertTrue(exception.getMessage().contains("params keys"));
     }
 
     @Test
@@ -240,8 +267,8 @@ class DefaultSemanticValidatorTest {
 
     @Test
     void contractViolationExhaustsRetriesThroughPipeline() {
-        FlakyPayloadClient client = new FlakyPayloadClient(
-                "{\"semantic_verdict\": \"true\", \"errors\": [], \"params\": {}}", null);
+        FlakyPayloadClient client =
+                new FlakyPayloadClient("{\"semantic_verdict\": \"true\", \"errors\": [], \"params\": {}}", null);
 
         DefaultSemanticValidator validator = new DefaultSemanticValidator(client, "en-US");
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 3);
@@ -249,7 +276,9 @@ class DefaultSemanticValidatorTest {
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> pipeline.validate(
-                        "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving")));
+                        "Check Site A power usage.",
+                        Map.of("type", "object"),
+                        TemplateUri.of("Task-T", "energy-saving")));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertEquals(3, client.invocations());
@@ -336,7 +365,9 @@ class DefaultSemanticValidatorTest {
         }
     }
 
-    /** LLM client returning a malformed payload first, then a compliant one (or always malformed when success is null). */
+    /**
+     * LLM client returning a malformed payload first, then a compliant one (or always malformed when success is null).
+     */
     private static final class FlakyPayloadClient implements LLMClient {
 
         private final String malformedPayload;

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
@@ -166,7 +166,7 @@ public final class DefaultA2ATServerBuilder {
      * Builds the task content validator from the configured unified SDK config.
      *
      * <p>The validator enforces the {@code Task-T} extension prefix and reuses the configured language, LLM retry
-     * attempt limit, LLM client and prompt resource access.
+     * attempt limit and LLM client; the content_validation prompt resources are loaded from the classpath.
      *
      * @return assembled task content validator
      */
@@ -178,7 +178,7 @@ public final class DefaultA2ATServerBuilder {
      * Builds the notification content validator from the configured unified SDK config.
      *
      * <p>The validator enforces the {@code Notification-T} extension prefix and reuses the configured language, LLM
-     * retry attempt limit, LLM client and prompt resource access.
+     * retry attempt limit and LLM client; the content_validation prompt resources are loaded from the classpath.
      *
      * @return assembled notification content validator
      */
@@ -190,7 +190,7 @@ public final class DefaultA2ATServerBuilder {
      * Builds the authorization content validator from the configured unified SDK config.
      *
      * <p>The validator enforces the {@code Authorization-T} extension prefix and reuses the configured language, LLM
-     * retry attempt limit, LLM client and prompt resource access.
+     * retry attempt limit and LLM client; the content_validation prompt resources are loaded from the classpath.
      *
      * @return assembled authorization content validator
      */

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
@@ -203,11 +203,7 @@ public final class DefaultA2ATServerBuilder {
         requireSupportedConfig();
         require(envPath, "Unified SDK env path must be configured.");
         return new DefaultContentValidator(
-                extensionName,
-                config.prompt().language(),
-                config.llm().maxAttempts(),
-                llmClient(),
-                PromptResourceAccess.create(config.prompt()));
+                extensionName, config.prompt().language(), config.llm().maxAttempts(), llmClient());
     }
 
     private static void require(Object value, String message) {

--- a/env.example
+++ b/env.example
@@ -2,7 +2,7 @@
 # Controls the language used by prompt runtime components.
 A2AT_LANGUAGE=en-US
 # Selects the prompt source backend.
-A2AT_PROMPT_SOURCE_TYPE=local_file
+A2AT_PROMPT_SOURCE_TYPE=classpath
 # Optional when A2AT_PROMPT_SOURCE_TYPE=local_file.
 A2AT_PROMPT_RESOURCE_LOCAL_ROOT_DIR=
 


### PR DESCRIPTION
## Summary

Three fixes for the server-side content validation pipeline (Task-T / Notification-T / Authorization-T `validate*PromptAndDataFilling`), all verified against the negotiation-side reference implementation:

1. **env.example defaults to classpath** — the previous `local_file` + empty root template made the first validate call fail 100% for users who copied it verbatim (local root resolves to the .env directory, which lacks the prompt tree). Now matches the code default.

2. **content_validation prompts are always loaded from classpath** — they are internal LLM instructions (like the negotiation semantic validation prompts), not business resources. This removes the hidden local_file dependency and aligns implementation with the documented claim that LLM prompt resources always come from the classpath. The lazy pipeline initialisation now maps missing-resource failures to `ContentValidationException(validation_prompt_resource_not_found)`, activating an error code that has been dead code since the pipeline was introduced (`331ff86`); the pipeline stays null so a transient failure retries on the next call.

3. **LLM output contract enforced in code** — a response that is valid JSON but misses a required key or carries a wrong-typed value (string verdict, non-array errors, non-object params) previously got misclassified as `validation_semantic_rejected` (blaming the peer's content) or silently degraded to empty params (verdict=true + zero params masks extraction failure). Both now fail with the retryable `validation_llm_infrastructure_error`, matching the negotiation validator. The output schema now requires all three keys, disallows additional properties and specifies the error item shape — resolving its self-contradiction with the system prompt.

## Test plan

- [x] `DefaultSemanticValidatorTest` rewritten: new constructor signature, drift matrix (8 new cases: missing verdict key / string verdict / non-list errors / malformed error element / non-map params / retry-and-recover / retry-exhausted)
- [x] New `DefaultContentValidatorTest`: resource-mapping contract (fr-FR maps to `validation_prompt_resource_not_found` with RNFE cause), extension mismatch, LLM infra mapping after resource load
- [x] `mvn verify` full reactor green

## Notes

- No new error codes; the public error-code registry is untouched.
- `DefaultContentValidator` / `DefaultSemanticValidator` no longer depend on `PromptResourceAccess` (constructor signature change; both are SDK-internal wiring points with no external callers).
- The old fr-FR test that had pinned the raw `ResourceNotFoundException` leak as expected behaviour was updated to assert the mapped contract.
