### PR TITLE
feat(sample): negotiation interface evaluator with fine-grained cases and API-call evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ task_plan.md
 .idea/
 
 .worktrees/
+eval-results/
+eval-run*.log
+eval-smoke.json

--- a/a2a-t-sample/README.zh-CN.md
+++ b/a2a-t-sample/README.zh-CN.md
@@ -121,6 +121,55 @@ java @a2a-t-sample/target/fromtext.javaargs.txt /path/to/.env
 
 复用 `shared/NegotiationSampleSupport` 公共辅助（SessionId、模板 URI 常量、summary），fromData 和 fromText 差异仅在输入构造（record vs 自然语言文本）。
 
+## 协商接口闭环评测（Negotiation Interface Eval）
+
+`NegotiationEvalApp` 是纯 Java 评测入口，对 `eval-suite.json` 里的每个用例按报文顺序驱动协商 prompt 接口，逐步采集证据并输出可回放的 JSON 报告：
+
+| 步骤 | 角色 | 接口 | 说明 |
+|---|---|---|---|
+| 1. Task-T 生成 | client | `generateTaskPromptFromDataWithSchema` / `FromText` | 按 case 的 `channel` 字段选通道；fromData 传入结构化 JSON（每个 key 对应一个槽位值）+ JSON schema |
+| 2. 服务端校验 | server | `validateTaskPromptAndDataFilling` | 传入 JSON schema 做缺槽检测 |
+| 3. Negotiation-T propose 生成 | server | `generateNegotiationProposePromptFromData` / `FromText` | 按 case 的 `negotiation_channel` 字段选通道 |
+| 4. 出站 propose 自检 | server | `validateProposePromptAndDataFilling` | 发送前自检，显式 `NegotiationContext` |
+| 5. 入站 propose 校验 | client | `validateProposePromptAndDataFilling` | 客户端校验收到的协商请求，提取"需要补充的槽位清单"，补槽由该清单驱动 |
+| 6. 客户端补槽 + accept 生成 | client | `generateTaskPromptFromDataWithSchema` + `generateNegotiationAcceptPromptFromData` / `FromText` | 补槽值来自 suite 的 `client_fill_values` |
+| 7. 入站 accept 校验 | server | `validateAcceptPromptAndDataFilling` | 校验抽取的槽值与补槽值一致 |
+| 8. 二次 Task-T 校验 | server | `validateTaskPromptAndDataFilling` | 断言闭环后无缺槽 |
+
+**API 调用证据**：报告的每个步骤都记录 `api_calls`（SDK 方法名 + 完整输入参数，含传入的 JSON schema 全文），可从报告直接核对每次调用是否携带 schema、用了哪个模板 URI 和协商上下文。
+
+**协议约定**（两条常见问题）：
+
+1. **服务端发起协商后，客户端是否还需调用 validate？** 是。SDK 在 client/server 两个门面上提供对称的 `validate*PromptAndDataFilling` API：发送方出站自检（步骤 4），接收方入站校验（步骤 5/7）。客户端收到 propose 后应调 `validateProposePromptAndDataFilling` 提取需要补充的槽位清单，再据此补槽。
+2. **客户端接受协商并补充报文后，服务端如何合并原始模板与协商补充内容？** 无增量合并 API。合并发生在客户端：客户端持有完整参数集（round-1 提取参数 + 补槽值），用 `generateTaskPromptFromDataWithSchema` **重新渲染整份 Task-T**（步骤 6），随 accept 一并发送；服务端对完整报文做 `validateTaskPromptAndDataFilling`（步骤 8）提参，不做"原始模板+增量"拼接。
+
+**槽位契约**：评测直接使用 SDK 内置的 private-line-complaint 模板（不做任何资源改动）。模板将"任务上下文"定义为一个组合槽，其内部要求 4 个子项（投诉分类[必选]、问题发生时间[可选]、OSS侧事件流水号[必选]、投诉详情[可选]）。评测的 `task_schema`（eval-suite.json 内）把该组合槽细化为 4 个独立子槽位用于**校验**：子项缺失在非空"任务上下文"内被校验检出并触发协商；"任务上下文"整体为空则在生成期被拦截（内置 required 槽，fail-fast）。fromData 用例输入为结构化 JSON——每个 key 对应一个明确的子项值（如 `"OSS侧事件流水号": "event-id-20260511-09013"`），生成时由 SDK 抽取管线组合进模板。
+
+通道语义：`fromData` 传结构化 JSON + schema；`fromText` 传自然语言由 LLM 抽取。所有生成/校验接口均走 SDK 管线（规则门 + 语义 LLM 调用）。**需要真实 LLM API key**（env 文件参考根目录 `env.example`，至少配置 `A2AT_LLM_PROVIDER` / `A2AT_LLM_MODEL` / `A2AT_LLM_API_KEY` / `A2AT_LLM_BASE_URL`）。
+
+运行命令：
+
+```bash
+# 1. 打包（首次，生成 target/eval.javaargs.txt）
+mvn -pl a2a-t-sample -am -DskipTests package
+
+# 2. 跑全量用例（每个 case 按各自 channel 配置执行）
+java @a2a-t-sample/target/eval.javaargs.txt /path/to/.env
+
+# 3. 只跑指定 case（可重复传 --case）
+java @a2a-t-sample/target/eval.javaargs.txt --case PLC-04 /path/to/.env
+
+# 4. 强制全量走 fromText 协商通道（不改用例文件）
+java @a2a-t-sample/target/eval.javaargs.txt --negotiation-channel fromText /path/to/.env
+
+# 5. 指定报告输出路径（默认 ./eval-report.json）
+java @a2a-t-sample/target/eval.javaargs.txt --out eval-report-my-model.json /path/to/.env
+```
+
+**换用其他模型测试**：只需在 env 文件里改 4 个 LLM 变量（`A2AT_LLM_PROVIDER` / `A2AT_LLM_MODEL` / `A2AT_LLM_API_KEY` / `A2AT_LLM_BASE_URL`），无需改任何代码或用例。报告的 `llm` 字段会记录当次使用的 provider / model / base_url，`negotiation_channel` 字段记录当次通道（`per-case` 或强制值），便于横向对比多个模型的报告。
+
+用例集：`sample/negotiation/eval/eval-suite.json`（15 条用例：fromData/fromText × 完整输入/任务对象缺失/投诉分类缺失/OSS流水号缺失/可选槽缺失/双槽缺失/负例补槽约束违反，含正反两类断言）。报告中每个 case 输出逐步证据（`api_calls`、生成 prompt 原文、校验判定与抽取参数、耗时），`metrics` 汇总通过率。
+
 ## 授权策略（Authorization-T）演示 Demo
 
 授权策略 Demo 是单进程直调 SDK 示例：客户端生成 Authorization-T prompt → 服务端校验合规性并提取参数。覆盖 3 个预置场景：

--- a/a2a-t-sample/README.zh-CN.md
+++ b/a2a-t-sample/README.zh-CN.md
@@ -168,6 +168,22 @@ java @a2a-t-sample/target/eval.javaargs.txt --out eval-report-my-model.json /pat
 
 **换用其他模型测试**：只需在 env 文件里改 4 个 LLM 变量（`A2AT_LLM_PROVIDER` / `A2AT_LLM_MODEL` / `A2AT_LLM_API_KEY` / `A2AT_LLM_BASE_URL`），无需改任何代码或用例。报告的 `llm` 字段会记录当次使用的 provider / model / base_url，`negotiation_channel` 字段记录当次通道（`per-case` 或强制值），便于横向对比多个模型的报告。
 
+**env 配置**：复制以下内容为 `eval.env`，填入你的模型信息即可（完整变量说明见根目录 `env.example`）：
+
+```bash
+A2AT_LANGUAGE=zh-CN
+A2AT_PROMPT_SOURCE_TYPE=classpath
+A2AT_LLM_PROVIDER=openai                     # OpenAI 兼容端点均为 openai
+A2AT_LLM_MODEL=glm-5.2                       # 换成你的模型名
+A2AT_LLM_API_KEY=sk-xxxxxxxx                 # 你的 API key
+A2AT_LLM_BASE_URL=https://your-endpoint/v1   # OpenAI 兼容 base URL
+A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
+A2AT_LLM_TIMEOUT_SECONDS=180                 # 推理型模型建议调大（默认 60）
+A2AT_LLM_MAX_TOKENS=8192                     # 推理型模型建议调大（默认 2000）
+```
+
+`*.env` 已被 .gitignore 忽略，携带真实 key 的 env 文件不会被提交。
+
 用例集：`sample/negotiation/eval/eval-suite.json`（15 条用例：fromData/fromText × 完整输入/任务对象缺失/投诉分类缺失/OSS流水号缺失/可选槽缺失/双槽缺失/负例补槽约束违反，含正反两类断言）。报告中每个 case 输出逐步证据（`api_calls`、生成 prompt 原文、校验判定与抽取参数、耗时），`metrics` 汇总通过率。
 
 ## 授权策略（Authorization-T）演示 Demo

--- a/a2a-t-sample/pom.xml
+++ b/a2a-t-sample/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
@@ -42,17 +42,22 @@ import net.openan.a2at.sdk.server.A2ATServer;
  * negotiation interfaces in message order, exactly the way the negotiation demo wires them:
  *
  * <ol>
- *   <li>Task-T generation — the client value from the Task-T extension metadata is either structured
- *       ({@code generateTaskPromptFromDataWithSchema}, deterministic rendering) or natural language
- *       ({@code generateTaskPromptFromText}, LLM slot extraction); both produce the Task-T prompt text;
- *   <li>server validation — {@code validateTaskPromptAndDataFilling} extracts the parameters; the missing-slot set
- *       (blank slots plus semantic {@code missing_required} errors) decides whether negotiation is triggered;
- *   <li>propose generation — for the detected missing slots, {@code generateNegotiationProposePromptFromData}
- *       renders the Negotiation-T information-propose message;
- *   <li>outbound propose validation — {@code validateProposePromptAndDataFilling} checks the generated propose
- *       against the negotiation template before it is sent (expected to pass);
- *   <li>client fill + accept — the client supplies the missing values, appends them to the Task-T prompt and renders
- *       the Negotiation-T accept via {@code generateNegotiationAcceptPromptFromData};
+ *   <li>Task-T generation — the client value from the Task-T extension metadata is either structured JSON
+ *       ({@code generateTaskPromptFromDataWithSchema}: every data key maps to one slot value, the schema is passed
+ *       as a call parameter) or natural language ({@code generateTaskPromptFromText}, LLM slot extraction);
+ *   <li>server validation — {@code validateTaskPromptAndDataFilling} extracts the parameters against the passed
+ *       JSON schema; the missing-slot set (blank slots plus semantic {@code missing_required} errors) decides
+ *       whether negotiation is triggered;
+ *   <li>propose generation — for the detected missing slots, {@code generateNegotiationProposePromptFromData} /
+ *       {@code FromText} renders the Negotiation-T information-propose message;
+ *   <li>outbound propose validation — the server self-checks the generated propose via
+ *       {@code validateProposePromptAndDataFilling} before sending it (expected to pass);
+ *   <li>inbound propose validation — the client validates the received propose through the symmetric client-side
+ *       API {@code validateProposePromptAndDataFilling} and reads out which slots it is asked to supplement;
+ *       the fill round is driven by this client-side view;
+ *   <li>client fill + accept — the client merges the round-1 parameters with its fill values, RE-RENDERS the full
+ *       Task-T prompt from the complete parameter map (there is no incremental merge API; the supplement is
+ *       incorporated by re-generating the whole prompt) and renders the Negotiation-T accept;
  *   <li>inbound accept validation — {@code validateAcceptPromptAndDataFilling} checks the accept message and extracts
  *       the supplemented values (expected to pass with the values the client sent);
  *   <li>second Task-T validation — {@code validateTaskPromptAndDataFilling} re-validates the filled Task-T prompt;
@@ -60,10 +65,12 @@ import net.openan.a2at.sdk.server.A2ATServer;
  *       INPUT_REQUIRED.
  * </ol>
  *
- * <p>Every intermediate artifact — the generated Task-T prompt, both negotiation messages, each validation verdict
- * with extracted parameters and per-slot errors, the client's fill values — is recorded per case in a JSON report, so
- * a single case can be replayed and audited without re-running it. The report is rewritten after every case, so an
- * interrupted run keeps the cases already finished.
+ * <p>Every intermediate artifact is recorded per case in a JSON report: the generated Task-T prompt, both
+ * negotiation messages, each validation verdict with extracted parameters and per-slot errors, the client's fill
+ * values — and, for every SDK call, an {@code api} entry carrying the exact method name plus its input parameters
+ * (including the full JSON schema passed to generate/validate), so a reviewer can verify from the report alone
+ * which interface ran with which arguments. A single case can be replayed and audited without re-running it. The
+ * report is rewritten after every case, so an interrupted run keeps the cases already finished.
  *
  * <p>Usage:
  *
@@ -91,12 +98,15 @@ public final class NegotiationEvalApp {
         Path envPath = null;
         Path outPath = Path.of("eval-report.json");
         List<String> caseFilter = new ArrayList<>();
+        String negotiationChannelOverride = null;
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
             if ("--out".equals(arg) && i + 1 < args.length) {
                 outPath = Path.of(args[++i]);
             } else if ("--case".equals(arg) && i + 1 < args.length) {
                 caseFilter.add(args[++i]);
+            } else if ("--negotiation-channel".equals(arg) && i + 1 < args.length) {
+                negotiationChannelOverride = args[++i];
             } else if (!arg.startsWith("--")) {
                 envPath = Path.of(arg);
             }
@@ -104,12 +114,18 @@ public final class NegotiationEvalApp {
         if (envPath == null) {
             System.err.println(
                     "Usage: java @a2a-t-sample/target/eval.javaargs.txt [--out eval-report.json] [--case PLC-04]"
-                            + " /path/to/.env");
+                            + " [--negotiation-channel fromData|fromText] /path/to/.env");
             System.exit(1);
         }
 
         SampleMockLlmInstaller.installLlmLogger(false, "eval");
         Map<String, Object> suite = loadSuite();
+        if (negotiationChannelOverride != null) {
+            // run the whole suite with one negotiation generation channel without duplicating cases
+            for (Map<String, Object> testCase : cases(suite)) {
+                testCase.put("negotiation_channel", negotiationChannelOverride);
+            }
+        }
 
         Map<String, Object> report = new LinkedHashMap<>();
         report.put("suite", suite.get("suite"));
@@ -118,6 +134,9 @@ public final class NegotiationEvalApp {
         report.put("generated_at", LocalDateTime.now().format(TIMESTAMP));
         report.put("llm", llmInfo(envPath));
         report.put("case_filter", caseFilter);
+        report.put("negotiation_channel", negotiationChannelOverride == null
+                ? "per-case"
+                : negotiationChannelOverride);
 
         List<Map<String, Object>> cases = new ArrayList<>();
         report.put("cases", cases);
@@ -158,6 +177,8 @@ public final class NegotiationEvalApp {
         String caseId = String.valueOf(testCase.get("id"));
         String channel = String.valueOf(testCase.get("channel"));
         boolean fromText = "fromText".equals(channel);
+        String negotiationChannel = String.valueOf(testCase.getOrDefault("negotiation_channel", "fromData"));
+        boolean negotiationFromText = "fromText".equals(negotiationChannel);
         String inputText = String.valueOf(testCase.get("input_text"));
         Map<String, Object> inputData = asMap(testCase.get("input_data"));
 
@@ -165,6 +186,7 @@ public final class NegotiationEvalApp {
         Map<String, Object> taskSchema = asMap(suite.get("task_schema"));
         Map<String, String> phrasing = stringMap(suite.get("negotiation_phrasing"));
         Map<String, Object> properties = asMap(taskSchema.get("properties"));
+        Set<String> requiredSlots = new TreeSet<>(stringList(taskSchema.get("required")));
         Map<String, String> fillValues = mergeFills(stringMap(suite.get("client_fill_values")),
                 stringMap(testCase.get("fill_override")));
 
@@ -177,6 +199,7 @@ public final class NegotiationEvalApp {
         Map<String, Object> record = new LinkedHashMap<>();
         record.put("case", caseId);
         record.put("channel", channel);
+        record.put("negotiation_channel", negotiationChannel);
         record.put("intent", testCase.get("intent"));
         Map<String, Object> input = new LinkedHashMap<>();
         input.put("fromText", fromText);
@@ -186,6 +209,7 @@ public final class NegotiationEvalApp {
             input.put("data", inputData);
         }
         record.put("input", input);
+        record.put("task_schema", taskSchema);
         Map<String, Object> expectJson = new LinkedHashMap<>();
         expectJson.put("negotiation_needed", expectNegotiation);
         expectJson.put("missing_slots", new ArrayList<>(expectMissing));
@@ -196,6 +220,17 @@ public final class NegotiationEvalApp {
         record.put("steps", steps);
 
         // -- step 1: Task-T prompt generation from the extension metadata value --
+        Map<String, Object> taskGenerationInput = new LinkedHashMap<>();
+        if (fromText) {
+            taskGenerationInput.put("text", inputText);
+        } else {
+            taskGenerationInput.put("data", inputData);
+            taskGenerationInput.put("schema", taskSchema);
+        }
+        taskGenerationInput.put("template_uri", taskTemplate.uri());
+        String taskGenerationApi = fromText
+                ? "A2ATClient.generateTaskPromptFromText"
+                : "A2ATClient.generateTaskPromptFromDataWithSchema";
         String taskPrompt;
         try {
             long nanos = System.nanoTime();
@@ -205,12 +240,14 @@ public final class NegotiationEvalApp {
                     : client.generateTaskPromptFromDataWithSchema(inputData, taskSchema, taskTemplate);
             taskPrompt = taskContent.promptText();
             Map<String, Object> step = step("1. Task-T generation (" + channel + ")", "client");
+            api(step, apiCall(taskGenerationApi, taskGenerationInput));
             step.put("generated_prompt", taskPrompt);
             step.put("template_uri", taskContent.templateUri());
             steps.add(step);
             emit("[eval]   [1] Task-T prompt generated (" + channel + ", " + secs(nanos) + "s)");
         } catch (A2ATError error) {
-            steps.add(errorStep("1. Task-T generation (" + channel + ")", "task_generation", error));
+            steps.add(errorStep("1. Task-T generation (" + channel + ")", "task_generation", error,
+                    apiCall(taskGenerationApi, taskGenerationInput)));
             emit("[eval]   [1] Task-T generation FAILED: " + error.getCode() + " " + error.getMessage());
             if (expectGenerationFails) {
                 // generation-time fail-fast is the expected outcome (e.g. a required slot missing from the
@@ -233,27 +270,35 @@ public final class NegotiationEvalApp {
         }
 
         // -- step 2: server validation of the Task-T prompt -> missing-slot detection --
+        Map<String, Object> taskValidationInput = Map.of(
+                "prompt", taskPrompt,
+                "schema", taskSchema,
+                "template_uri", taskTemplate.uri());
         Set<String> actualMissing;
         Map<String, Object> extractedRound1 = new LinkedHashMap<>();
         try {
             long nanos = System.nanoTime();
             A2ATServer server = new A2ATServer(envPath);
             FilledParamData params = server.validateTaskPromptAndDataFilling(taskPrompt, taskSchema, taskTemplate);
-            actualMissing = blankSlots(params);
+            actualMissing = requiredMissing(blankSlots(params), requiredSlots);
             if (params.data() != null) {
                 extractedRound1.putAll(params.data());
             }
-            steps.add(stepOf(
+            Map<String, Object> step = stepOf(
                     "2. server Task-T validation (missing-slot detection)",
                     "server",
-                    validationJson("passed", null, null, params, actualMissing)));
+                    validationJson("passed", null, null, params, actualMissing));
+            api(step, apiCall("A2ATServer.validateTaskPromptAndDataFilling", taskValidationInput));
+            steps.add(step);
             emit("[eval]   [2] validation passed, missing slots: " + actualMissing + " (" + secs(nanos) + "s)");
         } catch (ContentValidationException error) {
-            actualMissing = errorSlots(error);
-            steps.add(stepOf(
+            actualMissing = requiredMissing(errorSlots(error), requiredSlots);
+            Map<String, Object> step = stepOf(
                     "2. server Task-T validation (missing-slot detection)",
                     "server",
-                    validationJson("rejected", error.getCode(), error.errors(), null, actualMissing)));
+                    validationJson("rejected", error.getCode(), error.errors(), null, actualMissing));
+            api(step, apiCall("A2ATServer.validateTaskPromptAndDataFilling", taskValidationInput));
+            steps.add(step);
             emit("[eval]   [2] validation rejected (" + error.getCode() + "), missing slots: " + actualMissing);
         }
 
@@ -272,43 +317,75 @@ public final class NegotiationEvalApp {
         for (String slot : actualMissing) {
             missingItems.add(new NegotiationItem(slot, missingHint(phrasing, properties, slot)));
         }
-        String proposePrompt;
         NegotiationContext proposeContext = new NegotiationContext(
                 UUID.randomUUID().toString(), 1, NegotiationContext.DEFAULT_MAX_ROUNDS);
+        String proposeInputText = itemsToProposeText(missingItems, phrasing);
+        Map<String, Object> proposeGenerationInput = new LinkedHashMap<>();
+        if (negotiationFromText) {
+            proposeGenerationInput.put("text", proposeInputText);
+            proposeGenerationInput.put("context", contextJson(proposeContext));
+        } else {
+            proposeGenerationInput.put("data", Map.of(
+                    "context", contextJson(proposeContext),
+                    "items", itemsJson(missingItems),
+                    "relationship", String.valueOf(phrasing.get("propose_relationship"))));
+        }
+        proposeGenerationInput.put("template_uri", DemoTemplates.NEGOTIATION_PROPOSE.uri());
+        String proposeGenerationApi = negotiationFromText
+                ? "A2ATServer.generateNegotiationProposePromptFromText"
+                : "A2ATServer.generateNegotiationProposePromptFromData";
+        String proposePrompt;
         try {
             A2ATServer server = new A2ATServer(envPath);
-            MetadataContent propose = server.generateNegotiationProposePromptFromData(
-                    new NegotiationProposeData(
-                            proposeContext,
-                            new InformationProposeContent(missingItems, phrasing.get("propose_relationship"))),
-                    DemoTemplates.NEGOTIATION_PROPOSE);
+            MetadataContent propose = negotiationFromText
+                    ? server.generateNegotiationProposePromptFromText(
+                            proposeInputText, proposeContext, DemoTemplates.NEGOTIATION_PROPOSE)
+                    : server.generateNegotiationProposePromptFromData(
+                            new NegotiationProposeData(
+                                    proposeContext,
+                                    new InformationProposeContent(missingItems, phrasing.get("propose_relationship"))),
+                            DemoTemplates.NEGOTIATION_PROPOSE);
             proposePrompt = propose.promptText();
-            Map<String, Object> step = step("3. Negotiation-T propose generation (fromData)", "server");
+            Map<String, Object> step =
+                    step("3. Negotiation-T propose generation (" + negotiationChannel + ")", "server");
+            api(step, apiCall(proposeGenerationApi, proposeGenerationInput));
             step.put("negotiation_items", itemsJson(missingItems));
+            if (negotiationFromText) {
+                step.put("input_text", proposeInputText);
+            }
             step.put("generated_prompt", proposePrompt);
             step.put("template_uri", propose.templateUri());
             step.put("task_state", "INPUT_REQUIRED");
             steps.add(step);
-            emit("[eval]   [3] propose rendered for " + actualMissing + " -> INPUT_REQUIRED");
+            emit("[eval]   [3] propose rendered for " + actualMissing + " (" + negotiationChannel
+                    + ") -> INPUT_REQUIRED");
         } catch (A2ATError error) {
-            steps.add(errorStep("3. Negotiation-T propose generation (fromData)", "propose_generation", error));
+            steps.add(errorStep("3. Negotiation-T propose generation (" + negotiationChannel + ")",
+                    "propose_generation", error, apiCall(proposeGenerationApi, proposeGenerationInput)));
             emit("[eval]   [3] propose generation FAILED: " + error.getCode() + " " + error.getMessage());
             return finish(record, steps, negotiationTriggered, actualMissing, null, null, null, expectNegotiation,
                     expectMissing, expectFillCompletes);
         }
 
         // -- step 4: outbound validation of the generated propose --
+        Map<String, Object> proposeValidationInput = Map.of(
+                "prompt", proposePrompt,
+                "context", contextJson(proposeContext),
+                "schema", negotiationSchema(actualMissing, taskSchema),
+                "template_uri", DemoTemplates.NEGOTIATION_PROPOSE.uri());
         Boolean proposeValid = null;
         try {
             long nanos = System.nanoTime();
             A2ATServer server = new A2ATServer(envPath);
             FilledParamData proposeParams = server.validateProposePromptAndDataFilling(
-                    proposePrompt, proposeContext, negotiationSchema(actualMissing), DemoTemplates.NEGOTIATION_PROPOSE);
+                    proposePrompt, proposeContext, negotiationSchema(actualMissing, taskSchema),
+                    DemoTemplates.NEGOTIATION_PROPOSE);
             proposeValid = true;
             Map<String, Object> step = stepOf(
                     "4. outbound propose validation",
                     "server",
                     validationJson("passed", null, null, proposeParams, Set.of()));
+            api(step, apiCall("A2ATServer.validateProposePromptAndDataFilling", proposeValidationInput));
             steps.add(step);
             emit("[eval]   [4] outbound propose validation passed (" + secs(nanos) + "s)");
         } catch (A2ATError error) {
@@ -321,19 +398,80 @@ public final class NegotiationEvalApp {
                     "4. outbound propose validation",
                     "server",
                     validationJson("rejected", error.getCode(), slotErrors, null, Set.of()));
+            api(step, apiCall("A2ATServer.validateProposePromptAndDataFilling", proposeValidationInput));
             steps.add(step);
             emit("[eval]   [4] outbound propose validation REJECTED: " + error.getCode() + " " + error.getMessage());
         }
 
-        // -- step 5: client fills the missing slots and renders the Negotiation-T accept --
+        // -- step 5: client validates the INBOUND propose and reads out the requested slots --
+        // The SDK exposes the validate* API symmetrically on client and server: the receiving client re-validates
+        // the negotiation message it got and extracts which slots the server asked it to supplement. The fill round
+        // below is driven by this client-side view (not by the server's internal missing-slot set), so the report
+        // shows what a real client would learn from the propose message alone.
+        Set<String> clientRequestedSlots = new TreeSet<>();
+        try {
+            long nanos = System.nanoTime();
+            A2ATClient client = new A2ATClient(envPath);
+            FilledParamData requested = client.validateProposePromptAndDataFilling(
+                    proposePrompt, proposeContext, negotiationSchema(actualMissing, taskSchema),
+                    DemoTemplates.NEGOTIATION_PROPOSE);
+            if (requested.data() != null) {
+                for (String key : requested.data().keySet()) {
+                    // the SDK merges the negotiation context (id/round/maxRounds) into the extracted data; only the
+                    // real slot names tell the client what to supplement
+                    if (!"id".equals(key) && !"round".equals(key) && !"maxRounds".equals(key)) {
+                        clientRequestedSlots.add(key);
+                    }
+                }
+            }
+            Map<String, Object> step = stepOf(
+                    "5. client inbound propose validation (requested-slot extraction)",
+                    "client",
+                    validationJson("passed", null, null, requested, Set.of()));
+            api(step, apiCall("A2ATClient.validateProposePromptAndDataFilling", Map.of(
+                    "prompt", proposePrompt,
+                    "context", contextJson(proposeContext),
+                    "schema", negotiationSchema(actualMissing, taskSchema),
+                    "template_uri", DemoTemplates.NEGOTIATION_PROPOSE.uri())));
+            step.put("client_requested_slots", new ArrayList<>(clientRequestedSlots));
+            steps.add(step);
+            emit("[eval]   [5] client extracted requested slots: " + clientRequestedSlots + " (" + secs(nanos)
+                    + "s)");
+        } catch (A2ATError error) {
+            List<SlotValidationError> slotErrors = error instanceof
+                    net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException extraction
+                    ? extraction.getErrors()
+                    : List.of();
+            Map<String, Object> step = stepOf(
+                    "5. client inbound propose validation (requested-slot extraction)",
+                    "client",
+                    validationJson("rejected", error.getCode(), slotErrors, null, Set.of()));
+            api(step, apiCall("A2ATClient.validateProposePromptAndDataFilling", Map.of(
+                    "prompt", proposePrompt,
+                    "context", contextJson(proposeContext),
+                    "schema", negotiationSchema(actualMissing, taskSchema),
+                    "template_uri", DemoTemplates.NEGOTIATION_PROPOSE.uri())));
+            step.put("client_requested_slots", List.of());
+            steps.add(step);
+            emit("[eval]   [5] client propose validation REJECTED: " + error.getCode() + " " + error.getMessage()
+                    + " -> falling back to the server-side missing-slot set for the fill");
+        }
+        Set<String> slotsToFill = clientRequestedSlots.isEmpty() ? actualMissing : clientRequestedSlots;
+
+        // -- step 6: client fills the requested slots and renders the Negotiation-T accept --
         // the filled Task-T prompt is RE-GENERATED from the complete parameter map, exactly like the demo renders
-        // message 3's Task-T from the filled params — not text-appended. The client knows the full parameter set:
-        // the fromData input, or (for fromText) the parameters the server extracted in round 1 when validation
-        // passed, completed with the suite's fill values for everything still missing.
-        Map<String, String> fills = fills(actualMissing, fillValues);
+        // message 3's Task-T from the filled params — not text-appended. There is no incremental merge API: the
+        // client holds the full parameter set (the fromData input, or for fromText the parameters the server
+        // extracted in round 1), completed with the fill values for everything still missing, and re-renders the
+        // whole Task-T prompt from that map.
+        Map<String, String> fills = fills(slotsToFill, fillValues);
         Map<String, Object> baseData = fromText ? extractedRound1 : inputData;
         Map<String, Object> filledData = mergeInputData(baseData, taskSchema, mergeFills(fillValues, fills));
         String filledPrompt;
+        Map<String, Object> filledGenerationInput = Map.of(
+                "data", filledData,
+                "schema", taskSchema,
+                "template_uri", taskTemplate.uri());
         try {
             A2ATClient client = new A2ATClient(envPath);
             filledPrompt = client.generateTaskPromptFromDataWithSchema(filledData, taskSchema, taskTemplate)
@@ -342,13 +480,14 @@ public final class NegotiationEvalApp {
             // a fill value violates a slot constraint: fromData generation fails fast — the closed loop cannot
             // complete, which is the expected negative outcome for constraint-violating fills
             filledPrompt = appendSupplements(taskPrompt, fills);
-            Map<String, Object> step = step("5. client fill + Negotiation-T accept generation (fromData)", "client");
+            Map<String, Object> step = step("6. client fill + Negotiation-T accept generation (fromData)", "client");
+            api(step, apiCall("A2ATClient.generateTaskPromptFromDataWithSchema", filledGenerationInput));
             step.put("client_fill", fills);
             step.put("fill_generation_rejected", Map.of(
                     "code", error.getCode(),
                     "message", String.valueOf(error.getMessage())));
             steps.add(step);
-            emit("[eval]   [5] filled Task-T generation REJECTED (" + error.getCode() + "): "
+            emit("[eval]   [6] filled Task-T generation REJECTED (" + error.getCode() + "): "
                     + error.getMessage());
             return finish(record, steps, negotiationTriggered, actualMissing, proposeValid, null, false,
                     expectNegotiation, expectMissing, expectFillCompletes);
@@ -356,31 +495,62 @@ public final class NegotiationEvalApp {
         String acceptPrompt;
         NegotiationContext acceptContext = new NegotiationContext(
                 UUID.randomUUID().toString(), 1, NegotiationContext.DEFAULT_MAX_ROUNDS);
+        String acceptInputText = itemsToAcceptText(filledItems(fills), phrasing);
+        Map<String, Object> acceptGenerationInput = new LinkedHashMap<>();
+        if (negotiationFromText) {
+            acceptGenerationInput.put("text", acceptInputText);
+            acceptGenerationInput.put("context", contextJson(acceptContext));
+        } else {
+            acceptGenerationInput.put("data", Map.of(
+                    "context", contextJson(acceptContext),
+                    "conclusion", NegotiationConclusion.ACCEPT.toString(),
+                    "items", itemsJson(filledItems(fills))));
+        }
+        acceptGenerationInput.put("template_uri", DemoTemplates.NEGOTIATION_ACCEPT.uri());
+        String acceptGenerationApi = negotiationFromText
+                ? "A2ATClient.generateNegotiationAcceptPromptFromText"
+                : "A2ATClient.generateNegotiationAcceptPromptFromData";
         try {
             A2ATClient client = new A2ATClient(envPath);
-            MetadataContent accept = client.generateNegotiationAcceptPromptFromData(
-                    new NegotiationEndingData(
-                            acceptContext,
-                            new InformationEndingContent(NegotiationConclusion.ACCEPT, filledItems(fills))),
-                    DemoTemplates.NEGOTIATION_ACCEPT);
+            List<NegotiationItem> filledItems = filledItems(fills);
+            MetadataContent accept = negotiationFromText
+                    ? client.generateNegotiationAcceptPromptFromText(acceptInputText, acceptContext,
+                            DemoTemplates.NEGOTIATION_ACCEPT)
+                    : client.generateNegotiationAcceptPromptFromData(
+                            new NegotiationEndingData(
+                                    acceptContext,
+                                    new InformationEndingContent(NegotiationConclusion.ACCEPT, filledItems)),
+                            DemoTemplates.NEGOTIATION_ACCEPT);
             acceptPrompt = accept.promptText();
-            Map<String, Object> step = step("5. client fill + Negotiation-T accept generation (fromData)", "client");
+            Map<String, Object> step =
+                    step("6. client fill + Negotiation-T accept generation (" + negotiationChannel + ")", "client");
+            api(step,
+                    apiCall("A2ATClient.generateTaskPromptFromDataWithSchema", filledGenerationInput),
+                    apiCall(acceptGenerationApi, acceptGenerationInput));
             step.put("client_fill", fills);
             step.put("filled_task_prompt", filledPrompt);
             step.put("filled_params", filledData);
+            if (negotiationFromText) {
+                step.put("input_text", acceptInputText);
+            }
             step.put("generated_prompt", acceptPrompt);
             step.put("template_uri", accept.templateUri());
             steps.add(step);
-            emit("[eval]   [5] client fills " + fills.keySet() + ", accept rendered");
+            emit("[eval]   [6] client fills " + fills.keySet() + ", accept rendered (" + negotiationChannel + ")");
         } catch (A2ATError error) {
-            steps.add(errorStep("5. client fill + Negotiation-T accept generation (fromData)", "accept_generation",
-                    error));
-            emit("[eval]   [5] accept generation FAILED: " + error.getCode() + " " + error.getMessage());
+            steps.add(errorStep("6. client fill + Negotiation-T accept generation (" + negotiationChannel + ")",
+                    "accept_generation", error, apiCall(acceptGenerationApi, acceptGenerationInput)));
+            emit("[eval]   [6] accept generation FAILED: " + error.getCode() + " " + error.getMessage());
             return finish(record, steps, negotiationTriggered, actualMissing, proposeValid, null, null,
                     expectNegotiation, expectMissing, expectFillCompletes);
         }
 
-        // -- step 6: inbound validation of the accept message; extracted values must match the client fill --
+        // -- step 7: inbound validation of the accept message; extracted values must match the client fill --
+        Map<String, Object> acceptValidationInput = Map.of(
+                "prompt", acceptPrompt,
+                "context", contextJson(acceptContext),
+                "schema", negotiationSchema(slotsToFill, taskSchema),
+                "template_uri", DemoTemplates.NEGOTIATION_ACCEPT.uri());
         Boolean acceptValid = null;
         Boolean fillValueMatch = null;
         Map<String, Object> extractedAcceptParams = null;
@@ -388,16 +558,18 @@ public final class NegotiationEvalApp {
             long nanos = System.nanoTime();
             A2ATServer server = new A2ATServer(envPath);
             FilledParamData acceptParams = server.validateAcceptPromptAndDataFilling(
-                    acceptPrompt, acceptContext, negotiationSchema(actualMissing), DemoTemplates.NEGOTIATION_ACCEPT);
+                    acceptPrompt, acceptContext, negotiationSchema(slotsToFill, taskSchema),
+                    DemoTemplates.NEGOTIATION_ACCEPT);
             acceptValid = true;
             extractedAcceptParams = acceptParams.data() == null ? Map.of() : new LinkedHashMap<>(acceptParams.data());
             fillValueMatch = fillValuesMatch(extractedAcceptParams, fills);
             Map<String, Object> validation = validationJson("passed", null, null, acceptParams, Set.of());
             validation.put("expected_fill", fills);
             validation.put("fill_value_match", fillValueMatch);
-            Map<String, Object> step = stepOf("6. inbound accept validation", "server", validation);
+            Map<String, Object> step = stepOf("7. inbound accept validation", "server", validation);
+            api(step, apiCall("A2ATServer.validateAcceptPromptAndDataFilling", acceptValidationInput));
             steps.add(step);
-            emit("[eval]   [6] accept validation passed, fill value match: " + fillValueMatch + " (" + secs(nanos)
+            emit("[eval]   [7] accept validation passed, fill value match: " + fillValueMatch + " (" + secs(nanos)
                     + "s)");
         } catch (A2ATError error) {
             acceptValid = false;
@@ -409,39 +581,46 @@ public final class NegotiationEvalApp {
             Map<String, Object> validation = validationJson("rejected", error.getCode(), slotErrors, null, Set.of());
             validation.put("expected_fill", fills);
             validation.put("fill_value_match", false);
-            Map<String, Object> step = stepOf("6. inbound accept validation", "server", validation);
+            Map<String, Object> step = stepOf("7. inbound accept validation", "server", validation);
+            api(step, apiCall("A2ATServer.validateAcceptPromptAndDataFilling", acceptValidationInput));
             steps.add(step);
-            emit("[eval]   [6] accept validation REJECTED: " + error.getCode() + " " + error.getMessage());
+            emit("[eval]   [7] accept validation REJECTED: " + error.getCode() + " " + error.getMessage());
         }
 
-        // -- step 7: second Task-T validation of the filled prompt -> COMPLETED or stays INPUT_REQUIRED --
+        // -- step 8: second Task-T validation of the filled prompt -> COMPLETED or stays INPUT_REQUIRED --
+        Map<String, Object> secondValidationInput = Map.of(
+                "prompt", filledPrompt,
+                "schema", taskSchema,
+                "template_uri", taskTemplate.uri());
         Boolean fillCompleted = null;
         try {
             long nanos = System.nanoTime();
             A2ATServer server = new A2ATServer(envPath);
             FilledParamData filled = server.validateTaskPromptAndDataFilling(filledPrompt, taskSchema, taskTemplate);
-            Set<String> stillMissing = blankSlots(filled);
+            Set<String> stillMissing = requiredMissing(blankSlots(filled), requiredSlots);
             fillCompleted = stillMissing.isEmpty();
             Map<String, Object> step = stepOf(
-                    "7. second Task-T validation (fill round)",
+                    "8. second Task-T validation (fill round)",
                     "server",
                     validationJson(fillCompleted ? "passed" : "rejected",
                             fillCompleted ? null : "slots_still_missing",
                             fillCompleted ? null : stillMissingErrors(stillMissing),
                             filled,
                             stillMissing));
+            api(step, apiCall("A2ATServer.validateTaskPromptAndDataFilling", secondValidationInput));
             step.put("task_state", fillCompleted ? "COMPLETED" : "INPUT_REQUIRED");
             steps.add(step);
-            emit("[eval]   [7] second Task-T validation " + (fillCompleted ? "-> COMPLETED" : "still missing: "
+            emit("[eval]   [8] second Task-T validation " + (fillCompleted ? "-> COMPLETED" : "still missing: "
                     + stillMissing) + " (" + secs(nanos) + "s)");
         } catch (ContentValidationException error) {
             fillCompleted = false;
             Map<String, Object> step = stepOf(
-                    "7. second Task-T validation (fill round)",
+                    "8. second Task-T validation (fill round)",
                     "server",
                     validationJson("rejected", error.getCode(), error.errors(), null, errorSlots(error)));
+            api(step, apiCall("A2ATServer.validateTaskPromptAndDataFilling", secondValidationInput));
             steps.add(step);
-            emit("[eval]   [7] second Task-T validation REJECTED (" + error.getCode() + "): " + errorSlots(error));
+            emit("[eval]   [8] second Task-T validation REJECTED (" + error.getCode() + "): " + errorSlots(error));
         }
 
         return finish(record, steps, negotiationTriggered, actualMissing, proposeValid, fillValueMatch,
@@ -465,7 +644,11 @@ public final class NegotiationEvalApp {
         boolean triggerCorrect = !error && triggered == expectNegotiation;
         boolean slotsCorrect = !error && actualMissing != null && actualMissing.equals(expectMissing);
         Boolean proposeValidCorrect = error || proposeValid == null ? null : proposeValid;
-        Boolean fillMatchCorrect = error || fillValueMatch == null ? null : fillValueMatch;
+        // value match is only meaningful for cases whose fill round is expected to succeed; a negative fill case
+        // (expectFillCompletes=false) is judged by the fill round NOT completing — the accept validation rejecting
+        // the constraint-violating fill value is exactly the expected outcome, not a mismatch
+        Boolean fillMatchCorrect =
+                error || fillValueMatch == null || Boolean.FALSE.equals(expectFillCompletes) ? null : fillValueMatch;
         Boolean fillCorrect;
         if (error) {
             fillCorrect = false;
@@ -537,10 +720,10 @@ public final class NegotiationEvalApp {
             notes.add("generated propose failed outbound validation (step 4)");
         }
         if (fillMatchCorrect != null && !fillMatchCorrect) {
-            notes.add("server-side extracted fill values differ from what the client sent (step 6)");
+            notes.add("server-side extracted fill values differ from what the client sent (step 7)");
         }
         if (fillCorrect != null && !fillCorrect) {
-            notes.add("fill round did not complete as expected (step 7)");
+            notes.add("fill round did not complete as expected (step 8)");
         }
         return String.join("; ", notes);
     }
@@ -552,6 +735,29 @@ public final class NegotiationEvalApp {
         step.put("step", name);
         step.put("role", role);
         return step;
+    }
+
+    /** Attaches the SDK API call evidence (method name + input parameters) to a step; one step may make several calls. */
+    @SafeVarargs
+    private static void api(Map<String, Object> step, Map<String, Object>... calls) {
+        step.put("api_calls", List.of(calls));
+    }
+
+    /** One SDK API invocation record: the exact facade method plus the parameters it was called with. */
+    private static Map<String, Object> apiCall(String method, Map<String, Object> input) {
+        Map<String, Object> call = new LinkedHashMap<>();
+        call.put("method", method);
+        call.put("input", input);
+        return call;
+    }
+
+    /** Negotiation context as report JSON (the same object handed to the generate/validate calls). */
+    private static Map<String, Object> contextJson(NegotiationContext context) {
+        Map<String, Object> json = new LinkedHashMap<>();
+        json.put("id", context.id());
+        json.put("round", context.round());
+        json.put("maxRounds", context.maxRounds());
+        return json;
     }
 
     private static Map<String, Object> stepOf(String name, String role, Map<String, Object> validation) {
@@ -597,12 +803,16 @@ public final class NegotiationEvalApp {
         return errors;
     }
 
-    private static Map<String, Object> errorStep(String name, String stage, A2ATError error) {
+    private static Map<String, Object> errorStep(
+            String name, String stage, A2ATError error, Map<String, Object>... calls) {
         Map<String, Object> step = step(name, "n/a");
         step.put("error", Map.of(
                 "stage", stage,
                 "code", error.getCode(),
                 "message", String.valueOf(error.getMessage())));
+        if (calls.length > 0) {
+            api(step, calls);
+        }
         return step;
     }
 
@@ -627,6 +837,43 @@ public final class NegotiationEvalApp {
             description = text;
         }
         return template.replace("{slot}", slot).replace("{description}", description == null ? "" : String.valueOf(description));
+    }
+
+    /**
+     * Assembles the natural-language propose input for the fromText negotiation channel, mirroring the demo's
+     * {@code FromTextStrategy}: scenario-configured prefix, numbered item list, relationship sentence.
+     */
+    private static String itemsToProposeText(List<NegotiationItem> items, Map<String, String> phrasing) {
+        StringBuilder text = new StringBuilder(phrasing.getOrDefault("from_text_propose_prefix", ""));
+        appendNumberedItems(text, items);
+        String relationship = phrasing.get("propose_relationship");
+        if (relationship != null && !relationship.isBlank()) {
+            text.append(relationship);
+        }
+        return text.toString();
+    }
+
+    /**
+     * Assembles the natural-language accept input for the fromText negotiation channel: scenario-configured prefix,
+     * numbered item list, suffix sentence.
+     */
+    private static String itemsToAcceptText(List<NegotiationItem> items, Map<String, String> phrasing) {
+        StringBuilder text = new StringBuilder(phrasing.getOrDefault("from_text_accept_prefix", ""));
+        appendNumberedItems(text, items);
+        text.append(phrasing.getOrDefault("from_text_accept_suffix", ""));
+        return text.toString();
+    }
+
+    /** Generic numbered-list rule: {@code N. name：value；} per item, value omitted when blank. */
+    private static void appendNumberedItems(StringBuilder text, List<NegotiationItem> items) {
+        for (int i = 0; i < items.size(); i++) {
+            NegotiationItem item = items.get(i);
+            text.append(i + 1).append(". ").append(item.name());
+            if (item.value() != null && !item.value().isBlank()) {
+                text.append("：").append(item.value());
+            }
+            text.append("；");
+        }
     }
 
     /** The supplement values the simulated client supplies, keyed by slot. */
@@ -682,13 +929,20 @@ public final class NegotiationEvalApp {
     }
 
     /**
-     * Parameter schema for the negotiation-message validations (steps 4 and 6): one string property per negotiated
-     * slot, so the extraction surface is exactly the supplemented information.
+     * Parameter schema for the negotiation-message validations (steps 4/5/7): one property per negotiated slot,
+     * derived from the task schema so the description and {@code x-a2at-value-constraint} of each slot flow into the
+     * validation prompt — the extraction surface is exactly the supplemented information, with the same semantic
+     * constraints the Task-T validation enforces.
      */
-    private static Map<String, Object> negotiationSchema(Set<String> slots) {
+    private static Map<String, Object> negotiationSchema(Set<String> slots, Map<String, Object> taskSchema) {
+        Map<String, Object> taskProperties = asMap(taskSchema.get("properties"));
         Map<String, Object> properties = new LinkedHashMap<>();
         for (String slot : slots) {
-            properties.put(slot, Map.of("type", "string"));
+            Map<String, Object> property = new LinkedHashMap<>(asMap(taskProperties.get(slot)));
+            if (property.isEmpty()) {
+                property.put("type", "string");
+            }
+            properties.put(slot, property);
         }
         Map<String, Object> schema = new LinkedHashMap<>();
         schema.put("type", "object");
@@ -697,11 +951,20 @@ public final class NegotiationEvalApp {
         return schema;
     }
 
-    /** Whether every server-extracted fill value matches the value the client sent for that slot. */
+    /**
+     * Whether every server-extracted fill value matches the value the client sent for that slot. The comparison is
+     * containment in either direction after whitespace removal: the extracted value may carry the slot's field label
+     * (e.g. 接入端口名称：P781-…) or only the bare value (e.g. P781-…), both of which faithfully transport the fill.
+     */
     private static boolean fillValuesMatch(Map<String, Object> extracted, Map<String, String> fills) {
         for (Map.Entry<String, String> entry : fills.entrySet()) {
             Object value = extracted.get(entry.getKey());
-            if (value == null || !normalize(String.valueOf(value)).contains(normalize(entry.getValue()))) {
+            if (value == null) {
+                return false;
+            }
+            String extractedText = normalize(String.valueOf(value));
+            String sentText = normalize(entry.getValue());
+            if (!extractedText.contains(sentText) && !sentText.contains(extractedText)) {
                 return false;
             }
         }
@@ -724,6 +987,17 @@ public final class NegotiationEvalApp {
             }
         }
         return blank;
+    }
+
+    /**
+     * Restricts missing-slot candidates to the task schema's required slots: an empty optional slot is a valid
+     * state and never a negotiation trigger — only a required slot that is blank (or flagged by the semantic
+     * validator) means information the negotiation must ask for.
+     */
+    private static Set<String> requiredMissing(Set<String> candidates, Set<String> requiredSlots) {
+        Set<String> missing = new TreeSet<>(candidates);
+        missing.retainAll(requiredSlots);
+        return missing;
     }
 
     /** Slots reported as errors by the semantic validation. */

--- a/a2a-t-sample/src/main/resources/sample/negotiation/eval/eval-suite.json
+++ b/a2a-t-sample/src/main/resources/sample/negotiation/eval/eval-suite.json
@@ -1,6 +1,6 @@
 {
   "suite": "negotiation-interface-eval",
-  "description": "Private-line complaint negotiation closed-loop evaluation. Each case drives the negotiation prompt interfaces in message order: Task-T generation (fromData/fromText) -> server validation (missing-slot detection) -> Negotiation-T propose generation -> outbound propose validation -> client fill + accept generation -> inbound accept validation -> second Task-T validation. Channels: fromData is deterministic generation (no LLM for message rendering); fromText runs LLM slot extraction. All validation interfaces run the SDK pipeline (rule gate + one semantic LLM call).",
+  "description": "Private-line complaint negotiation closed-loop evaluation against the bundled private-line-complaint template. Each case drives the negotiation prompt interfaces in message order: Task-T generation (fromData/fromText) -> server validation (missing-slot detection) -> Negotiation-T propose generation -> server outbound propose validation -> client inbound propose validation -> client fill + accept generation -> server inbound accept validation -> second Task-T validation. Channels: fromData feeds structured JSON (every key maps to one slot value) together with the task schema; fromText feeds natural language. The suite's task schema refines the template's coarse 任务上下文 into four sub-slots (投诉分类/问题发生时间/OSS侧事件流水号/投诉详情, per the template's own requirement list): a missing sub-field inside a non-blank 任务上下文 is detected at validation and negotiated, while a completely empty 任务上下文 fails fast at generation (bundled required slot). Slot extraction and all validation interfaces run the SDK pipeline (rule gate + semantic LLM call), with the JSON schema passed on every generate/validate call.",
   "scenario": "private-line-complaint",
   "template_uri": "Task-T/network-layer/private-line-complaint/v1",
   "task_schema": {
@@ -8,33 +8,58 @@
     "properties": {
       "任务对象": {
         "type": "string",
-        "description": "专线业务对象标识：专线名称 / 接入端口名称（网元名称+单板号+单板型号+端口号）/ 接入端口资源ID，三者提供其一"
+        "description": "专线业务对象标识，用于定位被投诉的专线业务",
+        "x-a2at-value-constraint": "专线名称：网络侧EMS网管的专线对象标识。接入端口名称：网络侧EMS网管的接入端口名称，格式为：网元名称+单板号+单板型号+端口号。接入端口资源ID：网络侧EMS网管的接入端口资源对象标识。三者提供其一。"
       },
-      "任务上下文": {
+      "投诉分类": {
         "type": "string",
-        "description": "故障现象（专线中断/专线质量差，必选）+ 故障发生时间（可选）+ OSS侧事件流水号（可选）"
+        "enum": ["专线中断", "专线质差"],
+        "description": "投诉场景分类，标识专线故障的现象类型",
+        "x-a2at-value-constraint": "取值仅限两种场景之一：专线中断（业务完全不可用）、专线质差（业务可用但质量劣化）。"
+      },
+      "问题发生时间": {
+        "type": "string",
+        "description": "故障或投诉现象的发生时间",
+        "x-a2at-value-constraint": "可选参数，允许为空，为空不构成校验错误；时间格式建议为 ISO 8601（如 2026-05-11T08:21:46Z）。"
+      },
+      "OSS侧事件流水号": {
+        "type": "string",
+        "description": "OSS侧的专线业务投诉工单流水号",
+        "x-a2at-value-constraint": "OSS侧事件流水号：填写OSS侧的专线业务投诉工单流水号，格式为 event-id-开头的事件标识。"
+      },
+      "投诉详情": {
+        "type": "string",
+        "description": "专线用户对业务投诉的描述，以及OSS侧的预处理信息",
+        "x-a2at-value-constraint": "可选参数，允许为空，为空不构成校验错误；自由文本描述，无格式约束。"
       }
     },
-    "required": [
-      "任务上下文"
-    ]
+    "required": ["任务对象", "投诉分类", "OSS侧事件流水号"]
   },
   "negotiation_phrasing": {
     "missing_item_hint": "请提供{slot}：{description}",
-    "propose_relationship": "以上参数均为必选，缺少无法启动诊断"
+    "propose_relationship": "以上参数均为必选，缺少无法启动诊断",
+    "from_text_propose_prefix": "请提供以下缺失信息：",
+    "from_text_accept_prefix": "同意补充以下信息：",
+    "from_text_accept_suffix": "信息已完整，可以启动诊断。"
   },
   "client_fill_values": {
     "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
-    "任务上下文": "故障现象：专线中断，业务完全不可用。问题发生时间：2026-06-02T14:30:00Z。"
+    "投诉分类": "专线中断",
+    "问题发生时间": "2026-06-02T14:30:00Z",
+    "OSS侧事件流水号": "event-id-20260602-08841",
+    "投诉详情": "客户业务全部不通，柜面交易无法办理。"
   },
   "cases": [
     {
       "id": "PLC-01",
       "channel": "fromData",
-      "intent": "结构化参数完整，不应触发协商",
+      "intent": "结构化数据完整（5槽齐备），不应触发协商",
       "input_data": {
         "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
-        "任务上下文": "故障现象：专线质量差，深圳访问广州响应延迟骤升，交易接口频繁报连接超时。问题发生时间：2026-05-11T08:21:46Z。OSS侧事件流水号：event-id-20260511-09013。"
+        "投诉分类": "专线质差",
+        "问题发生时间": "2026-05-11T08:21:46Z",
+        "OSS侧事件流水号": "event-id-20260511-09013",
+        "投诉详情": "深圳访问广州响应延迟骤升，交易接口频繁报连接超时。"
       },
       "expect": {
         "negotiation_needed": false,
@@ -44,8 +69,8 @@
     {
       "id": "PLC-02",
       "channel": "fromText",
-      "intent": "自然语言完整（端口+现象+时间+流水号），不应触发协商",
-      "input_text": "深圳福田区某金融客户专线出现质量劣化。接入端口：P781-珠江新城-PTN7900-23-TPA1EG24-17。故障现象：专线质量差，深圳访问广州响应延迟骤升，交易接口频繁报连接超时。问题发生时间：2026-05-11T08:21:46Z。OSS侧事件流水号：event-id-20260511-09013。",
+      "intent": "自然语言完整（端口+分类+时间+流水号+详情），不应触发协商",
+      "input_text": "深圳福田区某金融客户专线出现质量劣化。接入端口：P781-珠江新城-PTN7900-23-TPA1EG24-17。故障现象：专线质差，深圳访问广州响应延迟骤升，交易接口频繁报连接超时。问题发生时间：2026-05-11T08:21:46Z。OSS侧事件流水号：event-id-20260511-09013。投诉详情：从5月11号早上8点半开始，核心交易系统访问非常慢，柜面和手机银行频繁报连接超时。",
       "expect": {
         "negotiation_needed": false,
         "missing_slots": []
@@ -54,36 +79,35 @@
     {
       "id": "PLC-03",
       "channel": "fromData",
-      "intent": "结构化缺任务对象，触发协商",
+      "intent": "结构化缺任务对象，触发任务对象协商",
       "input_data": {
         "任务对象": "",
-        "任务上下文": "故障现象：专线中断，客户业务全部不通。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。"
+        "投诉分类": "专线中断",
+        "问题发生时间": "2026-06-02T14:30:00Z",
+        "OSS侧事件流水号": "event-id-20260602-08841",
+        "投诉详情": "客户业务全部不通，柜面交易无法办理。"
       },
       "expect": {
         "negotiation_needed": true,
-        "missing_slots": [
-          "任务对象"
-        ],
+        "missing_slots": ["任务对象"],
         "fill_completes": true
       }
     },
     {
       "id": "PLC-04",
       "channel": "fromText",
-      "intent": "口语化缺专线标识，触发协商",
-      "input_text": "我们的专线出问题了，故障现象：专线中断，客户业务全部不通。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
+      "intent": "口语化缺专线标识（业务全断可推断投诉分类），触发任务对象协商",
+      "input_text": "我们的专线出问题了，业务全部都断了，完全用不了。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
       "expect": {
         "negotiation_needed": true,
-        "missing_slots": [
-          "任务对象"
-        ],
+        "missing_slots": ["任务对象"],
         "fill_completes": true
       }
     },
     {
       "id": "PLC-05",
       "channel": "fromText",
-      "intent": "自然语言两个槽全空（无对象无现象）：required 槽在生成期即被拦截，任务无法生成，协商不触发",
+      "intent": "自然语言任务上下文为空（bundled required 槽在生成期即被拦截，任务无法生成，协商不触发）",
       "input_text": "帮我看一下专线的问题。",
       "expect": {
         "negotiation_needed": false,
@@ -95,12 +119,10 @@
       "id": "PLC-06",
       "channel": "fromText",
       "intent": "任务对象模糊（非端口/ID/名称形态），触发任务对象协商",
-      "input_text": "故障现象：专线质量差，网页打开缓慢，视频卡顿。故障发生时间：2026-06-18T09:00:00Z。",
+      "input_text": "故障现象：专线质量差，网页打开缓慢，视频卡顿。问题发生时间：2026-06-18T09:00:00Z。OSS侧事件流水号：event-id-20260618-07721。",
       "expect": {
         "negotiation_needed": true,
-        "missing_slots": [
-          "任务对象"
-        ],
+        "missing_slots": ["任务对象"],
         "fill_completes": true
       }
     },
@@ -108,7 +130,7 @@
       "id": "PLC-07",
       "channel": "fromText",
       "intent": "口语化完整请求，端口埋在长句里，不应触发协商",
-      "input_text": "东莞松山湖科技园客户报障说专线卡，涉及端口 P662-松山湖北-PTN9900-12-TPB3EG12-08，成天丢包，业务系统登录都费劲，昨天下午三点开始的，流水号 event-id-20260619-55210。",
+      "input_text": "就是珠江新城那边 PTN7900 网元上 P781-珠江新城-PTN7900-23-TPA1EG24-17 这个接入端口带的专线，专线质差，深圳访问广州的响应延迟从12ms涨到了300多毫秒，问题发生时间：2026-05-11T08:21:46Z，OSS侧事件流水号：event-id-20260511-09013。",
       "expect": {
         "negotiation_needed": false,
         "missing_slots": []
@@ -117,13 +139,11 @@
     {
       "id": "PLC-08",
       "channel": "fromText",
-      "intent": "故障现象不明确（未指明中断或质差），触发任务上下文协商",
-      "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。专线好像有点问题，时好时坏，客户体验受影响。",
+      "intent": "自然语言未描述任何故障现象（投诉分类无从判定为中断或质差），触发投诉分类协商",
+      "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。OSS侧事件流水号：event-id-20260618-07721。",
       "expect": {
         "negotiation_needed": true,
-        "missing_slots": [
-          "任务上下文"
-        ],
+        "missing_slots": ["投诉分类"],
         "fill_completes": true
       }
     },
@@ -131,7 +151,7 @@
       "id": "PLC-09",
       "channel": "fromText",
       "intent": "端口误写在现象描述里（字段错位），抽取器应归位到任务对象，不触发协商",
-      "input_text": "故障现象：专线质量差。端口是 P120-南山智园-PTN7900-08-TPA1EG21-11，丢包严重。",
+      "input_text": "故障现象：专线中断，出现问题的接入端口是P781-珠江新城-PTN7900-23-TPA1EG24-17，业务完全不可用。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
       "expect": {
         "negotiation_needed": false,
         "missing_slots": []
@@ -140,20 +160,99 @@
     {
       "id": "PLC-10",
       "channel": "fromData",
-      "intent": "负例：补充值端口格式乱写，二次校验应拒绝（测校验器对值约束的把关）",
+      "intent": "负例：补充值投诉分类乱写（不符合中断/质差取值约束），二次校验应拒绝（测校验器对值约束的把关）",
       "input_data": {
-        "任务对象": "",
-        "任务上下文": "故障现象：专线中断，客户业务全部不通。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。"
+        "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
+        "投诉分类": "",
+        "问题发生时间": "2026-06-02T14:30:00Z",
+        "OSS侧事件流水号": "event-id-20260602-08841",
+        "投诉详情": "客户业务全部不通，柜面交易无法办理。"
       },
       "fill_override": {
-        "任务对象": "端口是坏的"
+        "投诉分类": "不知道是什么问题"
       },
       "expect": {
         "negotiation_needed": true,
-        "missing_slots": [
-          "任务对象"
-        ],
+        "missing_slots": ["投诉分类"],
         "fill_completes": false
+      }
+    },
+    {
+      "id": "PLC-11",
+      "channel": "fromData",
+      "intent": "结构化缺投诉分类（任务上下文子槽缺失），触发投诉分类协商",
+      "input_data": {
+        "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
+        "投诉分类": "",
+        "问题发生时间": "2026-06-18T09:00:00Z",
+        "OSS侧事件流水号": "event-id-20260618-07721",
+        "投诉详情": "网页打开缓慢，视频卡顿。"
+      },
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["投诉分类"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-12",
+      "channel": "fromData",
+      "intent": "结构化缺OSS侧事件流水号（任务上下文子槽缺失），触发流水号协商",
+      "input_data": {
+        "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
+        "投诉分类": "专线质差",
+        "问题发生时间": "2026-06-18T09:00:00Z",
+        "OSS侧事件流水号": "",
+        "投诉详情": "网页打开缓慢，视频卡顿。"
+      },
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["OSS侧事件流水号"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-13",
+      "channel": "fromData",
+      "intent": "可选槽缺失（问题发生时间/投诉详情为空），不应触发协商",
+      "input_data": {
+        "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
+        "投诉分类": "专线中断",
+        "问题发生时间": "",
+        "OSS侧事件流水号": "event-id-20260602-08841",
+        "投诉详情": ""
+      },
+      "expect": {
+        "negotiation_needed": false,
+        "missing_slots": []
+      }
+    },
+    {
+      "id": "PLC-14",
+      "channel": "fromText",
+      "intent": "自然语言缺OSS侧事件流水号（任务上下文子槽缺失），触发流水号协商",
+      "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。故障现象：专线中断，业务完全不可用，柜面交易无法办理。问题发生时间：2026-06-18T09:00:00Z。",
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["OSS侧事件流水号"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-15",
+      "channel": "fromData",
+      "intent": "结构化双槽缺失（任务对象+投诉分类），协商应同时请求两个槽",
+      "input_data": {
+        "任务对象": "",
+        "投诉分类": "",
+        "问题发生时间": "2026-06-18T09:00:00Z",
+        "OSS侧事件流水号": "event-id-20260618-07721",
+        "投诉详情": "客户业务全部不通。"
+      },
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["任务对象", "投诉分类"],
+        "fill_completes": true
       }
     }
   ]


### PR DESCRIPTION
Closes #139

## Summary

Extends `NegotiationEvalApp` into a replayable verification harness for the negotiation prompt interfaces. All changes are confined to the **a2a-t-sample** module; the SDK source and bundled prompt resources are untouched.

**Design**

1. **Fine-grained eval schema** — the suite's task schema refines the bundled template's coarse task-context slot into four sub-fields (complaint category, occurrence time, OSS event sequence number, complaint details), following the template's own requirement list (category and sequence number required, time and details optional). fromData cases feed structured JSON where every key maps to one explicit field value; the schema is passed as the caller schema on every generate/validate call.
2. **API-call evidence** — every report step records `api_calls`: the exact facade method plus its full input parameters (including the JSON schema), so schema passing is verifiable from the report alone.
3. **Client-side inbound propose validation** — new step 5: the client validates the received propose through the symmetric client-side validate API and reads out the requested slots; the fill round is driven by that client-side view. This also documents the role contract: sender self-checks outbound, receiver validates inbound.
4. **Constraint-bearing negotiation schemas** — negotiation-message validation schemas are derived from the task schema so slot descriptions and value constraints (complaint-category enum) flow into the validator.
5. **15-case matrix** constructing missing fields per the template requirements: complaint-category and OSS sequence-number missing (fromData + fromText), optional-field-absent non-trigger, dual-field negotiation, a negative fill-constraint case, and a generation-time fail-fast case.
6. **Protocol contract documented** in README: the fill merge model is a full client-side re-render of the Task-T prompt from the complete parameter map (no incremental merge API), followed by server-side re-validation.

Positive and negative cases alike probe the interfaces; failures are part of the deliverable and surface SDK-level behavior worth reviewing (see test results below).

## Test plan

- [x] `mvn test` full reactor — 89 tests green
- [x] Real-LLM full run (glm-5.2): **11/15 pass**, propose outbound validation 6/6, fill value match 6/6
- [x] The 4 failing cases captured as SDK-level observations with step-by-step evidence in the report:
  - validator *infers* an inferable required field from context instead of reporting it missing (complaint category empty but complaint details say "service fully down" → extracted as `专线中断`)
  - a missing format-constrained field is extracted as the placeholder string `无` and still passes semantic validation
  - an empty enum-constrained field in fromData input triggers empty extraction content (`llm_invocation_failed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)