### PR TITLE
fix(prompt): unify slot-section identification in sectioned renderers

### DIFF
--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/DropBlankSlotSectionRenderer.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/DropBlankSlotSectionRenderer.java
@@ -10,12 +10,12 @@ import java.util.regex.Pattern;
  * Sectioned template renderer with the <b>drop</b> blank-slot policy.
  *
  * <p>A template is split into sections on {@code ## } title lines; any content before the first title, including a
- * leading HTML description comment, is discarded. A section whose first non-empty body line is a slot placeholder line
- * such as {@code {{required_information_items}} (required)} — or the same shape with the full-width required/optional
- * markers used by zh-CN templates — is a slot section: it is rendered as the title followed by the slot value, or
- * dropped entirely when the slot value is null or blank. Every other section is static and passes through with
- * placeholder substitution applied. Rendered sections are joined with a single blank line and the result carries no
- * trailing newline.
+ * leading HTML description comment, is discarded. A section whose first non-empty body line begins with a
+ * double-braced placeholder {@code {{name}}} is a slot section: it is rendered as the title followed by the slot
+ * value, or dropped entirely when the slot value is null or blank. Whatever follows the placeholder (marker text,
+ * parenthesized prose, nothing) is ignored for identification. Every other section is static and passes through
+ * with placeholder substitution applied. Rendered sections are joined with a single blank line and the result
+ * carries no trailing newline.
  *
  * @since 2026-08
  */
@@ -24,7 +24,7 @@ public final class DropBlankSlotSectionRenderer implements SectionedTemplateRend
     private static final String SECTION_TITLE_PREFIX = "## ";
 
     private static final Pattern SLOT_LINE_PATTERN =
-            Pattern.compile("^\\{\\{([^{}]+)\\}\\}\\s*(（必填）|（选填）|\\(required\\)|\\(optional\\))$");
+            Pattern.compile("^\\{\\{([^{}]+)\\}\\}.*$");
 
     private static final Pattern SLOT_TOKEN_PATTERN = Pattern.compile("\\{\\{([^{}]+)\\}\\}");
 
@@ -35,7 +35,7 @@ public final class DropBlankSlotSectionRenderer implements SectionedTemplateRend
      * @param slots slot values keyed by the language-specific slot name; a null or blank value drops the slot section
      * @return rendered message text with sections joined by one blank line and no trailing newline; empty string when
      *     no section remains
-     * @throws IllegalArgumentException if the template text is null
+     * @throws NullPointerException if the template text is null
      */
     @Override
     public String render(String templateText, Map<String, String> slots) {

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/SectionedTemplateRenderer.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/SectionedTemplateRenderer.java
@@ -7,8 +7,8 @@ import org.jspecify.annotations.Nullable;
 /**
  * Renders a sectioned prompt template by filling slot values under one blank-slot policy.
  *
- * <p>A sectioned template is split into sections on {@code ## } title lines; any content before the first title is
- * preamble and is discarded. A section whose first non-empty body line is a standalone slot placeholder line is a
+ * <p>A sectioned template is split into sections on {@code ## } title lines; preamble handling is policy-specific —
+ * the drop policy discards content before the first title, while the collapse policy may retain it. A section whose first non-empty body line is a standalone slot placeholder line is a
  * slot section driven by that slot; every other section is static and passes through with placeholder substitution.
  *
  * <p>Implementations differ in how they treat a slot section whose value is null or blank:

--- a/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRenderer.java
+++ b/a2a-t-prompt/src/main/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRenderer.java
@@ -13,6 +13,11 @@ import net.openan.a2at.sdk.prompt.taskrendering.exception.TaskPromptRenderExcept
  * <p>This renderer carries the <b>collapse</b> blank-slot policy of {@link SectionedTemplateRenderer}: a slot section
  * keeps its scaffolding and its standalone slot line collapses to the bare slot placeholder.
  *
+ * <p>A section is identified as a slot section when its first non-empty body line begins with a double-braced
+ * placeholder {@code {{name}}}. Whatever follows the placeholder (marker text, parenthesized prose, nothing) is
+ * discarded on collapse. Single-brace example text (e.g. {@code {00:00~06:00,2Mbps}}) never triggers slot-section
+ * identification.
+ *
  * @since 2026-06
  */
 public final class TaskPromptRenderer implements SectionedTemplateRenderer {
@@ -29,7 +34,7 @@ public final class TaskPromptRenderer implements SectionedTemplateRenderer {
     }
     private static final Pattern SECTION_HEADER_PATTERN = Pattern.compile("^##\\s+.+$");
     private static final Pattern STANDALONE_SLOT_LINE_PATTERN = Pattern.compile(
-            "^\\s*(\\{\\{?\\s*[^{}]+?\\s*\\}\\}?)(?:\\s*(?:\\(Required\\)|\\(Optional\\)|（必选）|（可选）))?\\s*$");
+            "^\\s*(\\{\\{([^{}]+)\\}\\}).*$");
 
     /**
      * Renders a template by replacing slot placeholders with normalized slot values.

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/DropBlankSlotSectionRendererTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/DropBlankSlotSectionRendererTest.java
@@ -1,0 +1,203 @@
+package net.openan.a2at.sdk.prompt.taskrendering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DropBlankSlotSectionRendererTest {
+
+    private final DropBlankSlotSectionRenderer renderer = new DropBlankSlotSectionRenderer();
+
+    @Test
+    void rendersSlotSectionWithLowercaseEnglishMarker() {
+        String template =
+                """
+                ## Slot
+                {{slot}} (required)
+                Requirements:
+                Some requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of("slot", "value"));
+
+        assertEquals("## Slot\nvalue", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithFullWidthChineseMarker() {
+        String template =
+                """
+                ## 槽位
+                {{槽位}}（必填）
+                要求：
+                一些要求。
+                """;
+
+        String rendered = renderer.render(template, Map.of("槽位", "值"));
+
+        assertEquals("## 槽位\n值", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithChineseOptionalVariant() {
+        String template =
+                """
+                ## 订阅条件
+                {{订阅条件}}（可选）
+                要求：
+                提供订阅条件。
+                """;
+
+        String rendered = renderer.render(template, Map.of("订阅条件", "critical"));
+
+        assertEquals("## 订阅条件\ncritical", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithChineseRequiredVariant() {
+        String template =
+                """
+                ## 通知主题
+                {{通知主题}}（必选）
+                要求：
+                提供通知主题。
+                """;
+
+        String rendered = renderer.render(template, Map.of("通知主题", "Incident"));
+
+        assertEquals("## 通知主题\nIncident", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithBarePlaceholderNoMarker() {
+        String template =
+                """
+                ## Slot
+                {{slot}}
+                Requirements:
+                Some requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of("slot", "value"));
+
+        assertEquals("## Slot\nvalue", rendered);
+    }
+
+    @Test
+    void rendersSlotSectionWithLongConditionalSuffix() {
+        String template =
+                """
+                ## Expected Output
+                {{expected_output}} (optional when creating, not required when modifying)
+                Requirement:
+                Describe the output format.
+                """;
+
+        String rendered = renderer.render(template, Map.of("expected_output", "Report."));
+
+        assertEquals("## Expected Output\nReport.", rendered);
+    }
+
+    @Test
+    void dropsSlotSectionWhenValueIsNull() {
+        String template =
+                """
+                ## Slot
+                {{slot}} (required)
+                Requirements:
+                Some requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of());
+
+        assertEquals("", rendered);
+    }
+
+    @Test
+    void dropsSlotSectionWhenValueIsBlank() {
+        String template =
+                """
+                ## Slot
+                {{slot}} (required)
+                Requirements:
+                Some requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of("slot", "   "));
+
+        assertEquals("", rendered);
+    }
+
+    @Test
+    void keepsStaticSectionPassesThrough() {
+        String template =
+                """
+                ## Static
+                Some static content.
+                """;
+
+        String rendered = renderer.render(template, Map.of());
+
+        assertEquals("## Static\nSome static content.", rendered);
+    }
+
+    @Test
+    void joinsSectionsWithSingleBlankLine() {
+        String template =
+                """
+                ## Section A
+                Content A.
+
+                ## Section B
+                Content B.
+                """;
+
+        String rendered = renderer.render(template, Map.of());
+
+        assertEquals("## Section A\nContent A.\n\n## Section B\nContent B.", rendered);
+    }
+
+    @Test
+    void returnsEmptyStringWhenAllSectionsDropped() {
+        String template =
+                """
+                ## Slot A
+                {{slot_a}} (required)
+                Requirements.
+
+                ## Slot B
+                {{slot_b}} (required)
+                Requirements.
+                """;
+
+        String rendered = renderer.render(template, Map.of());
+
+        assertEquals("", rendered);
+    }
+
+    @Test
+    void rejectsNullTemplate() {
+        assertThrows(NullPointerException.class, () -> renderer.render(null, Map.of()));
+    }
+
+    @Test
+    void doesNotIdentifySlotSectionWhenFirstLineIsSingleBraceExample() {
+        String template =
+                """
+                ## Section
+                {00:00~06:00,2Mbps}
+
+                {{slot}} (optional)
+                """;
+
+        String rendered = renderer.render(template, Map.of("slot", "value"));
+
+        assertTrue(rendered.contains("{00:00~06:00,2Mbps}"));
+        assertTrue(rendered.contains("value"));
+        assertTrue(rendered.contains("(optional)"));
+    }
+}

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/RealTemplateRenderingContractTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/RealTemplateRenderingContractTest.java
@@ -1,0 +1,130 @@
+package net.openan.a2at.sdk.prompt.taskrendering;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import net.openan.a2at.sdk.resources.ClasspathPromptResourceLoader;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests that verify real template resources from the classpath are rendered correctly:
+ * scaffolding text (Requirement:/要求：) must be removed from rendered output.
+ */
+class RealTemplateRenderingContractTest {
+
+    private final TaskPromptRenderer taskRenderer = new TaskPromptRenderer();
+    private final DropBlankSlotSectionRenderer dropRenderer = new DropBlankSlotSectionRenderer();
+
+    @Test
+    void energySavingEnUsTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Task-T/network-layer/energy-saving/v1/en-US/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "operation_type", "Create",
+                "task_description", "Energy saving plan.",
+                "task_object", "Area: Songshanhu",
+                "task_target", "Maximize energy saving.",
+                "task_context", "NR; full period.",
+                "expected_output", "Report."));
+
+        assertFalse(rendered.contains("Requirement:"));
+        assertTrue(rendered.contains("Create"));
+        assertTrue(rendered.contains("Energy saving plan."));
+        assertTrue(rendered.contains("Maximize energy saving."));
+    }
+
+    @Test
+    void energySavingZhCnTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Task-T/network-layer/energy-saving/v1/zh-CN/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "操作类型", "创建",
+                "任务描述", "节能方案。",
+                "任务对象", "区域：松山湖",
+                "任务目标", "最大化节能。",
+                "任务上下文", "NR；全时段。",
+                "预期输出", "报告。"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("创建"));
+        assertTrue(rendered.contains("节能方案。"));
+        assertTrue(rendered.contains("最大化节能。"));
+    }
+
+    @Test
+    void authorizationEnUsTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Authorization-T/authorization-policy-management/v1/en-US/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "authorization_policy_operation_type", "add authorization policy",
+                "network_operation_authorization_policy_list", "Policy list content."));
+
+        assertFalse(rendered.contains("Requirement:"));
+        assertTrue(rendered.contains("add authorization policy"));
+        assertTrue(rendered.contains("Policy list content."));
+    }
+
+    @Test
+    void authorizationZhCnTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Authorization-T/authorization-policy-management/v1/zh-CN/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "授权策略的操作类型", "新增授权策略",
+                "动网操作的授权策略列表", "策略列表内容。"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("新增授权策略"));
+        assertTrue(rendered.contains("策略列表内容。"));
+    }
+
+    @Test
+    void subscribeIncidentZhCnTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Notification-T/network-layer/subscribe-incident/v1/zh-CN/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "通知主题", "Incident",
+                "订阅条件", "严重",
+                "上报通知数据格式", "DataPart"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("Incident"));
+        assertTrue(rendered.contains("DataPart"));
+    }
+
+    @Test
+    void serviceRecoveryZhCnTemplateCollapsesScaffolding() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Notification-T/network-layer/service-recovery/v1/zh-CN/template.md");
+        String rendered = taskRenderer.render(template, Map.of(
+                "订阅条件", "子网：xx",
+                "上报通知数据格式", "数据格式内容。"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("数据格式内容。"));
+    }
+
+    @Test
+    void negotiationZhCnTemplateDropsBlankSlotSections() {
+        String template = loadTemplate(
+                "prompt_resources/templates/Negotiation-T/information-negotiation/propose/v1/zh-CN/template.md");
+        String rendered = dropRenderer.render(template, Map.of(
+                "所需信息项", "1. 信息项"));
+
+        assertFalse(rendered.contains("要求："));
+        assertTrue(rendered.contains("信息项"));
+    }
+
+    private static String loadTemplate(String classpathResource) {
+        try (java.io.InputStream stream = RealTemplateRenderingContractTest.class
+                .getClassLoader()
+                .getResourceAsStream(classpathResource)) {
+            if (stream == null) {
+                throw new AssertionError("Template not found on classpath: " + classpathResource);
+            }
+            return new String(stream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to read template: " + classpathResource, e);
+        }
+    }
+}

--- a/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRendererTest.java
+++ b/a2a-t-prompt/src/test/java/net/openan/a2at/sdk/prompt/taskrendering/TaskPromptRendererTest.java
@@ -130,4 +130,69 @@ class TaskPromptRendererTest {
         assertThrows(
                 TaskPromptRenderException.class, () -> renderer.render("Site: {{site}", Map.of("site", "Site A")));
     }
+
+    @Test
+    void renderCollapsesSectionWithLowercaseEnglishMarker() {
+        String prompt = renderer.render(
+                "## Task Target\n"
+                        + "{{task_target}} (required)\n\n"
+                        + "Requirement: explain the target.\n\n"
+                        + "## Expected Output\n"
+                        + "{{expected_output}} (optional)\n",
+                Map.of("task_target", "Do X.", "expected_output", "Y."));
+
+        assertEquals(
+                "## Task Target\nDo X.\n\n## Expected Output\nY.\n", prompt);
+    }
+
+    @Test
+    void renderCollapsesSectionWithFullWidthChineseMarker() {
+        String prompt = renderer.render(
+                "## 操作类型\n"
+                        + "{{操作类型}}（必填）\n\n"
+                        + "要求：\n"
+                        + "请提供操作类型。\n\n"
+                        + "## 任务目标\n"
+                        + "{{任务目标}}（选填）\n",
+                Map.of("操作类型", "创建", "任务目标", "节能最大化"));
+
+        assertEquals(
+                "## 操作类型\n创建\n\n## 任务目标\n节能最大化\n", prompt);
+    }
+
+    @Test
+    void renderCollapsesSectionWithLongConditionalSuffix() {
+        String prompt = renderer.render(
+                "## Expected Output\n"
+                        + "{{expected_output}} (optional when creating, not required when modifying)\n\n"
+                        + "Requirement: describe the output format.\n",
+                Map.of("expected_output", "Report."));
+
+        assertEquals(
+                "## Expected Output\nReport.\n", prompt);
+    }
+
+    @Test
+    void renderCollapsesSectionWithBarePlaceholderNoMarker() {
+        String prompt = renderer.render(
+                "## Task Target\n"
+                        + "{{task_target}}\n\n"
+                        + "Requirement: explain the target.\n",
+                Map.of("task_target", "Do X."));
+
+        assertEquals(
+                "## Task Target\nDo X.\n", prompt);
+    }
+
+    @Test
+    void renderDoesNotCollapseWhenFirstEffectiveLineIsSingleBraceExample() {
+        String prompt = renderer.render(
+                "## Task Context\n"
+                        + "{00:00~06:00,2Mbps}\n\n"
+                        + "{{task_context}} (optional)\n",
+                Map.of("task_context", "Context value."));
+
+        assertEquals(
+                "## Task Context\n{00:00~06:00,2Mbps}\n\nContext value. (optional)\n", prompt);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a silent dialect-drift bug where the client-side section-collapse in `TaskPromptRenderer` failed for nearly ALL real delivered templates, leaking scaffolding text (Requirement:/要求：...) into generated prompts. Authorization-T was the reported case, but the root cause affected every en-US template (lowercase `(required)/(optional)`) and 必填-dialect zh-CN templates (energy-saving, Authorization-T).

- **Root cause**: the two sectioned renderers each enumerated a different marker vocabulary — `TaskPromptRenderer` accepted only `(Required)|(Optional)|（必选）|（可选）` as the slot-line suffix, while real templates use lowercase English markers, `（必填）/（选填）`, and long conditional markers (e.g. `（新增必填，修改必填，删除必填，查询选填）`). `DropBlankSlotSectionRenderer` (negotiation path) happened to match its templates by coincidence. Tests stayed green because fixtures used a synthetic `(Required)/(Optional)` dialect and never rendered real template resources.
- **Unified rule (both renderers)**: a section is a slot section iff its first non-empty body line **begins with** a double-braced placeholder `{{...}}` — whatever follows the placeholder (marker, prose, nothing) is ignored and discarded. Required-ness semantics stay in slot.json where they belong; the template marker vocabulary is decoration the code no longer parses.
- **Incidental pre-existing bug fixed**: the old pattern also misidentified single-brace example prose (`{00:00~06:00,2Mbps}`) as a slot line; requiring `{{` closes that hole.
- **Renderer classes stay separate** (collapse vs drop policy, per the existing load-bearing design decision); only the identification rule is unified.

## Test plan (TDD)

- Dialect matrix in `TaskPromptRendererTest` (+5): lowercase English, full-width 必填/选填, long conditional suffix, bare placeholder (no marker), single-brace negative
- New `DropBlankSlotSectionRendererTest` (13 tests): all marker variants, bare placeholder, single-brace example, drop behavior, joining, empty output
- New `RealTemplateRenderingContractTest` (7 tests): renders REAL delivered templates from classpath (energy-saving en/zh, Authorization en/zh, subscribe-incident zh, service-recovery zh, negotiation zh) and asserts scaffolding is removed — the missing guard that let this bug ship
- Full module suites green; `mvn verify` BUILD SUCCESS on this branch (based on current `main`)

Behavior-change surface (intended): en-US + 必填-dialect zh-CN templates stop leaking scaffolding into generated prompts; a bare no-marker placeholder line now counts as a slot section (no current template has this shape); negotiation rendering unchanged (475 tests green).

Docs (spec/impl) updated first per repo process; doc-code consistency issues found during review (stale exception-type claims, preamble-handling javadoc) corrected in the same chain.