### PR TITLE
fix(negotiation): require information propose requested items

### DIFF
--- a/a2a-t-corpus/src/test/java/net/openan/a2at/sdk/corpus/property/PropertyArbitraries.java
+++ b/a2a-t-corpus/src/test/java/net/openan/a2at/sdk/corpus/property/PropertyArbitraries.java
@@ -143,13 +143,14 @@ final class PropertyArbitraries {
     }
 
     /**
-     * Arbitrary of information propose contents: items in {@code [0, 5]} with 50% null item values, relationship null
-     * or present.
+     * Arbitrary of information propose contents: items in {@code [1, 5]} with 50% null item values, relationship null
+     * or present. The information propose generator requires at least one requested item, so the empty list is not a
+     * valid input.
      *
      * @return information propose content arbitrary
      */
     static Arbitrary<InformationProposeContent> informationProposeContents() {
-        return Combinators.combine(itemLists(0, 5), optionalTexts()).as(InformationProposeContent::new);
+        return Combinators.combine(itemLists(1, 5), optionalTexts()).as(InformationProposeContent::new);
     }
 
     /**

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/DefaultNegotiationContentExtractor.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/DefaultNegotiationContentExtractor.java
@@ -171,7 +171,8 @@ final class DefaultNegotiationContentExtractor implements NegotiationContentExtr
     private static NegotiationContent mapProposeContent(Map<String, Object> payload, NegotiationType type) {
         return switch (type) {
             case INFORMATION -> new InformationProposeContent(
-                    requiredItems(payload, "items"), optionalString(payload, "relationship"));
+                    requiredNonEmptyItems(payload, "items", "information negotiation requested items"),
+                    optionalString(payload, "relationship"));
             case TARGET -> new TargetProposeContent(
                     requiredString(payload, "target_negotiation_description"),
                     optionalItems(payload, "intent_understanding"),

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/InformationProposeGenerator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/InformationProposeGenerator.java
@@ -32,6 +32,10 @@ final class InformationProposeGenerator extends AbstractNegotiationGenerator {
             NegotiationContext context, NegotiationContent content, PromptTemplate template, Vocabulary vocabulary) {
         InformationProposeContent proposeContent =
                 contentOf(content, InformationProposeContent.class, "Information propose generator");
+        requiredItems(
+                proposeContent.items(),
+                "items",
+                "Information negotiation propose message requested items");
         Map<String, String> slots = new LinkedHashMap<>();
         slots.put(vocabulary.get("slot.info_items"), itemsSlotValue(proposeContent, vocabulary));
         return render(template, slots);

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationJsonSchemaBuilder.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationJsonSchemaBuilder.java
@@ -62,7 +62,7 @@ final class NegotiationJsonSchemaBuilder {
 
     private static Map<String, Object> informationProposeSchema() {
         Map<String, Object> properties = new LinkedHashMap<>();
-        properties.put("items", itemArraySchema());
+        properties.put("items", nonEmptyItemArraySchema());
         properties.put("relationship", nullableStringSchema());
         return objectSchema(properties, List.of("items"));
     }

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationContentExtractorTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationContentExtractorTest.java
@@ -243,6 +243,17 @@ class NegotiationContentExtractorTest {
     }
 
     @Test
+    void rejectsEmptyInformationProposeItemsBeforeTemplateRendering() {
+        NegotiationGenerationException exception = assertThrows(
+                NegotiationGenerationException.class,
+                () -> new DefaultNegotiationContentExtractor(new RecordingClient("{\"items\":[]}"))
+                        .extract("请补充缺失信息。", reference(NegotiationType.INFORMATION, NegotiationPhase.PROPOSE, "zh-CN")));
+
+        assertEquals(A2ATErrorCodes.NEGOTIATION_SLOT_MISSING, exception.getCode());
+        assertTrue(exception.getMessage().contains("requested items"));
+    }
+
+    @Test
     void mapsFeasibilityActionProblemsToTheInvalidInputCode() {
         NegotiationGenerationException missingAction = assertThrows(
                 NegotiationGenerationException.class, () -> new DefaultNegotiationContentExtractor(new RecordingClient(

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGeneratorsTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGeneratorsTest.java
@@ -421,6 +421,22 @@ class NegotiationGeneratorsTest {
     }
 
     @Test
+    void informationProposeRejectsEmptyRequestedItems() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new InformationProposeGenerator()
+                        .generate(
+                                context(1),
+                                new InformationProposeContent(List.of(), null),
+                                template(StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE, ZH_INFO_PROPOSE_TEMPLATE),
+                                zhVocabulary));
+
+        assertEquals(
+                "Information negotiation propose message requested items must contain at least one item.",
+                exception.getMessage());
+    }
+
+    @Test
     void abortConclusionIsRejectedByEveryEndingGenerator() {
         assertThrows(IllegalArgumentException.class, () -> new InformationEndingGenerator()
                 .generate(


### PR DESCRIPTION
Extends the guard #150 introduced for information ending messages to the propose side.

## Background

The fromData interface evaluator in #148 caught that `generateNegotiationProposePromptFromData` accepts an **empty item list** and happily renders a propose whose "required information items" section carries only the relationship line — a request that asks for nothing:

```
## 所需信息项
缺失项之间的关系：以上参数均为必选，缺少无法启动诊断
```

#150 added `requiredNonEmptyItems` for ending content (accept/reject); the propose path had no equivalent.

## Change

- `InformationProposeGenerator`: reject an empty item list with `IllegalArgumentException` (same guard, same message shape as the ending generator)
- `DefaultNegotiationContentExtractor`: the fromText path maps an empty `items` array to `negotiation_slot_missing`
- `NegotiationJsonSchemaBuilder`: the propose extraction schema sets `minItems: 1` on `items`
- Corpus property arbitraries: information propose contents generate at least one item (mirrors the ending-side alignment from #150)

## Test plan

- [x] New unit tests: `informationProposeRejectsEmptyRequestedItems` (generator), `rejectsEmptyInformationProposeItemsBeforeTemplateRendering` (extractor)
- [x] Full reactor `mvn test` green (negotiation 403+, corpus property tests aligned)
- [x] Evaluator case FD-P08 documents the gap and turns green with this fix