### PR TITLE
feat(validation): inject template content into validation prompts

### DIFF
--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATParamExtractionError.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATParamExtractionError.java
@@ -41,6 +41,20 @@ public class A2ATParamExtractionError extends A2ATError {
     }
 
     /**
+     * Creates a parameter-extraction failure with one specific error code, slot details and a root cause.
+     *
+     * @param code machine-readable error code for the failure
+     * @param message failure message
+     * @param errors structured per-slot validation error details
+     * @param cause root cause of the failure
+     */
+    public A2ATParamExtractionError(
+            @NonNull String code, String message, @NonNull List<SlotValidationError> errors, Throwable cause) {
+        super(code, message, cause);
+        this.errors = List.copyOf(errors);
+    }
+
+    /**
      * Returns the structured per-slot validation error details.
      *
      * @return immutable list of slot validation errors, never null

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/SemanticValidator.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/SemanticValidator.java
@@ -22,10 +22,11 @@ public interface SemanticValidator<T> {
      * @param prompt content prompt text
      * @param schema caller-provided parameter JSON schema embedded into the structured-call output contract
      * @param reference template addressing value the content is validated against
+     * @param templateContent loaded template text used as a reference for structure/completeness checks
      * @return semantic validation outcome carrying the verdict, the semantic errors and the extracted parameters
      * @throws net.openan.a2at.sdk.core.exception.ResourceNotFoundException if the semantic validation prompt resources
      *     are missing
      */
     @NonNull ValidationResult validate(
-            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull T reference);
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull T reference, @NonNull String templateContent);
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/ValidationPipeline.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/ValidationPipeline.java
@@ -56,13 +56,14 @@ public final class ValidationPipeline<T> {
      * @param prompt content prompt text
      * @param schema caller-provided parameter JSON schema
      * @param reference template addressing value the content is validated against
+     * @param templateContent loaded template text used as a reference for structure/completeness checks
      * @return filled parameter data carrying the merged parameters
      * @throws NullPointerException if the prompt, schema or reference is null
      * @throws IllegalArgumentException if the prompt is blank
      * @throws ContentValidationException if the validation fails at any stage
      */
     public @NonNull FilledParamData validate(
-            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull T reference) {
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull T reference, @NonNull String templateContent) {
         Objects.requireNonNull(schema, "schema");
         Objects.requireNonNull(prompt, "prompt");
         if (prompt.isBlank()) {
@@ -77,7 +78,7 @@ public final class ValidationPipeline<T> {
             semanticResult = RetryUtil.withRetry(
                     maxAttempts,
                     "semantic_validation",
-                    () -> semanticValidator.validate(prompt, schema, reference));
+                    () -> semanticValidator.validate(prompt, schema, reference, templateContent));
         } catch (ResourceNotFoundException exception) {
             throw new ContentValidationException(
                     A2ATErrorCodes.VALIDATION_PROMPT_RESOURCE_NOT_FOUND, exception.getMessage(), exception);

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationParamExtractionException.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/content/NegotiationParamExtractionException.java
@@ -3,6 +3,7 @@ package net.openan.a2at.sdk.negotiation.content;
 import java.util.List;
 import net.openan.a2at.sdk.core.exception.A2ATParamExtractionError;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Raised when validating a negotiation message and extracting parameters from it fails.
@@ -29,5 +30,18 @@ public class NegotiationParamExtractionException extends A2ATParamExtractionErro
      */
     public NegotiationParamExtractionException(String code, String message, List<SlotValidationError> errors) {
         super(code, message, errors);
+    }
+
+    /**
+     * Creates a negotiation parameter-extraction failure with one specific error code, slot details and a root cause.
+     *
+     * @param code machine-readable error code for the failure
+     * @param message failure message
+     * @param errors structured per-slot validation error details
+     * @param cause root cause of the failure
+     */
+    public NegotiationParamExtractionException(
+            String code, String message, List<SlotValidationError> errors, Throwable cause) {
+        super(code, message, errors, cause);
     }
 }

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
@@ -539,8 +539,15 @@ public final class NegotiationGenerationOrchestrator {
             NegotiationPhase phase) {
         Objects.requireNonNull(schema, "Parameter schema must not be null.");
         NegotiationReference reference = requireReference(templateUri, phase);
+        String templateContent;
         try {
-            return paramExtractor.extract(prompt, context, schema, reference);
+            templateContent = loadTemplate(reference).content();
+        } catch (NegotiationGenerationException exception) {
+            throw new NegotiationParamExtractionException(
+                    exception.getCode(), exception.getMessage(), List.of());
+        }
+        try {
+            return paramExtractor.extract(prompt, context, schema, reference, templateContent);
         } catch (NegotiationParamExtractionException failure) {
             logger.atWarn()
                     .log(

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
@@ -544,7 +544,7 @@ public final class NegotiationGenerationOrchestrator {
             templateContent = loadTemplate(reference).content();
         } catch (NegotiationGenerationException exception) {
             throw new NegotiationParamExtractionException(
-                    exception.getCode(), exception.getMessage(), List.of());
+                    exception.getCode(), exception.getMessage(), List.of(), exception);
         }
         try {
             return paramExtractor.extract(prompt, context, schema, reference, templateContent);

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilder.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilder.java
@@ -203,7 +203,7 @@ public final class NegotiationGenerationOrchestratorBuilder {
      */
     private NegotiationSemanticValidator defaultSemanticValidator() {
         if (llmClient == null) {
-            return (prompt, callerSchema, reference) -> {
+            return (prompt, callerSchema, reference, templateContent) -> {
                 throw new NegotiationValidationException(
                         "Semantic validation requires an LLM client but none is configured.");
             };

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidator.java
@@ -7,11 +7,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 import net.openan.a2at.sdk.core.exception.A2ATError;
@@ -164,10 +168,10 @@ public final class DefaultNegotiationSemanticValidator implements NegotiationSem
      */
     @Override
     public SemanticValidationResult validateNegotiation(
-            String prompt, Map<String, Object> callerSchema, NegotiationReference reference) {
+            String prompt, Map<String, Object> callerSchema, NegotiationReference reference, String templateContent) {
         Objects.requireNonNull(prompt, "prompt");
         Objects.requireNonNull(reference, "reference");
-        List<Map<String, String>> messages = buildMessages(prompt, callerSchema, reference);
+        List<Map<String, String>> messages = buildMessages(prompt, callerSchema, reference, templateContent);
         Map<String, Object> mergedSchema = schemaBuilder.apply(callerSchema);
         LLMResponse response;
         try {
@@ -184,17 +188,30 @@ public final class DefaultNegotiationSemanticValidator implements NegotiationSem
         return result;
     }
 
+    private static final Pattern USER_PROMPT_PLACEHOLDER_PATTERN =
+            Pattern.compile("\\[(phase|input|template_uri|negotiation_type|template_content|schema)\\]");
+
     private static List<Map<String, String>> buildMessages(
-            String prompt, Map<String, Object> callerSchema, NegotiationReference reference) {
+            String prompt, Map<String, Object> callerSchema, NegotiationReference reference, String templateContent) {
         String language = reference.language();
         String systemPrompt = loadPromptResource(SYSTEM_PROMPT_FILE, language);
         String userPrompt = loadPromptResource(USER_PROMPT_FILE, language);
-        String filledUserPrompt = userPrompt
-                .replace("[phase]", reference.phase().name().toLowerCase(Locale.ROOT))
-                .replace("[input]", prompt)
-                .replace("[template_uri]", reference.uri())
-                .replace("[negotiation_type]", declaredTypeName(reference))
-                .replace("[schema]", toJson(callerSchema));
+        Matcher matcher = USER_PROMPT_PLACEHOLDER_PATTERN.matcher(userPrompt);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            String replacement = switch (matcher.group(1)) {
+                case "phase" -> Matcher.quoteReplacement(reference.phase().name().toLowerCase(Locale.ROOT));
+                case "input" -> Matcher.quoteReplacement(prompt);
+                case "template_uri" -> Matcher.quoteReplacement(reference.uri());
+                case "negotiation_type" -> Matcher.quoteReplacement(declaredTypeName(reference));
+                case "template_content" -> Matcher.quoteReplacement(templateContent);
+                case "schema" -> Matcher.quoteReplacement(toJson(callerSchema));
+                default -> Matcher.quoteReplacement(matcher.group());
+            };
+            matcher.appendReplacement(sb, replacement);
+        }
+        matcher.appendTail(sb);
+        String filledUserPrompt = sb.toString();
         return List.of(
                 Map.of("role", "system", "content", systemPrompt), Map.of("role", "user", "content", filledUserPrompt));
     }

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidator.java
@@ -16,8 +16,6 @@ import java.util.Objects;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.Objects;
-import java.util.function.UnaryOperator;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.SlotValidationError;

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationSemanticValidator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/NegotiationSemanticValidator.java
@@ -29,6 +29,7 @@ public interface NegotiationSemanticValidator extends SemanticValidator<Negotiat
      * @param callerSchema caller-provided parameter JSON schema embedded into the structured-call output contract
      * @param reference negotiation reference the message is validated against, carrying the declared type, phase and
      *     language
+     * @param templateContent loaded template text used as a reference for structure/completeness checks
      * @return semantic validation outcome carrying the verdict, the implied negotiation type, the semantic errors and
      *     the extracted parameters
      * @throws NegotiationValidationException if the LLM invocation fails or the response misses a required key or has
@@ -37,12 +38,13 @@ public interface NegotiationSemanticValidator extends SemanticValidator<Negotiat
      *     of the reference language are missing
      */
     SemanticValidationResult validateNegotiation(
-            String prompt, Map<String, Object> callerSchema, NegotiationReference reference);
+            String prompt, Map<String, Object> callerSchema, NegotiationReference reference, String templateContent);
 
     @Override
-    default ValidationResult validate(String prompt, Map<String, Object> schema, NegotiationReference reference) {
+    default ValidationResult validate(
+            String prompt, Map<String, Object> schema, NegotiationReference reference, String templateContent) {
         try {
-            SemanticValidationResult result = validateNegotiation(prompt, schema, reference);
+            SemanticValidationResult result = validateNegotiation(prompt, schema, reference, templateContent);
             return new ValidationResult(result.verdict(), result.errors(), result.params());
         } catch (NegotiationValidationException exception) {
             throw new ContentValidationException(

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/ParamExtractor.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/validation/ParamExtractor.java
@@ -56,6 +56,7 @@ public final class ParamExtractor {
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param reference template reference the message is validated against
+     * @param templateContent loaded template text used as a reference for structure/completeness checks
      * @return filled parameter data carrying the context parameters and the extracted parameters
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input},
      *     {@code negotiation_rule_violation}, {@code negotiation_semantic_rejected},
@@ -63,11 +64,15 @@ public final class ParamExtractor {
      *     fails
      */
     public FilledParamData extract(
-            String prompt, NegotiationContext context, Map<String, Object> schema, NegotiationReference reference) {
+            String prompt,
+            NegotiationContext context,
+            Map<String, Object> schema,
+            NegotiationReference reference,
+            String templateContent) {
         ValidationPipeline<NegotiationReference> pipeline = new ValidationPipeline<>(
                 new NegotiationRuleCheckerAdapter(complianceChecker, context), semanticValidator, maxAttempts);
         try {
-            return pipeline.validate(prompt, schema, reference);
+            return pipeline.validate(prompt, schema, reference, templateContent);
         } catch (ContentValidationException e) {
             throw new NegotiationParamExtractionException(mapCode(e.getCode()), e.getMessage(), e.errors());
         }

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorTest.java
@@ -215,6 +215,30 @@ class NegotiationGenerationOrchestratorTest {
     }
 
     @Test
+    void validationTemplateLoadFailurePreservesTheOriginalCause() {
+        NegotiationGenerationOrchestrator orchestrator = NegotiationGenerationOrchestratorBuilder.builder()
+                .language("zh-CN")
+                .templateLoader(missingTemplateLoader())
+                .build();
+
+        NegotiationParamExtractionException failure = assertThrows(
+                NegotiationParamExtractionException.class,
+                () -> orchestrator.validateProposePromptAndDataFilling(
+                        "## 所需信息项\n1. 区域\n",
+                        new NegotiationContext(UUID, 1, 5),
+                        Map.of("type", "object"),
+                        INFORMATION_PROPOSE));
+
+        assertEquals(A2ATErrorCodes.TEMPLATE_NOT_FOUND, failure.getCode());
+        assertTrue(
+                failure.getCause() instanceof NegotiationGenerationException,
+                "the template-load failure must preserve the wrapped generation failure as cause for debugging");
+        assertTrue(
+                failure.getCause().getCause() instanceof ResourceNotFoundException,
+                "the original resource failure stays reachable through the cause chain");
+    }
+
+    @Test
     void rejectsNonNegotiationPromptInParameterExtraction() {
         ScriptedClient llm = new ScriptedClient(
                 "{\"semantic_verdict\":true,\"negotiation_type\":\"information\",\"errors\":[],\"params\":{}}");

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorTest.java
@@ -198,7 +198,7 @@ class NegotiationGenerationOrchestratorTest {
 
         NegotiationGenerationOrchestrator validationOrchestrator = NegotiationGenerationOrchestratorBuilder.builder()
                 .language("zh-CN")
-                .semanticValidator((prompt, callerSchema, reference) -> {
+                .semanticValidator((prompt, callerSchema, reference, templateContent) -> {
                     throw new ResourceNotFoundException(
                             "Semantic validation prompt does not exist.", "prompt_resources/prompts");
                 })

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidateAndFillingDataPipelineTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidateAndFillingDataPipelineTest.java
@@ -423,7 +423,7 @@ class ValidateAndFillingDataPipelineTest {
         NegotiationGenerationOrchestrator orchestrator = NegotiationGenerationOrchestratorBuilder.builder()
                 .language("zh-CN")
                 .llmClient(llm)
-                .semanticValidator((prompt, callerSchema, reference) -> {
+                .semanticValidator((prompt, callerSchema, reference, templateContent) -> {
                     throw new ResourceNotFoundException(
                             "Negotiation semantic validation prompt resource does not exist.",
                             "prompt_resources/prompts/negotiation_semantic_validation/zh-CN/system.md");

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidatePromptAndDataFillingSignatureContractTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/ValidatePromptAndDataFillingSignatureContractTest.java
@@ -15,13 +15,14 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Pins the compile-time contract of the validate-and-filling API: the negotiation context, the parameter schema and
- * the template URI are mandatory parts of the full signature of each of the three methods, so a caller that omits
+ * the template URI are mandatory parts of the full signature of each of the four methods, so a caller that omits
  * any argument is rejected at compile time and no reduced-arity overload can silently appear later.
  */
 class ValidatePromptAndDataFillingSignatureContractTest {
 
     private static final List<String> VALIDATE_PROMPT_FILLING_METHODS =
-            List.of("validateProposePromptAndDataFilling", "validateAcceptPromptAndDataFilling", "validateRejectPromptAndDataFilling");
+            List.of("validateProposePromptAndDataFilling", "validateAcceptPromptAndDataFilling",
+                    "validateRejectPromptAndDataFilling", "validateAbortPromptAndDataFilling");
 
     @Test
     void everyValidatePromptAndDataFillingMethodHasExactlyTheFullFourArgumentSignature() {
@@ -50,15 +51,15 @@ class ValidatePromptAndDataFillingSignatureContractTest {
     }
 
     @Test
-    void semanticValidatorSeamCarriesThePromptSchemaAndReferenceTogether() throws NoSuchMethodException {
+    void semanticValidatorSeamCarriesThePromptSchemaReferenceAndTemplateContentTogether() throws NoSuchMethodException {
         Method validate = NegotiationSemanticValidator.class.getMethod(
-                "validate", String.class, Map.class, NegotiationReference.class);
+                "validate", String.class, Map.class, NegotiationReference.class, String.class);
 
         assertTrue(Modifier.isPublic(validate.getModifiers()));
         assertEquals(
-                3,
+                4,
                 validate.getParameterCount(),
-                "the semantic validator seam must require the prompt, the caller schema and the template reference"
-                        + " together");
+                "the semantic validator seam must require the prompt, the caller schema, the template reference and"
+                        + " the template content together");
     }
 }

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationErrorCodeUsageMatrixTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/observability/NegotiationErrorCodeUsageMatrixTest.java
@@ -343,7 +343,7 @@ class NegotiationErrorCodeUsageMatrixTest {
     }
 
     private static NegotiationSemanticValidator throwingSemanticValidator() {
-        return (prompt, callerSchema, reference) -> {
+        return (prompt, callerSchema, reference, templateContent) -> {
             throw new ResourceNotFoundException(
                     "Semantic validation prompt does not exist.", "prompt_resources/prompts");
         };

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidatorTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/validation/DefaultNegotiationSemanticValidatorTest.java
@@ -27,6 +27,8 @@ class DefaultNegotiationSemanticValidatorTest {
             + "## Required Information Items\n"
             + "1. energy saving region: provide a real region\n";
 
+    private static final String TEMPLATE_CONTENT = "dummy template content";
+
     private final RecordingSchemaBuilder schemaBuilder = new RecordingSchemaBuilder();
 
     private final RecordingLLMClient llmClient = new RecordingLLMClient();
@@ -45,7 +47,7 @@ class DefaultNegotiationSemanticValidatorTest {
         llmClient.payload = "{\"semantic_verdict\":true,\"negotiation_type\":\"information\","
                 + "\"errors\":[],\"params\":{\"confirmed_rate_mbps\":2}}";
 
-        SemanticValidationResult result = validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference);
+        SemanticValidationResult result = validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT);
 
         assertTrue(result.verdict());
         assertEquals("information", result.negotiationType());
@@ -60,7 +62,7 @@ class DefaultNegotiationSemanticValidatorTest {
         llmClient.payload =
                 "{\"semantic_verdict\":true,\"negotiation_type\":\"information\"," + "\"errors\":[],\"params\":{}}";
 
-        validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference);
+        validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT);
 
         List<Map<String, String>> messages = llmClient.lastMessages;
         assertEquals(2, messages.size());
@@ -68,7 +70,9 @@ class DefaultNegotiationSemanticValidatorTest {
         assertTrue(messages.get(0).get("content").contains("semantic validation"));
         assertEquals("user", messages.get(1).get("role"));
         String userPrompt = messages.get(1).get("content");
-        assertTrue(userPrompt.contains("information"));
+assertTrue(userPrompt.contains("information"));
+        assertTrue(userPrompt.contains("propose"));
+        assertTrue(userPrompt.contains(TEMPLATE_CONTENT));
         assertTrue(userPrompt.contains(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri()));
         assertTrue(userPrompt.contains("confirmed_rate_mbps"));
         assertTrue(userPrompt.contains("energy saving region"));
@@ -83,7 +87,7 @@ class DefaultNegotiationSemanticValidatorTest {
 
         NegotiationValidationException exception = assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
 
         assertTrue(exception.getMessage().contains("negotiation_type"));
     }
@@ -93,17 +97,17 @@ class DefaultNegotiationSemanticValidatorTest {
         llmClient.payload = "{\"negotiation_type\":\"information\",\"errors\":[],\"params\":{}}";
         assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
 
         llmClient.payload = "{\"semantic_verdict\":true,\"negotiation_type\":\"information\",\"params\":{}}";
         assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
 
         llmClient.payload = "{\"semantic_verdict\":true,\"negotiation_type\":\"information\",\"errors\":[]}";
         assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
     }
 
     @Test
@@ -112,37 +116,37 @@ class DefaultNegotiationSemanticValidatorTest {
                 "{\"semantic_verdict\":\"yes\",\"negotiation_type\":\"information\"," + "\"errors\":[],\"params\":{}}";
         assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
 
         llmClient.payload = "{\"semantic_verdict\":true,\"negotiation_type\":\"information\","
                 + "\"errors\":\"none\",\"params\":{}}";
         assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
 
         llmClient.payload =
                 "{\"semantic_verdict\":true,\"negotiation_type\":\"information\"," + "\"errors\":[],\"params\":[]}";
         assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
 
         llmClient.payload = "{\"semantic_verdict\":true,\"negotiation_type\":\"information\","
                 + "\"errors\":[{\"slot_name\":\"section.context\"}],\"params\":{}}";
         assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
 
         llmClient.payload = "not json at all";
         assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
     }
 
     @Test
     void nullTypeWithTrueVerdictIsTurnedIntoSemanticRejection() {
         llmClient.payload = "{\"semantic_verdict\":true,\"negotiation_type\":null,\"errors\":[],\"params\":{}}";
 
-        SemanticValidationResult result = validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference);
+        SemanticValidationResult result = validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT);
 
         assertFalse(result.verdict());
         assertNull(result.negotiationType());
@@ -156,7 +160,7 @@ class DefaultNegotiationSemanticValidatorTest {
         llmClient.payload =
                 "{\"semantic_verdict\":true,\"negotiation_type\":\"target\"," + "\"errors\":[],\"params\":{}}";
 
-        SemanticValidationResult result = validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference);
+        SemanticValidationResult result = validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT);
 
         assertFalse(result.verdict());
         assertEquals("target", result.negotiationType());
@@ -172,7 +176,7 @@ class DefaultNegotiationSemanticValidatorTest {
                 + "\"errors\":[{\"slot_name\":\"section.target_result_content\","
                 + "\"code\":\"conclusion_content_mismatch\",\"message\":\"Mismatch\"}],\"params\":{}}";
 
-        SemanticValidationResult result = validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference);
+        SemanticValidationResult result = validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT);
 
         assertFalse(result.verdict());
         assertNull(result.negotiationType());
@@ -186,7 +190,7 @@ class DefaultNegotiationSemanticValidatorTest {
 
         NegotiationValidationException exception = assertThrows(
                 NegotiationValidationException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, informationReference, TEMPLATE_CONTENT));
 
         assertTrue(exception.getMessage().contains("invocation failed"));
     }
@@ -198,7 +202,7 @@ class DefaultNegotiationSemanticValidatorTest {
 
         assertThrows(
                 ResourceNotFoundException.class,
-                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, unsupportedLanguageReference));
+                () -> validator.validateNegotiation(VALID_PROMPT, callerSchema, unsupportedLanguageReference, TEMPLATE_CONTENT));
         assertEquals(0, llmClient.invocations);
     }
 

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/validation/ParamExtractorTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/validation/ParamExtractorTest.java
@@ -31,6 +31,8 @@ class ParamExtractorTest {
 
     private static final int MAX_ATTEMPTS = 1;
 
+    private static final String TEMPLATE_CONTENT = "dummy template content";
+
     private final StubComplianceChecker complianceChecker = new StubComplianceChecker();
 
     private final StubSemanticValidator semanticValidator = new StubSemanticValidator();
@@ -46,7 +48,7 @@ class ParamExtractorTest {
                 List.of(),
                 Map.of("id", "llm-value", "confirmed_rate_mbps", 2, "nested", Map.of("a", 1)));
 
-        FilledParamData filled = extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE);
+        FilledParamData filled = extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE, TEMPLATE_CONTENT);
 
         assertEquals(SESSION_ID, filled.data().get("id"));
         assertEquals(2, filled.data().get("round"));
@@ -62,7 +64,7 @@ class ParamExtractorTest {
         complianceChecker.result = new NegotiationRuleCheckResult(true, List.of());
         semanticValidator.result = new SemanticValidationResult(true, "information", List.of(), Map.of());
 
-        FilledParamData filled = extractor.extract(VALID_ZH_PROMPT, new NegotiationContext(SESSION_ID, 3, 7), Map.of(), REFERENCE);
+        FilledParamData filled = extractor.extract(VALID_ZH_PROMPT, new NegotiationContext(SESSION_ID, 3, 7), Map.of(), REFERENCE, TEMPLATE_CONTENT);
 
         assertTrue(filled.data().get("round") instanceof Integer);
         assertTrue(filled.data().get("maxRounds") instanceof Integer);
@@ -77,7 +79,7 @@ class ParamExtractorTest {
 
         NegotiationParamExtractionException exception = assertThrows(
                 NegotiationParamExtractionException.class,
-                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE));
+                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE, TEMPLATE_CONTENT));
 
         assertEquals("negotiation_rule_violation", exception.getCode());
         assertEquals(1, exception.getErrors().size());
@@ -92,7 +94,7 @@ class ParamExtractorTest {
 
         NegotiationParamExtractionException exception = assertThrows(
                 NegotiationParamExtractionException.class,
-                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE));
+                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE, TEMPLATE_CONTENT));
 
         assertEquals("negotiation_rule_violation", exception.getCode());
         assertEquals("id", exception.getErrors().get(0).slotName());
@@ -105,7 +107,7 @@ class ParamExtractorTest {
 
         NegotiationParamExtractionException exception = assertThrows(
                 NegotiationParamExtractionException.class,
-                () -> extractor.extract("## 任务目标\n诊断\n", null, Map.of(), REFERENCE));
+                () -> extractor.extract("## 任务目标\n诊断\n", null, Map.of(), REFERENCE, TEMPLATE_CONTENT));
 
         assertEquals("negotiation_invalid_input", exception.getCode());
         assertEquals(
@@ -126,7 +128,7 @@ class ParamExtractorTest {
 
         NegotiationParamExtractionException exception = assertThrows(
                 NegotiationParamExtractionException.class,
-                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE));
+                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE, TEMPLATE_CONTENT));
 
         assertEquals("negotiation_semantic_rejected", exception.getCode());
         assertEquals(semanticErrors, exception.getErrors());
@@ -138,7 +140,7 @@ class ParamExtractorTest {
         semanticValidator.result =
                 new SemanticValidationResult(true, "information", List.of(), Map.of("confirmed_rate_mbps", 2));
 
-        FilledParamData filled = extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE);
+        FilledParamData filled = extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE, TEMPLATE_CONTENT);
 
         assertEquals(1, semanticValidator.invocations);
         assertEquals(2, filled.data().get("confirmed_rate_mbps"));
@@ -151,7 +153,7 @@ class ParamExtractorTest {
 
         NegotiationParamExtractionException exception = assertThrows(
                 NegotiationParamExtractionException.class,
-                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE));
+                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE, TEMPLATE_CONTENT));
 
         assertEquals("negotiation_llm_infrastructure_error", exception.getCode());
         assertEquals(1, exception.getErrors().size());
@@ -167,7 +169,7 @@ class ParamExtractorTest {
 
         NegotiationParamExtractionException exception = assertThrows(
                 NegotiationParamExtractionException.class,
-                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE));
+                () -> extractor.extract(VALID_ZH_PROMPT, CONTEXT, Map.of(), REFERENCE, TEMPLATE_CONTENT));
 
         assertEquals("template_not_found", exception.getCode());
         assertEquals(List.of(), exception.getErrors());
@@ -196,7 +198,7 @@ class ParamExtractorTest {
 
         @Override
         public SemanticValidationResult validateNegotiation(
-                String prompt, Map<String, Object> callerSchema, NegotiationReference reference) {
+                String prompt, Map<String, Object> callerSchema, NegotiationReference reference, String templateContent) {
             invocations++;
             if (failure != null) {
                 throw failure;

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/DropBlankSlotSectionRenderer.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/DropBlankSlotSectionRenderer.java
@@ -10,12 +10,12 @@ import java.util.regex.Pattern;
  * Sectioned template renderer with the <b>drop</b> blank-slot policy.
  *
  * <p>A template is split into sections on {@code ## } title lines; any content before the first title, including a
- * leading HTML description comment, is discarded. A section whose first non-empty body line is a slot placeholder line
- * such as {@code {{required_information_items}} (required)} — or the same shape with the full-width required/optional
- * markers used by zh-CN templates — is a slot section: it is rendered as the title followed by the slot value, or
- * dropped entirely when the slot value is null or blank. Every other section is static and passes through with
- * placeholder substitution applied. Rendered sections are joined with a single blank line and the result carries no
- * trailing newline.
+ * leading HTML description comment, is discarded. A section whose first non-empty body line begins with a
+ * double-braced placeholder {@code {{name}}} is a slot section: it is rendered as the title followed by the slot
+ * value, or dropped entirely when the slot value is null or blank. Whatever follows the placeholder (marker text,
+ * parenthesized prose, nothing) is ignored for identification. Every other section is static and passes through
+ * with placeholder substitution applied. Rendered sections are joined with a single blank line and the result
+ * carries no trailing newline.
  *
  * @since 2026-08
  */
@@ -24,7 +24,7 @@ public final class DropBlankSlotSectionRenderer implements SectionedTemplateRend
     private static final String SECTION_TITLE_PREFIX = "## ";
 
     private static final Pattern SLOT_LINE_PATTERN =
-            Pattern.compile("^\\{\\{([^{}]+)\\}\\}\\s*(（必填）|（选填）|\\(required\\)|\\(optional\\))$");
+            Pattern.compile("^\\{\\{([^{}]+)\\}\\}.*$");
 
     private static final Pattern SLOT_TOKEN_PATTERN = Pattern.compile("\\{\\{([^{}]+)\\}\\}");
 
@@ -35,7 +35,7 @@ public final class DropBlankSlotSectionRenderer implements SectionedTemplateRend
      * @param slots slot values keyed by the language-specific slot name; a null or blank value drops the slot section
      * @return rendered message text with sections joined by one blank line and no trailing newline; empty string when
      *     no section remains
-     * @throws IllegalArgumentException if the template text is null
+     * @throws NullPointerException if the template text is null
      */
     @Override
     public String render(String templateText, Map<String, String> slots) {

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/SectionedTemplateRenderer.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/SectionedTemplateRenderer.java
@@ -7,8 +7,8 @@ import org.jspecify.annotations.Nullable;
 /**
  * Renders a sectioned prompt template by filling slot values under one blank-slot policy.
  *
- * <p>A sectioned template is split into sections on {@code ## } title lines; any content before the first title is
- * preamble and is discarded. A section whose first non-empty body line is a standalone slot placeholder line is a
+ * <p>A sectioned template is split into sections on {@code ## } title lines; preamble handling is policy-specific —
+ * the drop policy discards content before the first title, while the collapse policy may retain it. A section whose first non-empty body line is a standalone slot placeholder line is a
  * slot section driven by that slot; every other section is static and passes through with placeholder substitution.
  *
  * <p>Implementations differ in how they treat a slot section whose value is null or blank:

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRenderer.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRenderer.java
@@ -13,6 +13,11 @@ import net.openan.a2at.sdk.prompt.taskrendering.exception.TaskPromptRenderExcept
  * <p>This renderer carries the <b>collapse</b> blank-slot policy of {@link SectionedTemplateRenderer}: a slot section
  * keeps its scaffolding and its standalone slot line collapses to the bare slot placeholder.
  *
+ * <p>A section is identified as a slot section when its first non-empty body line begins with a double-braced
+ * placeholder {@code {{name}}}. Whatever follows the placeholder (marker text, parenthesized prose, nothing) is
+ * discarded on collapse. Single-brace example text (e.g. {@code {00:00~06:00,2Mbps}}) never triggers slot-section
+ * identification.
+ *
  * @since 2026-06
  */
 public final class TaskPromptRenderer implements SectionedTemplateRenderer {
@@ -29,7 +34,7 @@ public final class TaskPromptRenderer implements SectionedTemplateRenderer {
     }
     private static final Pattern SECTION_HEADER_PATTERN = Pattern.compile("^##\\s+.+$");
     private static final Pattern STANDALONE_SLOT_LINE_PATTERN = Pattern.compile(
-            "^\\s*(\\{\\{?\\s*[^{}]+?\\s*\\}\\}?)(?:\\s*(?:\\(Required\\)|\\(Optional\\)|（必选）|（可选）))?\\s*$");
+            "^\\s*(\\{\\{([^{}]+)\\}\\}).*$");
 
     /**
      * Renders a template by replacing slot placeholders with normalized slot values.

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidator.java
@@ -10,12 +10,18 @@ import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.core.validation.ContentValidator;
 import net.openan.a2at.sdk.core.validation.ValidationPipeline;
 import net.openan.a2at.sdk.llm.LLMClient;
+import net.openan.a2at.sdk.prompt.resources.loader.PromptTemplateTextLoader;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Default content validator that orchestrates the full validation pipeline with a no-op rule checker and an LLM-backed
  * semantic validator.
+ *
+ * <p>The template referenced by the {@code templateUri} argument of every {@link #validate} call is loaded through a
+ * sourceType-aware template loader before the validation pipeline is entered. A load failure is reported as a
+ * {@code TEMPLATE_NOT_FOUND} error, distinct from the {@code VALIDATION_PROMPT_RESOURCE_NOT_FOUND} code that signals
+ * missing content_validation prompt resources. The loaded template text flows into the pipeline for prompt injection.
  *
  * <p>The semantic validator is initialised lazily on the first {@link #validate} call so that constructing the
  * validator never loads prompt resources — the facade builders can wire the validator eagerly without requiring the
@@ -30,6 +36,7 @@ public final class DefaultContentValidator implements ContentValidator {
     private final String language;
     private final int maxAttempts;
     private final LLMClient llmClient;
+    private final PromptTemplateTextLoader templateLoader;
 
     private volatile ValidationPipeline pipeline;
 
@@ -40,18 +47,25 @@ public final class DefaultContentValidator implements ContentValidator {
      * are loaded on the first {@link #validate} call.
      *
      * @param extensionName extension name used for template URI validation
-     * @param language language code for prompt resource loading
+     * @param language language code for prompt resource loading and template loading
      * @param maxAttempts maximum retry attempts for semantic validation
      * @param llmClient LLM client for semantic validation; may be {@code null}, in which case the first
      *     {@link #validate} call fails with {@code ContentValidationException} carrying
      *     {@code VALIDATION_LLM_INFRASTRUCTURE_ERROR}; there is no late injection point
+     * @param templateLoader sourceType-aware template text loader for loading the template referenced by the
+     *     {@code templateUri} of every {@link #validate} call
      */
     public DefaultContentValidator(
-            @NonNull String extensionName, @NonNull String language, int maxAttempts, @Nullable LLMClient llmClient) {
+            @NonNull String extensionName,
+            @NonNull String language,
+            int maxAttempts,
+            @Nullable LLMClient llmClient,
+            @NonNull PromptTemplateTextLoader templateLoader) {
         this.extensionName = extensionName;
         this.language = language;
         this.maxAttempts = maxAttempts;
         this.llmClient = llmClient;
+        this.templateLoader = templateLoader;
     }
 
     /**
@@ -66,6 +80,7 @@ public final class DefaultContentValidator implements ContentValidator {
      * @throws IllegalArgumentException if the prompt is blank, the template URI addresses another extension than the
      *     one this validator is configured for, or the template URI version is unsupported
      * @throws ContentValidationException if the validation fails at any stage, including
+     *     {@code TEMPLATE_NOT_FOUND} when the template cannot be loaded, or
      *     {@code VALIDATION_PROMPT_RESOURCE_NOT_FOUND} when the content_validation prompt resources of the configured
      *     language are missing on the classpath
      */
@@ -83,7 +98,18 @@ public final class DefaultContentValidator implements ContentValidator {
             throw new IllegalArgumentException("Unsupported template URI version: " + templateUri.templateVersion());
         }
 
-        return pipeline().validate(prompt, schema, templateUri);
+        String templateContent;
+        try {
+            templateContent = templateLoader.loadTemplate(templateUri.uri(), language);
+        } catch (ResourceNotFoundException exception) {
+            throw new ContentValidationException(
+                    A2ATErrorCodes.TEMPLATE_NOT_FOUND,
+                    "Template not found for URI " + templateUri.uri() + " and language " + language + ": "
+                            + exception.getMessage(),
+                    exception);
+        }
+
+        return pipeline().validate(prompt, schema, templateUri, templateContent);
     }
 
     private ValidationPipeline pipeline() {

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidator.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
@@ -89,14 +90,14 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
 
     @Override
     public ValidationResult validate(
-            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri reference) {
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri reference, @NonNull String templateContent) {
         if (llmClient == null) {
             throw new ContentValidationException(
                     A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR,
                     "LLM client is not configured for semantic validation.");
         }
 
-        String userPrompt = fillUserPrompt(prompt, schema, reference);
+        String userPrompt = fillUserPrompt(prompt, schema, reference, templateContent);
         Map<String, Object> outputSchema = buildOutputSchema();
         List<Map<String, String>> messages = toStructuredMessages(
                 List.of(new PromptMessage("system", systemPrompt), new PromptMessage("user", userPrompt)));
@@ -150,7 +151,10 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
         }
     }
 
-    private String fillUserPrompt(String prompt, Map<String, Object> schema, TemplateUri reference) {
+    private static final Pattern PLACEHOLDER_PATTERN =
+            Pattern.compile("\\[(extension_name|input|template_uri|template_content|schema)\\]");
+
+    private String fillUserPrompt(String prompt, Map<String, Object> schema, TemplateUri reference, String templateContent) {
         String schemaJson;
         try {
             schemaJson = OBJECT_MAPPER.writeValueAsString(schema);
@@ -158,11 +162,21 @@ final class DefaultSemanticValidator implements SemanticValidator<TemplateUri> {
             throw new A2ATError("Failed to serialize schema to JSON.", exception);
         }
 
-        return userPromptTemplate
-                .replaceAll("\\[extension_name\\]", Matcher.quoteReplacement(reference.extensionName()))
-                .replaceAll("\\[input\\]", Matcher.quoteReplacement(prompt))
-                .replaceAll("\\[template_uri\\]", Matcher.quoteReplacement(reference.uri()))
-                .replaceAll("\\[schema\\]", Matcher.quoteReplacement(schemaJson));
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(userPromptTemplate);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            String replacement = switch (matcher.group(1)) {
+                case "extension_name" -> Matcher.quoteReplacement(reference.extensionName());
+                case "input" -> Matcher.quoteReplacement(prompt);
+                case "template_uri" -> Matcher.quoteReplacement(reference.uri());
+                case "template_content" -> Matcher.quoteReplacement(templateContent);
+                case "schema" -> Matcher.quoteReplacement(schemaJson);
+                default -> Matcher.quoteReplacement(matcher.group());
+            };
+            matcher.appendReplacement(sb, replacement);
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
     }
 
     private static Map<String, Object> buildOutputSchema() {

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/DropBlankSlotSectionRendererTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/DropBlankSlotSectionRendererTest.java
@@ -1,0 +1,203 @@
+package net.openan.a2at.sdk.prompt.taskrendering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DropBlankSlotSectionRendererTest {
+
+    private final DropBlankSlotSectionRenderer renderer = new DropBlankSlotSectionRenderer();
+
+    @Test
+    void rendersSlotSectionWithLowercaseEnglishMarker() {
+        String template =
+                """
+                ## Slot
+                {{slot}} (required)
+                Requirements:
+                Some requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of("slot", "value"));
+
+        assertEquals("## Slot\nvalue", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithFullWidthChineseMarker() {
+        String template =
+                """
+                ## 槽位
+                {{槽位}}（必填）
+                要求：
+                一些要求。
+                """;
+
+        String rendered = renderer.render(template, Map.of("槽位", "值"));
+
+        assertEquals("## 槽位\n值", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithChineseOptionalVariant() {
+        String template =
+                """
+                ## 订阅条件
+                {{订阅条件}}（可选）
+                要求：
+                提供订阅条件。
+                """;
+
+        String rendered = renderer.render(template, Map.of("订阅条件", "critical"));
+
+        assertEquals("## 订阅条件\ncritical", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithChineseRequiredVariant() {
+        String template =
+                """
+                ## 通知主题
+                {{通知主题}}（必选）
+                要求：
+                提供通知主题。
+                """;
+
+        String rendered = renderer.render(template, Map.of("通知主题", "Incident"));
+
+        assertEquals("## 通知主题\nIncident", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithBarePlaceholderNoMarker() {
+        String template =
+                """
+                ## Slot
+                {{slot}}
+                Requirements:
+                Some requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of("slot", "value"));
+
+        assertEquals("## Slot\nvalue", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithLongConditionalSuffix() {
+        String template =
+                """
+                ## Expected Output
+                {{expected_output}} (optional when creating, not required when modifying)
+                Requirement:
+                Describe the output format.
+                """;
+
+        String rendered = renderer.render(template, Map.of("expected_output", "Report."));
+
+        assertEquals("## Expected Output\nReport.", rendered);
+    }
+
+    @Test
+    void dropsSlotSectionWhenValueIsNull() {
+        String template =
+                """
+                ## Slot
+                {{slot}} (required)
+                Requirements:
+                Some requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of());
+
+        assertEquals("", rendered);
+    }
+
+    @Test
+    void dropsSlotSectionWhenValueIsBlank() {
+        String template =
+                """
+                ## Slot
+                {{slot}} (required)
+                Requirements:
+                Some requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of("slot", "   "));
+
+        assertEquals("", rendered);
+    }
+
+    @Test
+    void keepsStaticSectionPassesThrough() {
+        String template =
+                """
+                ## Static
+                Some static content.
+                """;
+
+        String rendered = renderer.render(template, Map.of());
+
+        assertEquals("## Static\nSome static content.", rendered);
+    }
+
+    @Test
+    void joinsSectionsWithSingleBlankLine() {
+        String template =
+                """
+                ## Section A
+                Content A.
+
+                ## Section B
+                Content B.
+                """;
+
+        String rendered = renderer.render(template, Map.of());
+
+        assertEquals("## Section A\nContent A.\n\n## Section B\nContent B.", rendered);
+    }
+
+    @Test
+    void returnsEmptyStringWhenAllSectionsDropped() {
+        String template =
+                """
+                ## Slot A
+                {{slot_a}} (required)
+                Requirements.
+
+                ## Slot B
+                {{slot_b}} (required)
+                Requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of());
+
+        assertEquals("", rendered);
+    }
+
+    @Test
+    void rejectsNullTemplate() {
+        assertThrows(NullPointerException.class, () -> renderer.render(null, Map.of()));
+    }
+
+    @Test
+    void doesNotIdentifySlotSectionWhenFirstLineIsSingleBraceExample() {
+        String template =
+                """
+                ## Section
+                {00:00~06:00,2Mbps}
+
+                {{slot}} (optional)
+                """;
+
+        String rendered = renderer.render(template, Map.of("slot", "value"));
+
+        assertTrue(rendered.contains("{00:00~06:00,2Mbps}"));
+        assertTrue(rendered.contains("value"));
+        assertTrue(rendered.contains("(optional)"));
+    }
+}

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/RealTemplateRenderingContractTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/RealTemplateRenderingContractTest.java
@@ -1,0 +1,130 @@
+package net.openan.a2at.sdk.prompt.taskrendering;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import net.openan.a2at.sdk.resources.ClasspathPromptResourceLoader;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests that verify real template resources from the classpath are rendered correctly:
+ * scaffolding text (Requirement:/要求：) must be removed from rendered output.
+ */
+class RealTemplateRenderingContractTest {
+
+    private final TaskPromptRenderer taskRenderer = new TaskPromptRenderer();
+    private final DropBlankSlotSectionRenderer dropRenderer = new DropBlankSlotSectionRenderer();
+
+    @Test
+    void energySavingEnUsTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Task-T/network-layer/energy-saving/v1/en-US/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "operation_type", "Create",
+                "task_description", "Energy saving plan.",
+                "task_object", "Area: Songshanhu",
+                "task_target", "Maximize energy saving.",
+                "task_context", "NR; full period.",
+                "expected_output", "Report."));
+
+        assertFalse(rendered.contains("Requirement:"));
+        assertTrue(rendered.contains("Create"));
+        assertTrue(rendered.contains("Energy saving plan."));
+        assertTrue(rendered.contains("Maximize energy saving."));
+    }
+
+    @Test
+    void energySavingZhCnTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Task-T/network-layer/energy-saving/v1/zh-CN/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "操作类型", "创建",
+                "任务描述", "节能方案。",
+                "任务对象", "区域：松山湖",
+                "任务目标", "最大化节能。",
+                "任务上下文", "NR；全时段。",
+                "预期输出", "报告。"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("创建"));
+        assertTrue(rendered.contains("节能方案。"));
+        assertTrue(rendered.contains("最大化节能。"));
+    }
+
+    @Test
+    void authorizationEnUsTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Authorization-T/authorization-policy-management/v1/en-US/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "authorization_policy_operation_type", "add authorization policy",
+                "network_operation_authorization_policy_list", "Policy list content."));
+
+        assertFalse(rendered.contains("Requirement:"));
+        assertTrue(rendered.contains("add authorization policy"));
+        assertTrue(rendered.contains("Policy list content."));
+    }
+
+    @Test
+    void authorizationZhCnTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Authorization-T/authorization-policy-management/v1/zh-CN/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "授权策略的操作类型", "新增授权策略",
+                "动网操作的授权策略列表", "策略列表内容。"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("新增授权策略"));
+        assertTrue(rendered.contains("策略列表内容。"));
+    }
+
+    @Test
+    void subscribeIncidentZhCnTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Notification-T/network-layer/subscribe-incident/v1/zh-CN/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "通知主题", "Incident",
+                "订阅条件", "严重",
+                "上报通知数据格式", "DataPart"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("Incident"));
+        assertTrue(rendered.contains("DataPart"));
+    }
+
+    @Test
+    void serviceRecoveryZhCnTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Notification-T/network-layer/service-recovery/v1/zh-CN/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "订阅条件", "子网：xx",
+                "上报通知数据格式", "数据格式内容。"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("数据格式内容。"));
+    }
+
+    @Test
+    void negotiationZhCnTemplateDropsBlankSlotSections() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Negotiation-T/information-negotiation/propose/v1/zh-CN/template.md");
+        String rendered = dropRenderer.render(template, Map.of(
+                "所需信息项", "1. 信息项"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("信息项"));
+    }
+
+    private static String loadTemplate(String classpathResource) {
+        try (java.io.InputStream stream = RealTemplateRenderingContractTest.class
+                .getClassLoader()
+                .getResourceAsStream(classpathResource)) {
+            if (stream == null) {
+                throw new AssertionError("Template not found on classpath: " + classpathResource);
+            }
+            return new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to read template: " + classpathResource, e);
+        }
+    }
+}

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRendererTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRendererTest.java
@@ -130,4 +130,69 @@ class TaskPromptRendererTest {
         assertThrows(
                 TaskPromptRenderException.class, () -> renderer.render("Site: {{site}", Map.of("site", "Site A")));
     }
+
+    @Test
+    void renderCollapsesSectionWithLowercaseEnglishMarker() {
+        String prompt = renderer.render(
+                "## Task Target\n"
+                        + "{{task_target}} (required)\n\n"
+                        + "Requirement: explain the target.\n\n"
+                        + "## Expected Output\n"
+                        + "{{expected_output}} (optional)\n",
+                Map.of("task_target", "Do X.", "expected_output", "Y."));
+
+        assertEquals(
+                "## Task Target\nDo X.\n\n## Expected Output\nY.\n", prompt);
+    }
+
+    @Test
+    void renderCollapsesSectionWithFullWidthChineseMarker() {
+        String prompt = renderer.render(
+                "## 操作类型\n"
+                        + "{{操作类型}}（必填）\n\n"
+                        + "要求：\n"
+                        + "请提供操作类型。\n\n"
+                        + "## 任务目标\n"
+                        + "{{任务目标}}（选填）\n",
+                Map.of("操作类型", "创建", "任务目标", "节能最大化"));
+
+        assertEquals(
+                "## 操作类型\n创建\n\n## 任务目标\n节能最大化\n", prompt);
+    }
+
+    @Test
+    void renderCollapsesSectionWithLongConditionalSuffix() {
+        String prompt = renderer.render(
+                "## Expected Output\n"
+                        + "{{expected_output}} (optional when creating, not required when modifying)\n\n"
+                        + "Requirement: describe the output format.\n",
+                Map.of("expected_output", "Report."));
+
+        assertEquals(
+                "## Expected Output\nReport.\n", prompt);
+    }
+
+    @Test
+    void renderCollapsesSectionWithBarePlaceholderNoMarker() {
+        String prompt = renderer.render(
+                "## Task Target\n"
+                        + "{{task_target}}\n\n"
+                        + "Requirement: explain the target.\n",
+                Map.of("task_target", "Do X."));
+
+        assertEquals(
+                "## Task Target\nDo X.\n", prompt);
+    }
+
+    @Test
+    void renderDoesNotCollapseWhenFirstEffectiveLineIsSingleBraceExample() {
+        String prompt = renderer.render(
+                "## Task Context\n"
+                        + "{00:00~06:00,2Mbps}\n\n"
+                        + "{{task_context}} (optional)\n",
+                Map.of("task_context", "Context value."));
+
+        assertEquals(
+                "## Task Context\n{00:00~06:00,2Mbps}\n\nContext value. (optional)\n", prompt);
+    }
 }

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultContentValidatorTest.java
@@ -16,15 +16,18 @@ import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import net.openan.a2at.sdk.llm.LLMRuntimeError;
+import net.openan.a2at.sdk.prompt.resources.loader.PromptTemplateTextLoader;
 import org.junit.jupiter.api.Test;
 
 class DefaultContentValidatorTest {
 
     private static final TemplateUri TASK_URI = TemplateUri.of("Task-T", "network-layer", "energy-saving");
 
+    private static final PromptTemplateTextLoader STUB_LOADER = (scenarioCode, language) -> "dummy template content";
+
     @Test
     void validatesSuccessfullyOnFirstCall() {
-        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient(), STUB_LOADER);
 
         FilledParamData result =
                 assertDoesNotThrow(() -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
@@ -35,7 +38,7 @@ class DefaultContentValidatorTest {
 
     @Test
     void rejectsMismatchedExtensionName() {
-        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient(), STUB_LOADER);
 
         assertThrows(
                 IllegalArgumentException.class,
@@ -47,7 +50,7 @@ class DefaultContentValidatorTest {
 
     @Test
     void missingPromptResourceFailsWithValidationPromptResourceNotFound() {
-        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient());
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient(), STUB_LOADER);
 
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
@@ -60,7 +63,7 @@ class DefaultContentValidatorTest {
 
     @Test
     void missingPromptResourceKeepsPipelineNullSoNextCallRetries() {
-        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient());
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient(), STUB_LOADER);
 
         // first call fails on the missing resource; the pipeline must stay uninitialised so the next
         // call re-attempts the construction (transient failures can heal)
@@ -76,7 +79,7 @@ class DefaultContentValidatorTest {
 
     @Test
     void succeedsOnSecondCallAfterTransientResourceFailureHeals() {
-        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient());
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient(), STUB_LOADER);
 
         assertThrows(
                 ContentValidationException.class,
@@ -84,7 +87,7 @@ class DefaultContentValidatorTest {
 
         // switching the language is impossible on this class; the healing path is instead proven by a
         // fresh validator with a supported language constructed after the failing one
-        DefaultContentValidator healed = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient());
+        DefaultContentValidator healed = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient(), STUB_LOADER);
         FilledParamData result =
                 assertDoesNotThrow(() -> healed.validate("task prompt", Map.of("type", "object"), TASK_URI));
 
@@ -93,13 +96,45 @@ class DefaultContentValidatorTest {
 
     @Test
     void retryableFailureAfterResourceLoadStillMapsLlmInfrastructureError() {
-        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 1, new FailingClient());
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 1, new FailingClient(), STUB_LOADER);
 
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
 
         assertEquals("validation_llm_infrastructure_error", exception.getCode());
+    }
+
+    @Test
+    void missingTemplateFailsWithTemplateNotFound() {
+        PromptTemplateTextLoader failingLoader = (scenarioCode, language) -> {
+            throw new ResourceNotFoundException("Template does not exist.", scenarioCode);
+        };
+        DefaultContentValidator validator = new DefaultContentValidator("Task-T", "zh-CN", 3, new StubClient(), failingLoader);
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+
+        assertEquals("template_not_found", exception.getCode());
+        assertInstanceOf(ResourceNotFoundException.class, exception.getCause());
+    }
+
+    @Test
+    void missingTemplateLoadsBeforePromptResourcesSoTemplateErrorTakesPrecedence() {
+        // template load fails on an otherwise-valid, resource-complete configuration: the template gate must
+        // short-circuit before the pipeline (and its prompt resources) are ever initialised
+        PromptTemplateTextLoader failingLoader = (scenarioCode, language) -> {
+            throw new ResourceNotFoundException("Template does not exist.", scenarioCode);
+        };
+        DefaultContentValidator validator =
+                new DefaultContentValidator("Task-T", "fr-FR", 3, new StubClient(), failingLoader);
+
+        ContentValidationException exception = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate("task prompt", Map.of("type", "object"), TASK_URI));
+
+        assertEquals("template_not_found", exception.getCode());
     }
 
     private static final class StubClient implements LLMClient {

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/validation/DefaultSemanticValidatorTest.java
@@ -34,6 +34,8 @@ class DefaultSemanticValidatorTest {
             }
             """;
 
+    private static final String TEMPLATE_CONTENT = "dummy template content";
+
     @Test
     void validatesEnUSPromptAndExtractsParams() {
         RecordingClient llmClient = new RecordingClient(VALID_RESPONSE);
@@ -41,7 +43,7 @@ class DefaultSemanticValidatorTest {
         DefaultSemanticValidator validator = new DefaultSemanticValidator(llmClient, "en-US");
 
         ValidationResult result = validator.validate(
-                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"));
+                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"), TEMPLATE_CONTENT);
 
         assertTrue(result.verdict());
         assertEquals(Map.of("site", "Site A"), result.params());
@@ -73,7 +75,7 @@ class DefaultSemanticValidatorTest {
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
 
         FilledParamData result = pipeline.validate(
-                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"));
+                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"), TEMPLATE_CONTENT);
 
         assertEquals(Map.of("site", "Site A"), result.data());
         assertEquals(2, flakyClient.invocations());
@@ -100,7 +102,7 @@ class DefaultSemanticValidatorTest {
                 () -> pipeline.validate(
                         "Check Site A power usage.",
                         Map.of("type", "object"),
-                        TemplateUri.of("Task-T", "energy-saving")));
+                        TemplateUri.of("Task-T", "energy-saving"), TEMPLATE_CONTENT));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertInstanceOf(LLMRuntimeError.class, exception.getCause().getCause());
@@ -119,7 +121,7 @@ class DefaultSemanticValidatorTest {
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
 
         FilledParamData result =
-                pipeline.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
+                pipeline.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT);
 
         assertEquals(2, result.data().size());
         assertEquals("端口A", result.data().get("任务对象"));
@@ -133,7 +135,7 @@ class DefaultSemanticValidatorTest {
         DefaultSemanticValidator validator = new DefaultSemanticValidator(new StubClient(llmJson), "zh-CN");
 
         ValidationResult result =
-                validator.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
+                validator.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT);
 
         assertTrue(result.verdict());
         // a null param is the validator's signal that a schema slot is missing from the content; the key must stay
@@ -152,7 +154,7 @@ class DefaultSemanticValidatorTest {
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> validator.validate(
-                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertTrue(exception.getMessage().contains("semantic_verdict"));
@@ -166,7 +168,7 @@ class DefaultSemanticValidatorTest {
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> validator.validate(
-                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertTrue(exception.getMessage().contains("semantic_verdict"));
@@ -180,7 +182,7 @@ class DefaultSemanticValidatorTest {
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> validator.validate(
-                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertTrue(exception.getMessage().contains("errors"));
@@ -194,7 +196,7 @@ class DefaultSemanticValidatorTest {
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> validator.validate(
-                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertTrue(exception.getMessage().contains("errors"));
@@ -208,7 +210,7 @@ class DefaultSemanticValidatorTest {
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> validator.validate(
-                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertTrue(exception.getMessage().contains("params"));
@@ -221,7 +223,7 @@ class DefaultSemanticValidatorTest {
                 "en-US");
 
         ValidationResult result =
-                validator.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"));
+                validator.validate("task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT);
 
         assertTrue(result.verdict());
     }
@@ -242,7 +244,7 @@ class DefaultSemanticValidatorTest {
         ContentValidationException exception = assertThrows(
                 ContentValidationException.class,
                 () -> validator.validate(
-                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer")));
+                        "task prompt", Map.of("type", "object"), TemplateUri.of("Task-T", "network-layer"), TEMPLATE_CONTENT));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertTrue(exception.getMessage().contains("params keys"));
@@ -257,7 +259,7 @@ class DefaultSemanticValidatorTest {
         ValidationPipeline pipeline = new ValidationPipeline(prompt -> Map.of(), validator, 2);
 
         FilledParamData result = pipeline.validate(
-                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"));
+                "Check Site A power usage.", Map.of("type", "object"), TemplateUri.of("Task-T", "energy-saving"), TEMPLATE_CONTENT);
 
         // first attempt violates the output contract (string verdict) → retryable infra error → second attempt
         // returns a compliant response and the pipeline succeeds
@@ -278,10 +280,44 @@ class DefaultSemanticValidatorTest {
                 () -> pipeline.validate(
                         "Check Site A power usage.",
                         Map.of("type", "object"),
-                        TemplateUri.of("Task-T", "energy-saving")));
+                        TemplateUri.of("Task-T", "energy-saving"), TEMPLATE_CONTENT));
 
         assertEquals(A2ATErrorCodes.VALIDATION_LLM_INFRASTRUCTURE_ERROR, exception.getCode());
         assertEquals(3, client.invocations());
+    }
+
+    @Test
+    void templateContentWithPlaceholderLiteralIsNotSecondOrderReplaced() {
+        String templateContentWithPlaceholder = "Template body with [extension_name] and [input] literals.";
+        RecordingClient recordingClient = new RecordingClient(VALID_RESPONSE);
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(recordingClient, "en-US");
+
+        validator.validate(
+                "Check Site A power usage.",
+                Map.of("type", "object"),
+                TemplateUri.of("Task-T", "network-layer"),
+                templateContentWithPlaceholder);
+
+        String userContent = recordingClient.userContent();
+        assertTrue(userContent.contains("Template body with [extension_name] and [input] literals."));
+        assertTrue(userContent.contains("Task-T"));
+        assertTrue(userContent.contains("Check Site A power usage"));
+    }
+
+    @Test
+    void templateContentPlaceholderIsFilled() {
+        RecordingClient recordingClient = new RecordingClient(VALID_RESPONSE);
+        DefaultSemanticValidator validator = new DefaultSemanticValidator(recordingClient, "en-US");
+
+        validator.validate(
+                "Check Site A power usage.",
+                Map.of("type", "object"),
+                TemplateUri.of("Task-T", "network-layer"),
+                "## Energy Saving Template\n\nCheck the energy saving region.");
+
+        String userContent = recordingClient.userContent();
+        assertTrue(userContent.contains("## Energy Saving Template"));
+        assertTrue(userContent.contains("energy saving region"));
     }
 
     private static final class RecordingClient implements LLMClient {
@@ -307,6 +343,15 @@ class DefaultSemanticValidatorTest {
         String lastSystemContent() {
             for (Map<String, String> message : lastMessages) {
                 if ("system".equals(message.get("role"))) {
+                    return message.get("content");
+                }
+            }
+            return "";
+        }
+
+        String userContent() {
+            for (Map<String, String> message : lastMessages) {
+                if ("user".equals(message.get("role"))) {
                     return message.get("content");
                 }
             }

--- a/a2a-t-resources/src/main/resources/prompt_resources/prompts/content_validation/en-US/user.md
+++ b/a2a-t-resources/src/main/resources/prompt_resources/prompts/content_validation/en-US/user.md
@@ -1,6 +1,7 @@
 Extension Name: [extension_name]
 Input Content: [input]
 Template URI: [template_uri]
+Template Content: [template_content]
 Parameter Schema: [schema]
 
 Following the system prompt, perform all validation tasks and the parameter extraction on the input content above. Output one JSON object containing all 3 required keys only.

--- a/a2a-t-resources/src/main/resources/prompt_resources/prompts/content_validation/zh-CN/user.md
+++ b/a2a-t-resources/src/main/resources/prompt_resources/prompts/content_validation/zh-CN/user.md
@@ -1,6 +1,7 @@
 扩展名称：[extension_name]
 输入内容：[input]
 模板标识：[template_uri]
+模板正文：[template_content]
 参数模式：[schema]
 
 请按系统提示词要求，对上述输入内容完成全部校验任务与参数提取，只输出包含全部 3 个必填键的 JSON 对象。

--- a/a2a-t-resources/src/main/resources/prompt_resources/prompts/negotiation_semantic_validation/en-US/user.md
+++ b/a2a-t-resources/src/main/resources/prompt_resources/prompts/negotiation_semantic_validation/en-US/user.md
@@ -1,5 +1,7 @@
+Negotiation phase: [phase]
 Declared negotiation type: [negotiation_type]
 Declared template identifier: [template_uri]
+Template content: [template_content]
 
 Parameter schema:
 [schema]

--- a/a2a-t-resources/src/main/resources/prompt_resources/prompts/negotiation_semantic_validation/zh-CN/user.md
+++ b/a2a-t-resources/src/main/resources/prompt_resources/prompts/negotiation_semantic_validation/zh-CN/user.md
@@ -1,5 +1,7 @@
+协商阶段：[phase]
 声明的协商类型：[negotiation_type]
 声明的模板标识：[template_uri]
+模板正文：[template_content]
 
 参数 schema：
 [schema]

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
@@ -42,6 +42,8 @@ public final class DefaultA2ATServerBuilder {
 
     private LLMClient llmClient;
 
+    private PromptResourceAccess promptResourceAccess;
+
     private DefaultServerPromptComplianceOrchestrator promptComplianceOrchestrator;
 
     /**
@@ -88,7 +90,7 @@ public final class DefaultA2ATServerBuilder {
             return promptComplianceOrchestrator;
         }
 
-        PromptResourceAccess resources = PromptResourceAccess.create(config.prompt());
+        PromptResourceAccess resources = promptResourceAccess();
         String language = config.prompt().language();
         List<ScenarioDefinition> scenarios = resources.loadScenarios(language);
         PromptTemplateTextLoader templateLoader = resources.templateLoader();
@@ -203,7 +205,11 @@ public final class DefaultA2ATServerBuilder {
         requireSupportedConfig();
         require(envPath, "Unified SDK env path must be configured.");
         return new DefaultContentValidator(
-                extensionName, config.prompt().language(), config.llm().maxAttempts(), llmClient());
+                extensionName,
+                config.prompt().language(),
+                config.llm().maxAttempts(),
+                llmClient(),
+                promptResourceAccess().templateLoader());
     }
 
     private static void require(Object value, String message) {
@@ -234,5 +240,12 @@ public final class DefaultA2ATServerBuilder {
             llmClient = LLMClientFactory.create(config.llm().provider(), LLMClientConfig.from(config.llm()));
         }
         return llmClient;
+    }
+
+    private synchronized PromptResourceAccess promptResourceAccess() {
+        if (promptResourceAccess == null) {
+            promptResourceAccess = PromptResourceAccess.create(config.prompt());
+        }
+        return promptResourceAccess;
     }
 }


### PR DESCRIPTION
## Summary

Two related changes on the theme "make validation and generation actually see the real template".

### 1. feat(validation): inject template content into validation prompts

Implements the ratified decisions in the template-content-in-validation discussion: the LLM validation prompts now receive the actual template body instead of only the URI string, restoring structural/required-ness judging.

- **Template existence gate (Task side)**: `DefaultContentValidator` regains a sourceType-aware `PromptTemplateTextLoader`; the template is loaded before the pipeline, fail-fast at the same level as the extension/version gates. Load failure maps to `template_not_found` (distinct from prompt-resource-missing errors). Local `local_file` template overrides now affect validation symmetrically with generation.
- **Negotiation symmetric injection**: all 4 validate entries (propose/accept/reject/abort) inject `[template_content]`, reusing the generation path's `DefaultNegotiationTemplateLoader` so generation and validation use the same template resources.
- **`[phase]` token fix**: negotiation_semantic_validation user.md (zh-CN/en-US) gains `[phase]` — the code already filled it but the token was missing from the resources (silent no-op), leaving accept/reject indistinguishable to the LLM.
- **Single-pass replacement**: placeholder filling on both sides refactored from chained replaces to one regex-based pass, preventing second-order injection of (potentially user-influenceable) template content.
- **No slot.json injection** (decided); prompt resources stay fixed classpath (PR #136 policy unchanged); public `validate*` API signatures unchanged.

### 2. fix(prompt): unify slot-section identification in sectioned renderers

Fixes a silent dialect-drift bug where the client-side section-collapse in `TaskPromptRenderer` failed for nearly ALL real delivered templates, leaking scaffolding text ("Requirement:/要求：...") into generated prompts. Authorization-T was the reported case, but the root cause affected every en-US template (lowercase `(required)/(optional)`) and 必填-dialect zh-CN templates (energy-saving, Authorization-T).

- **Root cause**: the two sectioned renderers each enumerated a different marker vocabulary — `TaskPromptRenderer` accepted only `(Required)|(Optional)|（必选）|（可选）` as the slot-line suffix, while real templates use lowercase English markers, `（必填）/（选填）`, and long conditional markers (e.g. `（新增必填，修改必填，删除必填，查询选填）`). Tests stayed green because fixtures used a synthetic `(Required)/(Optional)` dialect and never rendered real template resources.
- **Unified rule (both renderers)**: a section is a slot section iff its first non-empty body line **begins with** a double-braced placeholder `{{...}}` — whatever follows the placeholder (marker, prose, nothing) is ignored and discarded. Required-ness semantics stay in slot.json where they belong; the marker vocabulary is decoration the code no longer parses.
- **Incidental pre-existing bug fixed**: the old pattern also misidentified single-brace example prose (`{00:00~06:00,2Mbps}`) as a slot line; requiring `{{` closes that hole.
- **Renderer classes stay separate** (collapse vs drop policy, per the existing load-bearing design decision); only the identification rule is unified.
- Tests strengthened: dialect matrix, new `DropBlankSlotSectionRendererTest`, and new `RealTemplateRenderingContractTest` rendering REAL classpath templates and asserting scaffolding removal — the missing guard that let this bug ship.

## Design

Spec/impl docs updated first (content-validation, negotiation, config-resources, prompt-generation): new sub-scenario for template injection, `[template_content]` placeholder contract, error-taxonomy updates, unified slot-section identification rule, and bounded doc-debt fixes (stale 3-entry validate lists → 4 entries with current 4-arg signatures; stale wiring/security statements; exception-type doc corrections).

## Verification

- TDD throughout; per-module suites green: a2a-t-prompt (90), a2a-t-negotiation (475, 1 pre-existing skip), a2a-t-server (28), plus core/client/resources
- `mvn verify` — BUILD SUCCESS with both commits
- New/updated tests pin: template_not_found gate + precedence, `[template_content]`/`[phase]` injection into LLM messages, single-pass replacement semantics, local template override works while local prompt roots stay ignored, 4-entry signature contract (incl. abort), slot-section identification across all marker dialects, real-template scaffolding removal

Behavior-change surfaces (intended): validation prompts now include template bodies; en-US + 必填-dialect zh-CN generated prompts stop leaking scaffolding; a bare no-marker placeholder line now counts as a slot section (no current template has this shape); negotiation rendering unchanged.
