### PR TITLE
feat(sample): split eval suite into fromData/fromText tracks with full LLM call evidence

### DIFF
--- a/a2a-t-sample/README.zh-CN.md
+++ b/a2a-t-sample/README.zh-CN.md
@@ -145,7 +145,7 @@ java @a2a-t-sample/target/fromtext.javaargs.txt /path/to/.env
 1. **服务端发起协商后，客户端是否还需调用 validate？** 是。SDK 在 client/server 两个门面上提供对称的 `validate*PromptAndDataFilling` API：发送方出站自检（步骤 4），接收方入站校验（步骤 5/7）。客户端收到 propose 后应调 `validateProposePromptAndDataFilling` 提取需要补充的槽位清单，再据此补槽。
 2. **客户端接受协商并补充报文后，服务端如何合并原始模板与协商补充内容？** 无增量合并 API。合并发生在客户端：客户端持有完整参数集（round-1 提取参数 + 补槽值），用 `generateTaskPromptFromDataWithSchema` **重新渲染整份 Task-T**（步骤 6），随 accept 一并发送；服务端对完整报文做 `validateTaskPromptAndDataFilling`（步骤 8）提参，不做"原始模板+增量"拼接。
 
-**槽位契约**：评测直接使用 SDK 内置的 private-line-complaint 模板（不做任何资源改动）。模板将"任务上下文"定义为一个组合槽，其内部要求 4 个子项（投诉分类[必选]、问题发生时间[可选]、OSS侧事件流水号[必选]、投诉详情[可选]）。评测的 `task_schema`（eval-suite.json 内）把该组合槽细化为 4 个独立子槽位用于**校验**：子项缺失在非空"任务上下文"内被校验检出并触发协商；"任务上下文"整体为空则在生成期被拦截（内置 required 槽，fail-fast）。fromData 用例输入为结构化 JSON——每个 key 对应一个明确的子项值（如 `"OSS侧事件流水号": "event-id-20260511-09013"`），生成时由 SDK 抽取管线组合进模板。
+**槽位契约**：评测直接使用 SDK 内置的 private-line-complaint 模板（不做任何资源改动）。模板将"任务上下文"定义为一个组合槽，其内部要求 4 个子项（投诉分类[必选]、问题发生时间[可选]、OSS侧事件流水号[必选]、投诉详情[可选]）。评测的 `task_schema`（eval-suite.json 内）把该组合槽细化为 4 个独立子槽位用于**校验**。**生成门**（内置 slot.json 的 required）要求任务对象与任务上下文非空：任一为空即在生成期 fail-fast，协商不触发；**校验门**（调用方 schema 的 required）检出非空上下文内缺失或非法的必选子字段并触发协商。fromData 用例输入为结构化 JSON——每个 key 对应一个明确的子项值（如 `"OSS侧事件流水号": "event-id-20260511-09013"`）；fromText 用例若走到补槽环节则携带 `client_data`（客户端自身掌握的结构化知识，即其文本引用过的字段），补槽重渲染基于该知识而非服务端提取结果。
 
 通道语义：`fromData` 传结构化 JSON + schema；`fromText` 传自然语言由 LLM 抽取。所有生成/校验接口均走 SDK 管线（规则门 + 语义 LLM 调用）。**需要真实 LLM API key**（env 文件参考根目录 `env.example`，至少配置 `A2AT_LLM_PROVIDER` / `A2AT_LLM_MODEL` / `A2AT_LLM_API_KEY` / `A2AT_LLM_BASE_URL`）。
 
@@ -190,7 +190,7 @@ A2AT_LLM_MAX_TOKENS=8192                     # 推理型模型建议调大（默
 
 `*.env` 已被 .gitignore 忽略，携带真实 key 的 env 文件不会被提交。
 
-用例集：`sample/negotiation/eval/eval-suite.json`（**20 条用例，fromData（PLC-D01~D10）与 fromText（PLC-T01~T10）两条轨各 10 条**，覆盖同一场景矩阵：完整输入不触发 / 三个必选字段逐一缺失 / 双必选缺失 / 可选字段缺失不触发 / 值无效（对象形态、分类枚举、流水号格式）/ 字段错位归位 / 口语化与推断 / 生成期拦截 / 负例补槽被拒）。报告中每个 case 输出逐步证据（`api_calls`、`llm_calls`、生成 prompt 原文、校验判定与抽取参数、耗时），`metrics` 汇总通过率。
+用例集：`sample/negotiation/eval/eval-suite.json`（**20 条用例，fromData（PLC-D01~D10）与 fromText（PLC-T01~T10）两条轨各 10 条**，覆盖同一场景矩阵：完整输入不触发 / 必选字段缺失（生成期拦截或触发协商）/ 双必选子字段缺失 / 可选字段缺失不触发 / 值无效（对象形态、分类枚举、流水号格式）/ 字段错位归位 / 口语化与推断 / 负例补槽被拒）。报告中每个 case 输出逐步证据（`api_calls`、`llm_calls`、生成 prompt 原文、校验判定与抽取参数、耗时），`metrics` 汇总通过率。
 
 ## 授权策略（Authorization-T）演示 Demo
 

--- a/a2a-t-sample/README.zh-CN.md
+++ b/a2a-t-sample/README.zh-CN.md
@@ -138,6 +138,8 @@ java @a2a-t-sample/target/fromtext.javaargs.txt /path/to/.env
 
 **API 调用证据**：报告的每个步骤都记录 `api_calls`（SDK 方法名 + 完整输入参数，含传入的 JSON schema 全文），可从报告直接核对每次调用是否携带 schema、用了哪个模板 URI 和协商上下文。
 
+**LLM 调用证据**：每个步骤还记录 `llm_calls`——该步骤内每次大模型调用的完整请求（system + user prompt 全文、JSON schema、temperature、max_tokens）与响应（content、model、usage、耗时），调用失败时也记录请求与错误。用例失败时可直接从报告看到模型实际收到的 prompt（含槽位描述、值约束、schema 注入后的最终形态），据此反向定位是哪段提示词/约束导致了误判并调优。
+
 **协议约定**（两条常见问题）：
 
 1. **服务端发起协商后，客户端是否还需调用 validate？** 是。SDK 在 client/server 两个门面上提供对称的 `validate*PromptAndDataFilling` API：发送方出站自检（步骤 4），接收方入站校验（步骤 5/7）。客户端收到 propose 后应调 `validateProposePromptAndDataFilling` 提取需要补充的槽位清单，再据此补槽。

--- a/a2a-t-sample/README.zh-CN.md
+++ b/a2a-t-sample/README.zh-CN.md
@@ -155,16 +155,20 @@ java @a2a-t-sample/target/fromtext.javaargs.txt /path/to/.env
 # 1. 打包（首次，生成 target/eval.javaargs.txt）
 mvn -pl a2a-t-sample -am -DskipTests package
 
-# 2. 跑全量用例（每个 case 按各自 channel 配置执行）
+# 2. 跑全量用例（fromData 和 fromText 两条用例轨，每个 case 按各自 channel 配置执行）
 java @a2a-t-sample/target/eval.javaargs.txt /path/to/.env
 
 # 3. 只跑指定 case（可重复传 --case）
-java @a2a-t-sample/target/eval.javaargs.txt --case PLC-04 /path/to/.env
+java @a2a-t-sample/target/eval.javaargs.txt --case PLC-D03 /path/to/.env
 
-# 4. 强制全量走 fromText 协商通道（不改用例文件）
+# 4. 只跑其中一条用例轨：fromData 或 fromText 分开测评，报告可分别输出后横向对比
+java @a2a-t-sample/target/eval.javaargs.txt --channel fromData --out eval-report-fromdata.json /path/to/.env
+java @a2a-t-sample/target/eval.javaargs.txt --channel fromText --out eval-report-fromtext.json /path/to/.env
+
+# 5. 强制全量走 fromText 协商生成通道（不改用例文件）
 java @a2a-t-sample/target/eval.javaargs.txt --negotiation-channel fromText /path/to/.env
 
-# 5. 指定报告输出路径（默认 ./eval-report.json）
+# 6. 指定报告输出路径（默认 ./eval-report.json）
 java @a2a-t-sample/target/eval.javaargs.txt --out eval-report-my-model.json /path/to/.env
 ```
 
@@ -186,7 +190,7 @@ A2AT_LLM_MAX_TOKENS=8192                     # 推理型模型建议调大（默
 
 `*.env` 已被 .gitignore 忽略，携带真实 key 的 env 文件不会被提交。
 
-用例集：`sample/negotiation/eval/eval-suite.json`（15 条用例：fromData/fromText × 完整输入/任务对象缺失/投诉分类缺失/OSS流水号缺失/可选槽缺失/双槽缺失/负例补槽约束违反，含正反两类断言）。报告中每个 case 输出逐步证据（`api_calls`、生成 prompt 原文、校验判定与抽取参数、耗时），`metrics` 汇总通过率。
+用例集：`sample/negotiation/eval/eval-suite.json`（**20 条用例，fromData（PLC-D01~D10）与 fromText（PLC-T01~T10）两条轨各 10 条**，覆盖同一场景矩阵：完整输入不触发 / 三个必选字段逐一缺失 / 双必选缺失 / 可选字段缺失不触发 / 值无效（对象形态、分类枚举、流水号格式）/ 字段错位归位 / 口语化与推断 / 生成期拦截 / 负例补槽被拒）。报告中每个 case 输出逐步证据（`api_calls`、`llm_calls`、生成 prompt 原文、校验判定与抽取参数、耗时），`metrics` 汇总通过率。
 
 ## 授权策略（Authorization-T）演示 Demo
 

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/EvalLlmCaptureClient.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/EvalLlmCaptureClient.java
@@ -1,0 +1,133 @@
+package net.openan.a2at.sample.negotiation.eval;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import net.openan.a2at.sample.subscribe_incident.shared.error.ValueErrorException;
+import net.openan.a2at.sample.subscribe_incident.shared.mock.SampleLoggingLLMClient;
+import net.openan.a2at.sdk.llm.LLMClient;
+import net.openan.a2at.sdk.llm.LLMClientConfig;
+import net.openan.a2at.sdk.llm.LLMClientFactory;
+import net.openan.a2at.sdk.llm.LLMResponse;
+
+/**
+ * LLM client wrapper for the evaluator: records every structured call — the full request (messages, JSON
+ * schema, temperature, max tokens) and the response (content, model, usage) — into an in-memory buffer so
+ * the report can attach the exact prompts fed to the model to each step.
+ *
+ * <p>When a case fails, the recorded prompts show precisely which system prompt, slot description or schema
+ * entry the model saw, which is what drives reverse tuning of the prompt resources: a rejected or
+ * mis-extracted case can be traced to the exact prompt text instead of being guessed at.
+ *
+ * <p>Installed into {@link LLMClientFactory} by replacing the {@code openai} entry — the same reflective
+ * mechanism {@code SampleMockLlmInstaller.installLlmLogger} uses. Delegates to
+ * {@link SampleLoggingLLMClient} so the live console logging keeps working unchanged.
+ *
+ * @since 2026-08
+ */
+public final class EvalLlmCaptureClient implements LLMClient {
+
+    private static final List<Map<String, Object>> buffer = new ArrayList<>();
+
+    private final LLMClient delegate;
+
+    /**
+     * Creates a capturing LLM client. The supplied config is passed through to the logging delegate.
+     *
+     * @param config resolved LLM provider config
+     */
+    public EvalLlmCaptureClient(LLMClientConfig config) {
+        this.delegate = new SampleLoggingLLMClient(config);
+    }
+
+    /**
+     * Installs this client as the {@code openai} provider and keeps the console logging configured.
+     *
+     * <p>Must be called once at evaluator startup, before any {@code A2ATClient} or {@code A2ATServer} is
+     * constructed, so that every structured call of the run is captured.
+     */
+    public static synchronized void install() {
+        try {
+            Field clientsField = LLMClientFactory.class.getDeclaredField("CLIENTS");
+            clientsField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<String, Class<? extends LLMClient>> clients =
+                    (Map<String, Class<? extends LLMClient>>) clientsField.get(null);
+            clients.put("openai", EvalLlmCaptureClient.class);
+            SampleLoggingLLMClient.configure(false, "eval", System.out::println);
+        } catch (ReflectiveOperationException exception) {
+            throw new ValueErrorException("Failed to install the capturing LLM client", exception);
+        }
+    }
+
+    /** Clears the capture buffer; called at the start of each case so calls never leak across cases. */
+    public static void reset() {
+        synchronized (buffer) {
+            buffer.clear();
+        }
+    }
+
+    /** Drains the calls recorded since the last reset or drain; empty when no LLM call happened. */
+    public static List<Map<String, Object>> drain() {
+        synchronized (buffer) {
+            List<Map<String, Object>> calls = new ArrayList<>(buffer);
+            buffer.clear();
+            return calls;
+        }
+    }
+
+    @Override
+    public LLMResponse structured(
+            List<Map<String, String>> messages,
+            Map<String, Object> jsonSchema,
+            Double temperature,
+            Integer maxTokens) {
+        long nanos = System.nanoTime();
+        try {
+            LLMResponse response = delegate.structured(messages, jsonSchema, temperature, maxTokens);
+            record(messages, jsonSchema, temperature, maxTokens, response, null, nanos);
+            return response;
+        } catch (RuntimeException error) {
+            // the request is recorded even when the call fails (rate limit, empty content, timeout) so the
+            // failing prompt is still inspectable from the report
+            record(messages, jsonSchema, temperature, maxTokens, null, error, nanos);
+            throw error;
+        }
+    }
+
+    private static void record(
+            List<Map<String, String>> messages,
+            Map<String, Object> jsonSchema,
+            Double temperature,
+            Integer maxTokens,
+            LLMResponse response,
+            RuntimeException error,
+            long nanos) {
+        Map<String, Object> call = new LinkedHashMap<>();
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("messages", messages);
+        request.put("json_schema", jsonSchema);
+        request.put("temperature", temperature);
+        request.put("max_tokens", maxTokens);
+        call.put("request", request);
+        if (response != null) {
+            Map<String, Object> resp = new LinkedHashMap<>();
+            resp.put("content", response.content());
+            resp.put("model", response.model());
+            resp.put("usage", response.usage());
+            call.put("response", resp);
+        }
+        if (error != null) {
+            Map<String, Object> failure = new LinkedHashMap<>();
+            failure.put("type", error.getClass().getSimpleName());
+            failure.put("message", String.valueOf(error.getMessage()));
+            call.put("error", failure);
+        }
+        call.put("duration_ms", (System.nanoTime() - nanos) / 1_000_000);
+        synchronized (buffer) {
+            buffer.add(call);
+        }
+    }
+}

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Consumer;
-import net.openan.a2at.sample.subscribe_incident.shared.mock.SampleMockLlmInstaller;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.model.FilledParamData;
@@ -118,7 +117,7 @@ public final class NegotiationEvalApp {
             System.exit(1);
         }
 
-        SampleMockLlmInstaller.installLlmLogger(false, "eval");
+        EvalLlmCaptureClient.install();
         Map<String, Object> suite = loadSuite();
         if (negotiationChannelOverride != null) {
             // run the whole suite with one negotiation generation channel without duplicating cases
@@ -174,6 +173,7 @@ public final class NegotiationEvalApp {
 
     /** Runs one case end to end and returns its replayable trace record. */
     private static Map<String, Object> runCase(Path envPath, Map<String, Object> suite, Map<String, Object> testCase) {
+        EvalLlmCaptureClient.reset();
         String caseId = String.valueOf(testCase.get("id"));
         String channel = String.valueOf(testCase.get("channel"));
         boolean fromText = "fromText".equals(channel);
@@ -734,7 +734,21 @@ public final class NegotiationEvalApp {
         Map<String, Object> step = new LinkedHashMap<>();
         step.put("step", name);
         step.put("role", role);
+        attachLlmCalls(step);
         return step;
+    }
+
+    /**
+     * Attaches the LLM calls recorded since the previous step was built: the exact messages (system + user
+     * prompt) and JSON schema fed to the model, plus the response or the failure. When a case fails, this is
+     * what makes the cause traceable — the recorded prompt shows which slot description, constraint or
+     * system instruction the model actually saw, so the prompt resources can be tuned in reverse.
+     */
+    private static void attachLlmCalls(Map<String, Object> step) {
+        List<Map<String, Object>> calls = EvalLlmCaptureClient.drain();
+        if (!calls.isEmpty()) {
+            step.put("llm_calls", calls);
+        }
     }
 
     /** Attaches the SDK API call evidence (method name + input parameters) to a step; one step may make several calls. */
@@ -815,7 +829,6 @@ public final class NegotiationEvalApp {
         }
         return step;
     }
-
     private static List<Map<String, Object>> itemsJson(List<NegotiationItem> items) {
         List<Map<String, Object>> list = new ArrayList<>();
         for (NegotiationItem item : items) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
@@ -98,6 +98,7 @@ public final class NegotiationEvalApp {
         Path outPath = Path.of("eval-report.json");
         List<String> caseFilter = new ArrayList<>();
         String negotiationChannelOverride = null;
+        String channelFilter = null;
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
             if ("--out".equals(arg) && i + 1 < args.length) {
@@ -106,6 +107,8 @@ public final class NegotiationEvalApp {
                 caseFilter.add(args[++i]);
             } else if ("--negotiation-channel".equals(arg) && i + 1 < args.length) {
                 negotiationChannelOverride = args[++i];
+            } else if ("--channel".equals(arg) && i + 1 < args.length) {
+                channelFilter = args[++i];
             } else if (!arg.startsWith("--")) {
                 envPath = Path.of(arg);
             }
@@ -113,7 +116,8 @@ public final class NegotiationEvalApp {
         if (envPath == null) {
             System.err.println(
                     "Usage: java @a2a-t-sample/target/eval.javaargs.txt [--out eval-report.json] [--case PLC-04]"
-                            + " [--negotiation-channel fromData|fromText] /path/to/.env");
+                            + " [--channel fromData|fromText] [--negotiation-channel fromData|fromText]"
+                            + " /path/to/.env");
             System.exit(1);
         }
 
@@ -133,6 +137,7 @@ public final class NegotiationEvalApp {
         report.put("generated_at", LocalDateTime.now().format(TIMESTAMP));
         report.put("llm", llmInfo(envPath));
         report.put("case_filter", caseFilter);
+        report.put("channel_filter", channelFilter == null ? "all" : channelFilter);
         report.put("negotiation_channel", negotiationChannelOverride == null
                 ? "per-case"
                 : negotiationChannelOverride);
@@ -140,10 +145,15 @@ public final class NegotiationEvalApp {
         List<Map<String, Object>> cases = new ArrayList<>();
         report.put("cases", cases);
         int index = 0;
-        int total = countCases(suite, caseFilter);
+        int total = countCases(suite, caseFilter, channelFilter);
         for (Map<String, Object> testCase : cases(suite)) {
             String caseId = String.valueOf(testCase.get("id"));
             if (!caseFilter.isEmpty() && !caseFilter.contains(caseId)) {
+                continue;
+            }
+            // evaluate one task-generation channel in isolation: only its cases run, so fromData and
+            // fromText can be measured (and reported) separately
+            if (channelFilter != null && !channelFilter.equals(String.valueOf(testCase.get("channel")))) {
                 continue;
             }
             index++;
@@ -466,7 +476,9 @@ public final class NegotiationEvalApp {
         // whole Task-T prompt from that map.
         Map<String, String> fills = fills(slotsToFill, fillValues);
         Map<String, Object> baseData = fromText ? extractedRound1 : inputData;
-        Map<String, Object> filledData = mergeInputData(baseData, taskSchema, mergeFills(fillValues, fills));
+        // only the negotiated slots' fill values enter the merge: round-1 base values are preserved verbatim,
+        // so the re-rendered prompt carries exactly what the client knew plus what it supplemented
+        Map<String, Object> filledData = mergeInputData(baseData, taskSchema, fills);
         String filledPrompt;
         Map<String, Object> filledGenerationInput = Map.of(
                 "data", filledData,
@@ -1144,13 +1156,12 @@ public final class NegotiationEvalApp {
         }
     }
 
-    private static int countCases(Map<String, Object> suite, List<String> filter) {
-        if (filter.isEmpty()) {
-            return cases(suite).size();
-        }
+    private static int countCases(Map<String, Object> suite, List<String> filter, String channelFilter) {
         return (int) cases(suite).stream()
-                .map(testCase -> String.valueOf(testCase.get("id")))
-                .filter(filter::contains)
+                .filter(testCase -> filter.isEmpty()
+                        || filter.contains(String.valueOf(testCase.get("id"))))
+                .filter(testCase -> channelFilter == null
+                        || channelFilter.equals(String.valueOf(testCase.get("channel"))))
                 .count();
     }
 

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
@@ -475,7 +475,10 @@ public final class NegotiationEvalApp {
         // extracted in round 1), completed with the fill values for everything still missing, and re-renders the
         // whole Task-T prompt from that map.
         Map<String, String> fills = fills(slotsToFill, fillValues);
-        Map<String, Object> baseData = fromText ? extractedRound1 : inputData;
+        // the fill round re-renders from the CLIENT's own knowledge: for fromData the structured input, for
+        // fromText the client_data the case carries (what its text quoted) — falling back to the server's
+        // round-1 extraction, which is only available when that validation passed
+        Map<String, Object> baseData = fromText ? clientBaseData(testCase, extractedRound1) : inputData;
         // only the negotiated slots' fill values enter the merge: round-1 base values are preserved verbatim,
         // so the re-rendered prompt carries exactly what the client knew plus what it supplemented
         Map<String, Object> filledData = mergeInputData(baseData, taskSchema, fills);
@@ -899,6 +902,17 @@ public final class NegotiationEvalApp {
             }
             text.append("；");
         }
+    }
+
+    /**
+     * The client's own structured knowledge for the fill round of a fromText case: the fields its input text
+     * quoted. The server's round-1 extraction is the fallback when the case carries no client data — a lossy
+     * fallback, because those params are only produced when round-1 validation passed.
+     */
+    private static Map<String, Object> clientBaseData(
+            Map<String, Object> testCase, Map<String, Object> extractedRound1) {
+        Map<String, Object> clientData = asMap(testCase.get("client_data"));
+        return clientData.isEmpty() ? extractedRound1 : clientData;
     }
 
     /** The supplement values the simulated client supplies, keyed by slot. */

--- a/a2a-t-sample/src/main/resources/sample/negotiation/eval/eval-suite.json
+++ b/a2a-t-sample/src/main/resources/sample/negotiation/eval/eval-suite.json
@@ -1,6 +1,6 @@
 {
   "suite": "negotiation-interface-eval",
-  "description": "Private-line complaint negotiation closed-loop evaluation against the bundled private-line-complaint template. Two tracks of ten cases each: fromData feeds structured JSON (every key maps to one field value) and fromText feeds natural language; run one track in isolation with --channel fromData|fromText. Each case drives the negotiation prompt interfaces in message order: Task-T generation -> server validation (missing-slot detection) -> Negotiation-T propose generation -> server outbound propose validation -> client inbound propose validation -> client fill + accept generation -> server inbound accept validation -> second Task-T validation. The suite's task schema refines the template's coarse 任务上下文 into four sub-fields (投诉分类/问题发生时间/OSS侧事件流水号/投诉详情, per the template's own requirement list): a missing or invalid sub-field inside a non-blank 任务上下文 is detected at validation and negotiated, while a completely empty 任务上下文 fails fast at generation (bundled required slot). Coverage matrix per track: complete input (no negotiation), each required field missing, dual required fields missing, optional fields missing (no negotiation), invalid values (object form, category enum, sequence-number format), field misplacement, colloquial/inferable input, generation-time fail-fast, and a negative fill whose value violates the constraint. Slot extraction and all validation interfaces run the SDK pipeline (rule gate + semantic LLM call), with the JSON schema passed on every generate/validate call.",
+  "description": "Private-line complaint negotiation closed-loop evaluation against the bundled private-line-complaint template. Two tracks of ten cases each: fromData feeds structured JSON (every key maps to one field value) and fromText feeds natural language; run one track in isolation with --channel fromData|fromText. Each case drives the negotiation prompt interfaces in message order: Task-T generation -> server validation (missing-slot detection) -> Negotiation-T propose generation -> server outbound propose validation -> client inbound propose validation -> client fill + accept generation -> server inbound accept validation -> second Task-T validation. The suite's task schema refines the template's coarse 任务上下文 into four sub-fields (投诉分类/问题发生时间/OSS侧事件流水号/投诉详情, per the template's own requirement list). Generation gate: the bundled slot schema requires 任务对象 and 任务上下文, so an input missing either fails fast at generation; a required sub-field that is missing or invalid inside a non-blank context is detected at validation and negotiated. Coverage matrix per track: complete input (no negotiation), required fields missing (fail-fast or negotiated), dual sub-fields missing, optional fields missing (no negotiation), invalid values (object form, category enum, sequence-number format), field misplacement, colloquial/inferable input, and a negative fill whose value violates the constraint. fromText cases that reach the fill round carry client_data: the structured knowledge the client itself holds (what its input text quoted), which is what the fill round re-renders from. Slot extraction and all validation interfaces run the SDK pipeline (rule gate + semantic LLM call), with the JSON schema passed on every generate/validate call.",
   "scenario": "private-line-complaint",
   "template_uri": "Task-T/network-layer/private-line-complaint/v1",
   "task_schema": {
@@ -69,7 +69,7 @@
     {
       "id": "PLC-D02",
       "channel": "fromData",
-      "intent": "缺任务对象（必选），触发任务对象协商并补齐闭环",
+      "intent": "缺任务对象（bundled required 槽）：生成期 fail-fast，任务无法生成，协商不触发",
       "input_data": {
         "任务对象": "",
         "投诉分类": "专线中断",
@@ -78,9 +78,9 @@
         "投诉详情": "客户业务全部不通，柜面交易无法办理。"
       },
       "expect": {
-        "negotiation_needed": true,
-        "missing_slots": ["任务对象"],
-        "fill_completes": true
+        "negotiation_needed": false,
+        "missing_slots": [],
+        "generation_fails": true
       }
     },
     {
@@ -120,17 +120,17 @@
     {
       "id": "PLC-D05",
       "channel": "fromData",
-      "intent": "双必选字段缺失（任务对象+投诉分类），协商应同时请求两个字段并补齐闭环",
+      "intent": "双必选子字段缺失（投诉分类+OSS流水号），协商应同时请求两个字段并补齐闭环",
       "input_data": {
-        "任务对象": "",
+        "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
         "投诉分类": "",
         "问题发生时间": "2026-06-18T09:00:00Z",
-        "OSS侧事件流水号": "event-id-20260618-07721",
+        "OSS侧事件流水号": "",
         "投诉详情": "客户已在客服渠道催单，请尽快处理。"
       },
       "expect": {
         "negotiation_needed": true,
-        "missing_slots": ["任务对象", "投诉分类"],
+        "missing_slots": ["投诉分类", "OSS侧事件流水号"],
         "fill_completes": true
       }
     },
@@ -234,12 +234,12 @@
     {
       "id": "PLC-T02",
       "channel": "fromText",
-      "intent": "口语化缺专线标识（业务全断可推断投诉分类为中断），触发任务对象协商并补齐闭环",
+      "intent": "口语化完全缺专线标识（bundled required 槽）：生成期 fail-fast，任务无法生成，协商不触发",
       "input_text": "我们的专线出问题了，业务全部都断了，完全用不了。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
       "expect": {
-        "negotiation_needed": true,
-        "missing_slots": ["任务对象"],
-        "fill_completes": true
+        "negotiation_needed": false,
+        "missing_slots": [],
+        "generation_fails": true
       }
     },
     {
@@ -247,6 +247,10 @@
       "channel": "fromText",
       "intent": "未描述任何故障现象（投诉分类无从判定为中断或质差），触发投诉分类协商并补齐闭环",
       "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。OSS侧事件流水号：event-id-20260618-07721。",
+      "client_data": {
+        "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
+        "OSS侧事件流水号": "event-id-20260618-07721"
+      },
       "expect": {
         "negotiation_needed": true,
         "missing_slots": ["投诉分类"],
@@ -258,6 +262,11 @@
       "channel": "fromText",
       "intent": "缺OSS侧事件流水号，触发流水号协商并补齐闭环",
       "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。故障现象：专线中断，业务完全不可用，柜面交易无法办理。问题发生时间：2026-06-18T09:00:00Z。",
+      "client_data": {
+        "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
+        "投诉分类": "专线中断",
+        "问题发生时间": "2026-06-18T09:00:00Z"
+      },
       "expect": {
         "negotiation_needed": true,
         "missing_slots": ["OSS侧事件流水号"],
@@ -277,8 +286,13 @@
     {
       "id": "PLC-T06",
       "channel": "fromText",
-      "intent": "任务对象模糊（未指明端口/ID/名称形态），触发任务对象协商并补齐闭环",
-      "input_text": "故障现象：专线质量差，网页打开缓慢，视频卡顿。问题发生时间：2026-06-18T09:00:00Z。OSS侧事件流水号：event-id-20260618-07721。",
+      "intent": "任务对象指代模糊（'我们金融客户的那条专线'，非端口/ID/名称形态），触发任务对象协商并补齐闭环",
+      "input_text": "我们金融客户的那条专线出问题了，专线质差，网页打开缓慢，视频卡顿。问题发生时间：2026-06-18T09:00:00Z。OSS侧事件流水号：event-id-20260618-07721。",
+      "client_data": {
+        "投诉分类": "专线质差",
+        "问题发生时间": "2026-06-18T09:00:00Z",
+        "OSS侧事件流水号": "event-id-20260618-07721"
+      },
       "expect": {
         "negotiation_needed": true,
         "missing_slots": ["任务对象"],
@@ -319,14 +333,18 @@
     {
       "id": "PLC-T10",
       "channel": "fromText",
-      "intent": "负例补槽：缺任务对象，补入非端口/ID/名称形态的值，二次校验应拒绝（测校验器对补槽值的把关）",
-      "input_text": "我们的专线出问题了，业务全部都断了，完全用不了。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
+      "intent": "负例补槽：缺投诉分类，补入违反枚举约束的值，二次校验应拒绝（测校验器对补槽值的把关）",
+      "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。OSS侧事件流水号：event-id-20260618-07721。",
+      "client_data": {
+        "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
+        "OSS侧事件流水号": "event-id-20260618-07721"
+      },
       "fill_override": {
-        "任务对象": "就是那条线"
+        "投诉分类": "搞不清楚什么问题"
       },
       "expect": {
         "negotiation_needed": true,
-        "missing_slots": ["任务对象"],
+        "missing_slots": ["投诉分类"],
         "fill_completes": false
       }
     }

--- a/a2a-t-sample/src/main/resources/sample/negotiation/eval/eval-suite.json
+++ b/a2a-t-sample/src/main/resources/sample/negotiation/eval/eval-suite.json
@@ -1,6 +1,6 @@
 {
   "suite": "negotiation-interface-eval",
-  "description": "Private-line complaint negotiation closed-loop evaluation against the bundled private-line-complaint template. Each case drives the negotiation prompt interfaces in message order: Task-T generation (fromData/fromText) -> server validation (missing-slot detection) -> Negotiation-T propose generation -> server outbound propose validation -> client inbound propose validation -> client fill + accept generation -> server inbound accept validation -> second Task-T validation. Channels: fromData feeds structured JSON (every key maps to one slot value) together with the task schema; fromText feeds natural language. The suite's task schema refines the template's coarse 任务上下文 into four sub-slots (投诉分类/问题发生时间/OSS侧事件流水号/投诉详情, per the template's own requirement list): a missing sub-field inside a non-blank 任务上下文 is detected at validation and negotiated, while a completely empty 任务上下文 fails fast at generation (bundled required slot). Slot extraction and all validation interfaces run the SDK pipeline (rule gate + semantic LLM call), with the JSON schema passed on every generate/validate call.",
+  "description": "Private-line complaint negotiation closed-loop evaluation against the bundled private-line-complaint template. Two tracks of ten cases each: fromData feeds structured JSON (every key maps to one field value) and fromText feeds natural language; run one track in isolation with --channel fromData|fromText. Each case drives the negotiation prompt interfaces in message order: Task-T generation -> server validation (missing-slot detection) -> Negotiation-T propose generation -> server outbound propose validation -> client inbound propose validation -> client fill + accept generation -> server inbound accept validation -> second Task-T validation. The suite's task schema refines the template's coarse 任务上下文 into four sub-fields (投诉分类/问题发生时间/OSS侧事件流水号/投诉详情, per the template's own requirement list): a missing or invalid sub-field inside a non-blank 任务上下文 is detected at validation and negotiated, while a completely empty 任务上下文 fails fast at generation (bundled required slot). Coverage matrix per track: complete input (no negotiation), each required field missing, dual required fields missing, optional fields missing (no negotiation), invalid values (object form, category enum, sequence-number format), field misplacement, colloquial/inferable input, generation-time fail-fast, and a negative fill whose value violates the constraint. Slot extraction and all validation interfaces run the SDK pipeline (rule gate + semantic LLM call), with the JSON schema passed on every generate/validate call.",
   "scenario": "private-line-complaint",
   "template_uri": "Task-T/network-layer/private-line-complaint/v1",
   "task_schema": {
@@ -51,9 +51,9 @@
   },
   "cases": [
     {
-      "id": "PLC-01",
+      "id": "PLC-D01",
       "channel": "fromData",
-      "intent": "结构化数据完整（5槽齐备），不应触发协商",
+      "intent": "结构化完整输入（端口名形态），不应触发协商",
       "input_data": {
         "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
         "投诉分类": "专线质差",
@@ -67,19 +67,9 @@
       }
     },
     {
-      "id": "PLC-02",
-      "channel": "fromText",
-      "intent": "自然语言完整（端口+分类+时间+流水号+详情），不应触发协商",
-      "input_text": "深圳福田区某金融客户专线出现质量劣化。接入端口：P781-珠江新城-PTN7900-23-TPA1EG24-17。故障现象：专线质差，深圳访问广州响应延迟骤升，交易接口频繁报连接超时。问题发生时间：2026-05-11T08:21:46Z。OSS侧事件流水号：event-id-20260511-09013。投诉详情：从5月11号早上8点半开始，核心交易系统访问非常慢，柜面和手机银行频繁报连接超时。",
-      "expect": {
-        "negotiation_needed": false,
-        "missing_slots": []
-      }
-    },
-    {
-      "id": "PLC-03",
+      "id": "PLC-D02",
       "channel": "fromData",
-      "intent": "结构化缺任务对象，触发任务对象协商",
+      "intent": "缺任务对象（必选），触发任务对象协商并补齐闭环",
       "input_data": {
         "任务对象": "",
         "投诉分类": "专线中断",
@@ -94,99 +84,15 @@
       }
     },
     {
-      "id": "PLC-04",
-      "channel": "fromText",
-      "intent": "口语化缺专线标识（业务全断可推断投诉分类），触发任务对象协商",
-      "input_text": "我们的专线出问题了，业务全部都断了，完全用不了。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
-      "expect": {
-        "negotiation_needed": true,
-        "missing_slots": ["任务对象"],
-        "fill_completes": true
-      }
-    },
-    {
-      "id": "PLC-05",
-      "channel": "fromText",
-      "intent": "自然语言任务上下文为空（bundled required 槽在生成期即被拦截，任务无法生成，协商不触发）",
-      "input_text": "帮我看一下专线的问题。",
-      "expect": {
-        "negotiation_needed": false,
-        "missing_slots": [],
-        "generation_fails": true
-      }
-    },
-    {
-      "id": "PLC-06",
-      "channel": "fromText",
-      "intent": "任务对象模糊（非端口/ID/名称形态），触发任务对象协商",
-      "input_text": "故障现象：专线质量差，网页打开缓慢，视频卡顿。问题发生时间：2026-06-18T09:00:00Z。OSS侧事件流水号：event-id-20260618-07721。",
-      "expect": {
-        "negotiation_needed": true,
-        "missing_slots": ["任务对象"],
-        "fill_completes": true
-      }
-    },
-    {
-      "id": "PLC-07",
-      "channel": "fromText",
-      "intent": "口语化完整请求，端口埋在长句里，不应触发协商",
-      "input_text": "就是珠江新城那边 PTN7900 网元上 P781-珠江新城-PTN7900-23-TPA1EG24-17 这个接入端口带的专线，专线质差，深圳访问广州的响应延迟从12ms涨到了300多毫秒，问题发生时间：2026-05-11T08:21:46Z，OSS侧事件流水号：event-id-20260511-09013。",
-      "expect": {
-        "negotiation_needed": false,
-        "missing_slots": []
-      }
-    },
-    {
-      "id": "PLC-08",
-      "channel": "fromText",
-      "intent": "自然语言未描述任何故障现象（投诉分类无从判定为中断或质差），触发投诉分类协商",
-      "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。OSS侧事件流水号：event-id-20260618-07721。",
-      "expect": {
-        "negotiation_needed": true,
-        "missing_slots": ["投诉分类"],
-        "fill_completes": true
-      }
-    },
-    {
-      "id": "PLC-09",
-      "channel": "fromText",
-      "intent": "端口误写在现象描述里（字段错位），抽取器应归位到任务对象，不触发协商",
-      "input_text": "故障现象：专线中断，出现问题的接入端口是P781-珠江新城-PTN7900-23-TPA1EG24-17，业务完全不可用。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
-      "expect": {
-        "negotiation_needed": false,
-        "missing_slots": []
-      }
-    },
-    {
-      "id": "PLC-10",
+      "id": "PLC-D03",
       "channel": "fromData",
-      "intent": "负例：补充值投诉分类乱写（不符合中断/质差取值约束），二次校验应拒绝（测校验器对值约束的把关）",
-      "input_data": {
-        "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
-        "投诉分类": "",
-        "问题发生时间": "2026-06-02T14:30:00Z",
-        "OSS侧事件流水号": "event-id-20260602-08841",
-        "投诉详情": "客户业务全部不通，柜面交易无法办理。"
-      },
-      "fill_override": {
-        "投诉分类": "不知道是什么问题"
-      },
-      "expect": {
-        "negotiation_needed": true,
-        "missing_slots": ["投诉分类"],
-        "fill_completes": false
-      }
-    },
-    {
-      "id": "PLC-11",
-      "channel": "fromData",
-      "intent": "结构化缺投诉分类（任务上下文子槽缺失），触发投诉分类协商",
+      "intent": "缺投诉分类（必选，投诉详情刻意中性不可推断分类），触发投诉分类协商并补齐闭环",
       "input_data": {
         "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
         "投诉分类": "",
         "问题发生时间": "2026-06-18T09:00:00Z",
         "OSS侧事件流水号": "event-id-20260618-07721",
-        "投诉详情": "网页打开缓慢，视频卡顿。"
+        "投诉详情": "客户已在客服渠道催单，请尽快处理。"
       },
       "expect": {
         "negotiation_needed": true,
@@ -195,9 +101,9 @@
       }
     },
     {
-      "id": "PLC-12",
+      "id": "PLC-D04",
       "channel": "fromData",
-      "intent": "结构化缺OSS侧事件流水号（任务上下文子槽缺失），触发流水号协商",
+      "intent": "缺OSS侧事件流水号（必选），触发流水号协商并补齐闭环",
       "input_data": {
         "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
         "投诉分类": "专线质差",
@@ -212,9 +118,26 @@
       }
     },
     {
-      "id": "PLC-13",
+      "id": "PLC-D05",
       "channel": "fromData",
-      "intent": "可选槽缺失（问题发生时间/投诉详情为空），不应触发协商",
+      "intent": "双必选字段缺失（任务对象+投诉分类），协商应同时请求两个字段并补齐闭环",
+      "input_data": {
+        "任务对象": "",
+        "投诉分类": "",
+        "问题发生时间": "2026-06-18T09:00:00Z",
+        "OSS侧事件流水号": "event-id-20260618-07721",
+        "投诉详情": "客户已在客服渠道催单，请尽快处理。"
+      },
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["任务对象", "投诉分类"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-D06",
+      "channel": "fromData",
+      "intent": "可选字段缺失（问题发生时间/投诉详情为空），不应触发协商",
       "input_data": {
         "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
         "投诉分类": "专线中断",
@@ -228,9 +151,112 @@
       }
     },
     {
-      "id": "PLC-14",
+      "id": "PLC-D07",
+      "channel": "fromData",
+      "intent": "任务对象值无效（非端口名/资源ID/专线名称三种形态），触发任务对象协商",
+      "input_data": {
+        "任务对象": "客户的专线",
+        "投诉分类": "专线质差",
+        "问题发生时间": "2026-06-18T09:00:00Z",
+        "OSS侧事件流水号": "event-id-20260618-07721",
+        "投诉详情": "网页打开缓慢，视频卡顿。"
+      },
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["任务对象"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-D08",
+      "channel": "fromData",
+      "intent": "投诉分类值违反枚举约束（非中断/质差），触发投诉分类协商",
+      "input_data": {
+        "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
+        "投诉分类": "网络有点问题",
+        "问题发生时间": "2026-06-18T09:00:00Z",
+        "OSS侧事件流水号": "event-id-20260618-07721",
+        "投诉详情": "客户已在客服渠道催单，请尽快处理。"
+      },
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["投诉分类"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-D09",
+      "channel": "fromData",
+      "intent": "OSS侧事件流水号值格式错误（非 event-id- 开头标识），触发流水号协商",
+      "input_data": {
+        "任务对象": "接入端口名称：P781-珠江新城-PTN7900-23-TPA1EG24-17",
+        "投诉分类": "专线中断",
+        "问题发生时间": "2026-06-02T14:30:00Z",
+        "OSS侧事件流水号": "12345",
+        "投诉详情": "客户已在客服渠道催单，请尽快处理。"
+      },
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["OSS侧事件流水号"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-D10",
+      "channel": "fromData",
+      "intent": "负例补槽：缺投诉分类，补入违反枚举约束的值，二次校验应拒绝（测校验器对补槽值的把关）",
+      "input_data": {
+        "任务对象": "接入端口名称：P311-会展中心-ATN910C-05-TPA2EG8-03",
+        "投诉分类": "",
+        "问题发生时间": "2026-06-18T09:00:00Z",
+        "OSS侧事件流水号": "event-id-20260618-07721",
+        "投诉详情": "客户已在客服渠道催单，请尽快处理。"
+      },
+      "fill_override": {
+        "投诉分类": "不确定是什么问题"
+      },
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["投诉分类"],
+        "fill_completes": false
+      }
+    },
+    {
+      "id": "PLC-T01",
       "channel": "fromText",
-      "intent": "自然语言缺OSS侧事件流水号（任务上下文子槽缺失），触发流水号协商",
+      "intent": "自然语言完整（分类+端口+时间+流水号+详情全部明确），不应触发协商",
+      "input_text": "深圳福田区某金融客户专线出现质量劣化。接入端口：P781-珠江新城-PTN7900-23-TPA1EG24-17。故障现象：专线质差，深圳访问广州响应延迟骤升，交易接口频繁报连接超时。问题发生时间：2026-05-11T08:21:46Z。OSS侧事件流水号：event-id-20260511-09013。投诉详情：从5月11号早上8点半开始，核心交易系统访问非常慢，柜面和手机银行频繁报连接超时。",
+      "expect": {
+        "negotiation_needed": false,
+        "missing_slots": []
+      }
+    },
+    {
+      "id": "PLC-T02",
+      "channel": "fromText",
+      "intent": "口语化缺专线标识（业务全断可推断投诉分类为中断），触发任务对象协商并补齐闭环",
+      "input_text": "我们的专线出问题了，业务全部都断了，完全用不了。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["任务对象"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-T03",
+      "channel": "fromText",
+      "intent": "未描述任何故障现象（投诉分类无从判定为中断或质差），触发投诉分类协商并补齐闭环",
+      "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。OSS侧事件流水号：event-id-20260618-07721。",
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["投诉分类"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-T04",
+      "channel": "fromText",
+      "intent": "缺OSS侧事件流水号，触发流水号协商并补齐闭环",
       "input_text": "接入端口：P311-会展中心-ATN910C-05-TPA2EG8-03。故障现象：专线中断，业务完全不可用，柜面交易无法办理。问题发生时间：2026-06-18T09:00:00Z。",
       "expect": {
         "negotiation_needed": true,
@@ -239,20 +265,69 @@
       }
     },
     {
-      "id": "PLC-15",
-      "channel": "fromData",
-      "intent": "结构化双槽缺失（任务对象+投诉分类），协商应同时请求两个槽",
-      "input_data": {
-        "任务对象": "",
-        "投诉分类": "",
-        "问题发生时间": "2026-06-18T09:00:00Z",
-        "OSS侧事件流水号": "event-id-20260618-07721",
-        "投诉详情": "客户业务全部不通。"
+      "id": "PLC-T05",
+      "channel": "fromText",
+      "intent": "可选信息缺失（无时间无详情，必选齐全），不应触发协商",
+      "input_text": "接入端口：P781-珠江新城-PTN7900-23-TPA1EG24-17。故障现象：专线质差，网页打开缓慢。OSS侧事件流水号：event-id-20260602-08841。",
+      "expect": {
+        "negotiation_needed": false,
+        "missing_slots": []
+      }
+    },
+    {
+      "id": "PLC-T06",
+      "channel": "fromText",
+      "intent": "任务对象模糊（未指明端口/ID/名称形态），触发任务对象协商并补齐闭环",
+      "input_text": "故障现象：专线质量差，网页打开缓慢，视频卡顿。问题发生时间：2026-06-18T09:00:00Z。OSS侧事件流水号：event-id-20260618-07721。",
+      "expect": {
+        "negotiation_needed": true,
+        "missing_slots": ["任务对象"],
+        "fill_completes": true
+      }
+    },
+    {
+      "id": "PLC-T07",
+      "channel": "fromText",
+      "intent": "字段错位（端口误写在现象描述里），抽取器应归位到任务对象，不触发协商",
+      "input_text": "故障现象：专线中断，出现问题的接入端口是P781-珠江新城-PTN7900-23-TPA1EG24-17，业务完全不可用。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
+      "expect": {
+        "negotiation_needed": false,
+        "missing_slots": []
+      }
+    },
+    {
+      "id": "PLC-T08",
+      "channel": "fromText",
+      "intent": "口语化完整（端口埋在长句中需归位，现象模糊需推断为质差），不应触发协商",
+      "input_text": "就是珠江新城那边PTN7900网元上P781-珠江新城-PTN7900-23-TPA1EG24-17这个接入端口带的专线，最近时好时坏，网速慢得很，客户体验受影响，OSS侧事件流水号：event-id-20260511-09013。",
+      "expect": {
+        "negotiation_needed": false,
+        "missing_slots": []
+      }
+    },
+    {
+      "id": "PLC-T09",
+      "channel": "fromText",
+      "intent": "任务上下文整体为空：bundled required 槽在生成期即被拦截，任务无法生成，协商不触发",
+      "input_text": "帮我看一下专线的问题。",
+      "expect": {
+        "negotiation_needed": false,
+        "missing_slots": [],
+        "generation_fails": true
+      }
+    },
+    {
+      "id": "PLC-T10",
+      "channel": "fromText",
+      "intent": "负例补槽：缺任务对象，补入非端口/ID/名称形态的值，二次校验应拒绝（测校验器对补槽值的把关）",
+      "input_text": "我们的专线出问题了，业务全部都断了，完全用不了。问题发生时间：2026-06-02T14:30:00Z。OSS侧事件流水号：event-id-20260602-08841。",
+      "fill_override": {
+        "任务对象": "就是那条线"
       },
       "expect": {
         "negotiation_needed": true,
-        "missing_slots": ["任务对象", "投诉分类"],
-        "fill_completes": true
+        "missing_slots": ["任务对象"],
+        "fill_completes": false
       }
     }
   ]


### PR DESCRIPTION
Follow-up to #142 (merged). All changes are confined to the **a2a-t-sample** module; the SDK source and bundled prompt resources are untouched.

## Summary

**Two eval tracks, ten cases each** — `PLC-D01..D10` (fromData, structured JSON input) and `PLC-T01..T10` (fromText, natural language) — covering the same scenario matrix per track:

| Dimension | Cases |
|---|---|
| Complete input, no negotiation | D01 / T01 |
| Each required field missing (object / category / sequence number) | D02-04 / T02-04 |
| Dual required fields missing | D05 |
| Optional fields absent, no negotiation | D06 / T05 |
| Invalid values (object form, category enum, sequence-number format) | D07-09 / T06 |
| Field misplacement, extractor reassignment | T07 |
| Colloquial + inferable input | T08 |
| Generation-time fail-fast (empty task context) | T09 |
| Negative fill violating the constraint, rejected | D10 / T10 |

Missing-category cases use a deliberately neutral complaint detail so the validator cannot infer the category from context — the missing field itself is what must be detected.

**`--channel fromData|fromText`** runs one track in isolation, so the two generation channels are evaluated and reported separately and the reports can be compared side by side.

**Full LLM call evidence in the report** — every step now carries `llm_calls`: the exact prompts fed to the model for that step (system and user messages, JSON schema, temperature, max tokens) plus the response (content, model, usage, duration); when a call fails, the request and its error are recorded. A capturing LLM client wrapper (`EvalLlmCaptureClient`) installed into the client factory records the calls; console logging is unchanged. A failing case is now traceable end to end — the recorded prompt shows the final form the model saw (slot descriptions, value constraints, schema injection), which is what enables reverse tuning of the prompt resources.

**Fill-merge fix**: only the negotiated slots' fill values are merged into the round-1 parameter map, so the re-rendered Task-T preserves what the client already provided verbatim (previously the whole fill-value table overwrote it, which let an invalid fill pass by giving the validator inferable context).

## Test plan

- [x] `mvn test` full reactor — 105 tests green
- [x] Smoke runs on both tracks (representative cases pass; the negative fill is now correctly rejected at accept validation)
- [ ] Full 20-case real-LLM run in progress; results will be reported on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)