### PR TITLE
fix(client): register built-in negotiation handlers in the client orchestrator

### DIFF
--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilder.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilder.java
@@ -122,6 +122,10 @@ public final class DefaultA2ATClientBuilder {
     /**
      * Builds the default negotiation orchestrator from the configured unified SDK config.
      *
+     * <p>Registers handlers for all three built-in negotiation types, mirroring the server-side
+     * {@code ServerNegotiationOrchestratorBuilder}. Without them {@code receiveNegotiation}
+     * fails with "Unsupported negotiation type" for every message.
+     *
      * @return assembled negotiation orchestrator
      */
     public RoleBoundNegotiationOrchestrator buildNegotiationOrchestrator() {
@@ -130,6 +134,15 @@ public final class DefaultA2ATClientBuilder {
         return new RoleBoundNegotiationOrchestrator(
                 NegotiationHandler.builder()
                         .store(new InMemoryNegotiationStore())
+                        .register(
+                                net.openan.a2at.sdk.negotiation.types.model.NegotiationType.INFORMATION,
+                                new net.openan.a2at.sdk.negotiation.handler.InformationNegotiation())
+                        .register(
+                                net.openan.a2at.sdk.negotiation.types.model.NegotiationType.TARGET,
+                                new net.openan.a2at.sdk.negotiation.handler.TargetNegotiation())
+                        .register(
+                                net.openan.a2at.sdk.negotiation.types.model.NegotiationType.FEASIBILITY,
+                                new net.openan.a2at.sdk.negotiation.handler.FeasibilityNegotiation())
                         .build(),
                 NegotiationRole.CLIENT);
     }

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
@@ -222,6 +222,41 @@ class A2ATClientTest {
         assertEquals("Site A", continueData.get("message"));
     }
 
+    /**
+     * Regression test: the client orchestrator must register handlers for all built-in
+     * negotiation types. Before the fix every {@code receiveNegotiation} call failed with
+     * "Unsupported negotiation type: ..." because {@code DefaultA2ATClientBuilder} built the
+     * handler map empty (the server-side builder registers all three).
+     */
+    @Test
+    void receiveNegotiationDispatchesToBuiltInHandlers() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        for (NegotiationType type : NegotiationType.values()) {
+            Map<String, Object> startResult =
+                    client.startNegotiation(type, "Please provide the missing parameter.", Map.of());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> startData = (Map<String, Object>)
+                    startResult.get(net.openan.a2at.sdk.negotiation.runtime.NegotiationHandler.NEGOTIATION_T_URI_NL);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> contextMap = new java.util.LinkedHashMap<>(startData);
+            contextMap.remove("message");
+
+            Map<String, Object> receiveResult = client.receiveNegotiation(
+                    "Parameter provided: port-1.", contextMap);
+
+            assertEquals(Boolean.TRUE, receiveResult.get("needResponse"),
+                    type + " must dispatch to a registered handler");
+            assertEquals("Parameter provided: port-1.", receiveResult.get("message"),
+                    type + " handler must echo the received message");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> roundTripped = (Map<String, Object>) receiveResult.get("context");
+            assertEquals(startData.get("negotiationId"), roundTripped.get("negotiationId"),
+                    type + " receive must carry the negotiation context");
+        }
+    }
+
     @Test
     void pathBasedConstructorSupportsNonEnergySavingLocalScenarioCatalog() throws IOException {
         Path tempDir = Files.createTempDirectory("a2at-client-private-line");


### PR DESCRIPTION
Closes #137

## Problem

`A2ATClient.receiveNegotiation` **always throws** `NegotiationStateException: Unsupported negotiation type: <TYPE>` on the client side — for every negotiation type, every message, every time.

## Root cause

`DefaultA2ATClientBuilder.buildNegotiationOrchestrator()` assembles the `NegotiationHandler` with a store but **zero type registrations**:

```java
// before
return new RoleBoundNegotiationOrchestrator(
        NegotiationHandler.builder()
                .store(new InMemoryNegotiationStore())
                .build(),          // ← empty handler map
        NegotiationRole.CLIENT);
```

The dispatch chain is `receiveNegotiation → RoleBoundNegotiationOrchestrator → NegotiationHandler.receive → NegotiationRuntime.receive → negotiationHandlerMap.get(context.negotiationType())`; an empty map always throws.

The server-side `ServerNegotiationOrchestratorBuilder.build()` registers all three built-in handlers — the asymmetry is specific to the client builder.

Why it went unnoticed:

- the bundled negotiation sample only calls `startNegotiation`, never `receiveNegotiation`
- `Negotiation-Sample-Design.md` §8.2 documents "skip receiveNegotiation on the missing-params branch" as a known limitation (workaround, not fix)
- no existing unit test exercises the client-side receive path

## Fix

Mirror the server wiring: register the three built-in handlers in the client builder.

```java
// after
return new RoleBoundNegotiationOrchestrator(
        NegotiationHandler.builder()
                .store(new InMemoryNegotiationStore())
                .register(NegotiationType.INFORMATION, new InformationNegotiation())
                .register(NegotiationType.TARGET, new TargetNegotiation())
                .register(NegotiationType.FEASIBILITY, new FeasibilityNegotiation())
                .build(),
        NegotiationRole.CLIENT);
```

`InformationNegotiation` uses the no-arg constructor on the client side — the compliance-checker callback is a server-side concern (the server validates received Task-T prompts; the client receives the agent's negotiation request and echoes it with `needResponse=true`).

## Test

Adds `A2ATClientTest.receiveNegotiationDispatchesToBuiltInHandlers`: starts a negotiation per built-in type and receives a reply, asserting `needResponse=true`, message echo, and context round-trip.

- Red on the unfixed builder: fails with `NegotiationStateException: Unsupported negotiation type: INFORMATION` (verified by reverting only the builder change)
- Green after the fix
- Full a2a-t-client module: 83 tests pass

## Downstream verification

In our downstream workflow engine (`workflow-exec-engine-java`), the Negotiation-T auto-loop previously degraded to a non-SDK fallback path on every round because of this bug. With the fix, the full documented chain runs on the SDK path with zero degradation:

```
agent propose (stateful context)
  → receiveNegotiation          ✓ (was: Unsupported negotiation type)
  → validateProposePromptAndDataFilling   ✓ extracted [id, round, maxRounds] params
  → generateNegotiationAcceptPromptFromText
  → continueNegotiation          ✓ state machine advances
```

Side note for reviewers: with the client receive path working, the "known limitation" wording in `Negotiation-Sample-Design.md` §8.2 may deserve a follow-up revisit.