### PR TITLE
feat(input-limit): guard free-text facade inputs with configurable max length

### DIFF
--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
@@ -62,8 +62,10 @@ public final class A2ATClient {
      * Generates a processed task prompt from raw user input. Both text and structured input ({@code Map}) are unified
      * through LLM extraction; there is no zero-LLM rule shortcut.
      *
-     * @param userInput user-provided task description (text or structured input map)
-     * @return prompt generation result containing either rendered prompt text or failure details
+     * @param userInput user-provided task description (text or structured input map); a String input longer than the
+     *     configured maximum length ({@code A2AT_INPUT_TEXT_MAX_CHARS}) fails fast without any LLM call
+     * @return prompt generation result containing either rendered prompt text or failure details; a String input over
+     *     the limit yields the failure code {@code input_text_too_long}
      */
     public PromptGenerationResult generateTaskPrompt(Object userInput) {
         return promptGenerationOrchestrator.generateTaskPrompt(userInput);
@@ -79,7 +81,8 @@ public final class A2ATClient {
      * @throws NullPointerException if the text or template URI is null
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
      *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
-     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails, or the code
+     *     {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateTaskPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
         Objects.requireNonNull(text, "text");
@@ -122,7 +125,8 @@ public final class A2ATClient {
      * @throws NullPointerException if the text or template URI is null
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
      *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
-     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails, or the code
+     *     {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateAuthPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
         Objects.requireNonNull(text, "text");
@@ -165,7 +169,8 @@ public final class A2ATClient {
      * @throws NullPointerException if the text or template URI is null
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template_not_found},
      *     {@code prompt_resource_load_error}, {@code slot_schema_not_found}, {@code llm_invocation_failed},
-     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails
+     *     {@code render_failed} or {@code slot_validation_error} when generating the prompt fails, or the code
+     *     {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateNotificationPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
         Objects.requireNonNull(text, "text");
@@ -341,7 +346,9 @@ public final class A2ATClient {
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
      *     content misses a required field, or {@code negotiation_invalid_input} when the text is blank or the extracted
-     *     content contradicts the phase
+     *     content contradicts the phase,
+     *     or the code {@code input_text_too_long} when the text exceeds the configured
+     *     maximum length
      */
     public MetadataContent generateNegotiationProposePromptFromText(
             @NonNull String text,
@@ -370,7 +377,9 @@ public final class A2ATClient {
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
      *     content misses a required field, or {@code negotiation_invalid_input} when the text is blank or the extracted
-     *     conclusion is not {@code Accept}
+     *     conclusion is not {@code Accept},
+     *     or the code {@code input_text_too_long} when the text exceeds the configured
+     *     maximum length
      */
     public MetadataContent generateNegotiationAcceptPromptFromText(
             @NonNull String text,
@@ -399,7 +408,9 @@ public final class A2ATClient {
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
      *     content misses a required field, or {@code negotiation_invalid_input} when the text is blank or the extracted
-     *     conclusion is not {@code Reject}
+     *     conclusion is not {@code Reject},
+     *     or the code {@code input_text_too_long} when the text exceeds the configured
+     *     maximum length
      */
     public MetadataContent generateNegotiationRejectPromptFromText(
             @NonNull String text,
@@ -427,7 +438,9 @@ public final class A2ATClient {
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
-     *     content misses the termination reason, or {@code negotiation_invalid_input} when the text is blank
+     *     content misses the termination reason, or {@code negotiation_invalid_input} when the text is blank,
+     *     or the code {@code input_text_too_long} when the text exceeds the configured
+     *     maximum length
      */
     public MetadataContent generateNegotiationAbortPromptFromText(
             @NonNull String text,

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/assembly/ClientPromptGenerationOrchestratorBuilder.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/assembly/ClientPromptGenerationOrchestratorBuilder.java
@@ -2,6 +2,7 @@ package net.openan.a2at.sdk.client.prompt.assembly;
 
 import java.util.List;
 import net.openan.a2at.sdk.client.prompt.orchestration.DefaultClientPromptGenerationOrchestrator;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.prompt.analysis.impl.DefaultStructuredPromptSlotValueExtractor;
 import net.openan.a2at.sdk.prompt.analysis.impl.PromptSlotValueExtractor;
@@ -47,6 +48,8 @@ public final class ClientPromptGenerationOrchestratorBuilder {
     private PromptSlotValueExtractor slotValueExtractor;
 
     private TaskPromptRenderer renderer;
+
+    private Integer maxTextChars;
 
     private ClasspathPromptResourceLoader resourceLoader;
 
@@ -193,6 +196,18 @@ public final class ClientPromptGenerationOrchestratorBuilder {
     }
 
     /**
+     * Configures the maximum accepted length in characters for free-text inputs.
+     *
+     * @param maxTextChars maximum accepted length in characters; unset falls back to
+     *     {@link InputLimitConfig#DEFAULT_MAX_TEXT_CHARS}
+     * @return current builder
+     */
+    public ClientPromptGenerationOrchestratorBuilder maxTextChars(int maxTextChars) {
+        this.maxTextChars = maxTextChars;
+        return this;
+    }
+
+    /**
      * Overrides the classpath resource loader shared by template and schema resolution.
      *
      * @param resourceLoader resource loader implementation
@@ -243,7 +258,8 @@ public final class ClientPromptGenerationOrchestratorBuilder {
                 effectiveTemplateLoader,
                 effectiveSlotValueExtractor,
                 effectiveRenderer,
-                effectiveSlotSchemaLoader);
+                effectiveSlotSchemaLoader,
+                maxTextChars == null ? InputLimitConfig.DEFAULT_MAX_TEXT_CHARS : maxTextChars);
     }
 
     private static void require(Object value, String message) {

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilder.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilder.java
@@ -133,6 +133,7 @@ public final class DefaultA2ATClientBuilder {
                 .slotSchemaLoader(slotSchemaLoader)
                 .slotValueExtractor(slotValueExtractor)
                 .renderer(new TaskPromptRenderer())
+                .maxTextChars(config.inputLimits().maxTextChars())
                 .build();
     }
 

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/ClientPromptGenerationOrchestrator.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/ClientPromptGenerationOrchestrator.java
@@ -15,7 +15,8 @@ public interface ClientPromptGenerationOrchestrator {
     /**
      * Generates a processed task prompt from user input.
      *
-     * @param userInput raw or structured user input
+     * @param userInput raw or structured user input; a String input longer than the configured maximum length fails
+     *     fast with the code {@code input_text_too_long}
      * @return prompt-generation result
      */
     PromptGenerationResult generateTaskPrompt(Object userInput);
@@ -28,6 +29,8 @@ public interface ClientPromptGenerationOrchestrator {
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the text or template URI is null
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code input_text_too_long}
+     *     when the text exceeds the configured maximum length
      */
     MetadataContent generateTaskPromptFromText(String text, TemplateUri templateUri);
 
@@ -53,6 +56,8 @@ public interface ClientPromptGenerationOrchestrator {
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the text or template URI is null
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code input_text_too_long}
+     *     when the text exceeds the configured maximum length
      */
     MetadataContent generateAuthPromptFromText(String text, TemplateUri templateUri);
 
@@ -78,6 +83,8 @@ public interface ClientPromptGenerationOrchestrator {
      * @param templateUri template URI identifying the target template
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the text or template URI is null
+     * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code input_text_too_long}
+     *     when the text exceeds the configured maximum length
      */
     MetadataContent generateNotificationPromptFromText(String text, TemplateUri templateUri);
 

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestrator.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestrator.java
@@ -13,6 +13,7 @@ import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
 import net.openan.a2at.sdk.core.model.TemplateUri;
@@ -53,6 +54,8 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
 
     private final TaskPromptRenderer renderer;
 
+    private final int maxTextChars;
+
     /**
      * Creates a client prompt-generation orchestrator with explicit collaborators.
      *
@@ -76,6 +79,44 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
             PromptSlotValueExtractor slotValueExtractor,
             TaskPromptRenderer renderer,
             PromptSlotSchemaLoader slotSchemaLoader) {
+        this(
+                scenarioRecognizer,
+                scenarios,
+                language,
+                systemPrompt,
+                userPrompt,
+                templateLoader,
+                slotValueExtractor,
+                renderer,
+                slotSchemaLoader,
+                InputLimitConfig.DEFAULT_MAX_TEXT_CHARS);
+    }
+
+    /**
+     * Creates a client prompt-generation orchestrator with explicit collaborators and one free-text input length limit.
+     *
+     * @param scenarioRecognizer scenario recognizer
+     * @param scenarios supported scenario definitions
+     * @param language locale identifier for resource lookup
+     * @param systemPrompt system prompt for scenario recognition
+     * @param userPrompt user prompt for scenario recognition
+     * @param templateLoader template loader
+     * @param slotValueExtractor slot value extractor
+     * @param renderer task prompt renderer
+     * @param slotSchemaLoader slot schema loader
+     * @param maxTextChars maximum accepted length in characters for free-text inputs
+     */
+    public DefaultClientPromptGenerationOrchestrator(
+            ScenarioRecognizer scenarioRecognizer,
+            List<ScenarioDefinition> scenarios,
+            String language,
+            String systemPrompt,
+            String userPrompt,
+            PromptTemplateTextLoader templateLoader,
+            PromptSlotValueExtractor slotValueExtractor,
+            TaskPromptRenderer renderer,
+            PromptSlotSchemaLoader slotSchemaLoader,
+            int maxTextChars) {
         this.scenarioRecognizer = scenarioRecognizer;
         this.scenarios = scenarios;
         this.language = language;
@@ -85,10 +126,17 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
         this.slotValueExtractor = slotValueExtractor;
         this.renderer = renderer;
         this.slotSchemaLoader = slotSchemaLoader;
+        this.maxTextChars = maxTextChars;
     }
 
     @Override
     public PromptGenerationResult generateTaskPrompt(Object userInput) {
+        if (userInput instanceof String text && InputLimitConfig.isTooLong(text, maxTextChars)) {
+            return PromptGenerationResult.failure(new PromptGenerationFailure(
+                    A2ATErrorCodes.INPUT_TEXT_TOO_LONG,
+                    InputLimitConfig.violationMessage(text, maxTextChars),
+                    "input"));
+        }
         String normalizedInput = String.valueOf(userInput);
 
         final ScenarioRecognitionResult recognition;
@@ -167,6 +215,11 @@ public final class DefaultClientPromptGenerationOrchestrator implements ClientPr
     private MetadataContent generateFromTemplateUriWithMetadata(
             String userInput, TemplateUri templateUri, String extensionUri) {
         Objects.requireNonNull(userInput, "userInput");
+        if (InputLimitConfig.isTooLong(userInput, maxTextChars)) {
+            throw new PromptGenerationException(
+                    A2ATErrorCodes.INPUT_TEXT_TOO_LONG,
+                    InputLimitConfig.violationMessage(userInput, maxTextChars));
+        }
         return generateWithMetadata(templateUri, extensionUri, templateIdentifier -> slotValueExtractor
                 .extractSlots(userInput, templateIdentifier, language)
                 .slots());

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import net.openan.a2at.sdk.client.model.PromptGenerationResult;
 import net.openan.a2at.sdk.client.prompt.orchestration.ClientPromptGenerationOrchestrator;
 import net.openan.a2at.sdk.core.exception.A2ATError;
+import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
@@ -437,6 +438,49 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
                 NullPointerException.class,
                 () -> client.generateNotificationPromptFromDataWithSchema(data, schema, null));
         assertFalse(A2ATError.class.isInstance(notifEx), "null template URI must stay outside the A2ATError tree");
+    }
+
+    @Test
+    void fromTextRejectsOverLimitTextWhenConfiguredWithSmallLimit() throws IOException {
+        Path envFile = writeMinimalClientEnvWithInputLimit(TEST_MOCK_PROVIDER, 100);
+        A2ATClient client = new A2ATClient(envFile);
+        String overLimitText = "a".repeat(101);
+
+        PromptGenerationException taskEx = assertThrows(
+                PromptGenerationException.class,
+                () -> client.generateTaskPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING));
+        PromptGenerationException authEx = assertThrows(
+                PromptGenerationException.class,
+                () -> client.generateAuthPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING));
+        PromptGenerationException notificationEx = assertThrows(
+                PromptGenerationException.class,
+                () -> client.generateNotificationPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING));
+
+        assertEquals("input_text_too_long", taskEx.getCode());
+        assertEquals("input_text_too_long", authEx.getCode());
+        assertEquals("input_text_too_long", notificationEx.getCode());
+        assertEquals(0, RecordingClient.REQUEST_COUNT.get(), "over-limit input must fail before any LLM call");
+    }
+
+    @Test
+    void generateTaskPromptRejectsOverLimitStringInputWithoutLlmCall() throws IOException {
+        Path envFile = writeMinimalClientEnvWithInputLimit(TEST_MOCK_PROVIDER, 100);
+        A2ATClient client = new A2ATClient(envFile);
+
+        PromptGenerationResult result = client.generateTaskPrompt("a".repeat(101));
+
+        assertFalse(result.success());
+        assertEquals("input_text_too_long", result.failure().code());
+        assertEquals(0, RecordingClient.REQUEST_COUNT.get(), "over-limit input must fail before any LLM call");
+    }
+
+    private static Path writeMinimalClientEnvWithInputLimit(String provider, int maxTextChars) throws IOException {
+        Path envFile = writeMinimalClientEnv(provider);
+        Files.writeString(
+                envFile,
+                "A2AT_INPUT_TEXT_MAX_CHARS=" + maxTextChars + "\n",
+                java.nio.file.StandardOpenOption.APPEND);
+        return envFile;
     }
 
     private static Path writeMinimalClientEnvWithoutRequiredSlots(String provider) throws IOException {

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilderTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/assembly/DefaultA2ATClientBuilderTest.java
@@ -43,7 +43,7 @@ class DefaultA2ATClientBuilderTest {
         config = new A2ATConfig(
                 new net.openan.a2at.sdk.core.model.PromptRuntimeConfig(
                         config.prompt().language(), config.prompt().sourceType(), resolvedRoot),
-                config.llm(), config.negotiation(), config.promptCompliance());
+                config.llm(), config.inputLimits(), config.negotiation(), config.promptCompliance());
 
         DefaultA2ATClientBuilder builder =
                 DefaultA2ATClientBuilder.builder().config(config).envPath(envFile);
@@ -70,7 +70,7 @@ class DefaultA2ATClientBuilderTest {
         config = new A2ATConfig(
                 new net.openan.a2at.sdk.core.model.PromptRuntimeConfig(
                         config.prompt().language(), config.prompt().sourceType(), resolvedRoot),
-                config.llm(), config.negotiation(), config.promptCompliance());
+                config.llm(), config.inputLimits(), config.negotiation(), config.promptCompliance());
 
         DefaultA2ATClientBuilder builder =
                 DefaultA2ATClientBuilder.builder().config(config).envPath(envFile);

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/prompt/orchestration/DefaultClientPromptGenerationOrchestratorTest.java
@@ -14,6 +14,7 @@ import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
@@ -982,5 +983,115 @@ class DefaultClientPromptGenerationOrchestratorTest {
         assertEquals(1, ex.failedParameters().size());
         assertEquals("site", ex.failedParameters().get(0).slotName());
         assertEquals("missing_required", ex.failedParameters().get(0).code());
+    }
+
+    // --- free-text input length limit tests ---
+
+    @Test
+    void fromTextEntryPointsRejectTextOverTheDefaultLimitBeforeAnyLlmCall() {
+        String overLimitText = "a".repeat(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS + 1);
+        RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
+        CountingFailingTemplateLoader templateLoader = new CountingFailingTemplateLoader();
+        DefaultClientPromptGenerationOrchestrator orchestrator =
+                newTemplateUriOrchestrator(recognizer, templateLoader, new FakeSlotValueExtractor(Map.of()));
+
+        PromptGenerationException taskEx = assertThrows(
+                PromptGenerationException.class,
+                () -> orchestrator.generateTaskPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING));
+        PromptGenerationException authEx = assertThrows(
+                PromptGenerationException.class,
+                () -> orchestrator.generateAuthPromptFromText(overLimitText, AUTH_DATABASE_READ));
+        PromptGenerationException notificationEx = assertThrows(
+                PromptGenerationException.class,
+                () -> orchestrator.generateNotificationPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING));
+
+        assertEquals("input_text_too_long", taskEx.getCode());
+        assertEquals("input_text_too_long", authEx.getCode());
+        assertEquals("input_text_too_long", notificationEx.getCode());
+        assertTrue(taskEx.getMessage().contains(String.valueOf(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS + 1)));
+        assertEquals(0, recognizer.invocationCount, "over-limit input must fail before any LLM call");
+        assertEquals(0, templateLoader.loadCount, "over-limit input must fail before template loading");
+    }
+
+    @Test
+    void fromTextAcceptsTextAtExactlyTheDefaultLimit() {
+        String limitText = "a".repeat(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS);
+        DefaultClientPromptGenerationOrchestrator orchestrator = newTemplateUriOrchestrator(
+                new RecordingScenarioRecognizer(),
+                new FakeTemplateLoader("Site: {site}"),
+                new FakeSlotValueExtractor(Map.of("site", "Site A")));
+
+        MetadataContent result =
+                orchestrator.generateTaskPromptFromText(limitText, StandardTemplates.ENERGY_SAVING);
+
+        assertEquals("Site: Site A", result.promptText());
+    }
+
+    @Test
+    void fromTextRejectsTextOverOneConfiguredLimit() {
+        DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
+                new RecordingScenarioRecognizer(),
+                List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
+                "en-US",
+                "",
+                "",
+                new FakeTemplateLoader("Site: {site}"),
+                new FakeSlotValueExtractor(Map.of("site", "Site A")),
+                new TaskPromptRenderer(),
+                EMPTY_SCHEMA_LOADER,
+                10);
+
+        PromptGenerationException overEx = assertThrows(
+                PromptGenerationException.class,
+                () -> orchestrator.generateTaskPromptFromText("a".repeat(11), StandardTemplates.ENERGY_SAVING));
+        assertEquals("input_text_too_long", overEx.getCode());
+
+        MetadataContent atLimit =
+                orchestrator.generateTaskPromptFromText("a".repeat(10), StandardTemplates.ENERGY_SAVING);
+        assertEquals("Site: Site A", atLimit.promptText());
+    }
+
+    @Test
+    void generateTaskPromptReturnsFailureWhenStringInputExceedsTheDefaultLimit() {
+        String overLimitText = "a".repeat(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS + 1);
+        RecordingScenarioRecognizer recognizer = new RecordingScenarioRecognizer();
+        DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
+                recognizer,
+                List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
+                "en-US",
+                "",
+                "",
+                new FakeTemplateLoader("Site: {site}"),
+                new FakeSlotValueExtractor(Map.of("site", "Site A")),
+                new TaskPromptRenderer(),
+                EMPTY_SCHEMA_LOADER);
+
+        PromptGenerationResult result = orchestrator.generateTaskPrompt(overLimitText);
+
+        assertFalse(result.success());
+        assertEquals("input_text_too_long", result.failure().code());
+        assertEquals("input", result.failure().stage());
+        assertEquals(0, recognizer.invocationCount, "over-limit input must fail before any LLM call");
+    }
+
+    @Test
+    void generateTaskPromptDoesNotCheckLengthForMapInput() {
+        Map<String, Object> mapInputWithLongStringValue =
+                Map.of("notes", "a".repeat(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS + 1));
+        DefaultClientPromptGenerationOrchestrator orchestrator = new DefaultClientPromptGenerationOrchestrator(
+                new RecordingScenarioRecognizer(),
+                List.of(new ScenarioDefinition("energy_saving", "Energy Saving", "Energy analysis", "Analyze")),
+                "en-US",
+                "",
+                "",
+                new FakeTemplateLoader("Site: {site}"),
+                new FakeSlotValueExtractor(Map.of("site", "Site A")),
+                new TaskPromptRenderer(),
+                EMPTY_SCHEMA_LOADER);
+
+        PromptGenerationResult result = orchestrator.generateTaskPrompt(mapInputWithLongStringValue);
+
+        assertTrue(result.success(), "map input must not be length-checked");
+        assertEquals("Site: Site A", result.promptText());
     }
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATErrorCodes.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/exception/A2ATErrorCodes.java
@@ -14,6 +14,9 @@ public final class A2ATErrorCodes {
     /** Default code for SDK processing failures without a more specific code. */
     public static final String SDK_INTERNAL_ERROR = "sdk_internal_error";
 
+    /** A free-text input exceeded the configured maximum length. */
+    public static final String INPUT_TEXT_TOO_LONG = "input_text_too_long";
+
     /** Default code for parameter-extraction failures without a more specific code. */
     public static final String PARAM_EXTRACTION_FAILED = "param_extraction_failed";
 

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/A2ATConfig.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/A2ATConfig.java
@@ -13,6 +13,7 @@ import org.jspecify.annotations.NonNull;
 public record A2ATConfig(
         PromptRuntimeConfig prompt,
         LlmConfig llm,
+        InputLimitConfig inputLimits,
         NegotiationConfig negotiation,
         PromptComplianceConfig promptCompliance) {
 
@@ -27,6 +28,7 @@ public record A2ATConfig(
         return new A2ATConfig(
                 PromptRuntimeConfig.fromMap(values),
                 LlmConfig.fromMap(values),
+                InputLimitConfig.fromMap(values),
                 NegotiationConfig.fromMap(values),
                 PromptComplianceConfig.fromMap(values));
     }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/A2ATConfigKeys.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/A2ATConfigKeys.java
@@ -78,6 +78,14 @@ public final class A2ATConfigKeys {
         public static final String STATE_STORE_TYPE = "A2AT_NEGOTIATION_STATE_STORE_TYPE";
     }
 
+    /** Input limit configuration keys. */
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static final class Input {
+
+        /** Maximum length in characters accepted for free-text inputs before they reach an LLM step. */
+        public static final String MAX_TEXT_CHARS = "A2AT_INPUT_TEXT_MAX_CHARS";
+    }
+
     /** Prompt compliance configuration keys. */
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class PromptCompliance {

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/InputLimitConfig.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/InputLimitConfig.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 public record InputLimitConfig(int maxTextChars) {
 
     /** Default maximum length in characters ({@link String#length()}) accepted for free-text inputs. */
-    public static final int DEFAULT_MAX_TEXT_CHARS = 12288;
+    public static final int DEFAULT_MAX_TEXT_CHARS = 16384;
 
     private static final String NON_NUMERIC_OR_NON_POSITIVE_LOG_FORMAT =
             "Input max text chars value is not a valid positive integer, falling back to default. key={} raw_value={}"

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/InputLimitConfig.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/InputLimitConfig.java
@@ -1,0 +1,76 @@
+package net.openan.a2at.sdk.core.model;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Input limit configuration resolved from unified SDK config.
+ *
+ * <p>The limits guard every facade entry point that accepts a free-text {@link String} and forwards it to an LLM step,
+ * so oversized inputs fail fast before any LLM call instead of overflowing the LLM context.
+ *
+ * @since 2026-08
+ */
+@Slf4j
+public record InputLimitConfig(int maxTextChars) {
+
+    /** Default maximum length in characters ({@link String#length()}) accepted for free-text inputs. */
+    public static final int DEFAULT_MAX_TEXT_CHARS = 12288;
+
+    private static final String NON_NUMERIC_OR_NON_POSITIVE_LOG_FORMAT =
+            "Input max text chars value is not a valid positive integer, falling back to default. key={} raw_value={}"
+                    + " default_value={}";
+
+    public InputLimitConfig {
+        if (maxTextChars <= 0) {
+            throw new IllegalArgumentException("maxTextChars must be positive: " + maxTextChars);
+        }
+    }
+
+    /**
+     * Builds one input limit config from raw {@code .env} values.
+     *
+     * @param values raw config values
+     * @return resolved input limit config
+     */
+    public static InputLimitConfig fromMap(Map<String, String> values) {
+        String rawValue = values.get(A2ATConfigKeys.Input.MAX_TEXT_CHARS);
+        if (StringUtils.isBlank(rawValue)) {
+            return new InputLimitConfig(DEFAULT_MAX_TEXT_CHARS);
+        }
+        try {
+            return new InputLimitConfig(Integer.parseInt(rawValue.trim()));
+        } catch (IllegalArgumentException error) {
+            log.atWarn().log(
+                    NON_NUMERIC_OR_NON_POSITIVE_LOG_FORMAT,
+                    A2ATConfigKeys.Input.MAX_TEXT_CHARS,
+                    rawValue.trim(),
+                    DEFAULT_MAX_TEXT_CHARS);
+            return new InputLimitConfig(DEFAULT_MAX_TEXT_CHARS);
+        }
+    }
+
+    /**
+     * Reports whether the given free-text input exceeds the given character limit.
+     *
+     * @param text free-text input; {@code null} is never too long
+     * @param maxTextChars maximum accepted length in characters
+     * @return true when the input length exceeds the limit
+     */
+    public static boolean isTooLong(String text, int maxTextChars) {
+        return text != null && text.length() > maxTextChars;
+    }
+
+    /**
+     * Builds the violation message for an oversized free-text input.
+     *
+     * @param text oversized free-text input
+     * @param maxTextChars maximum accepted length in characters
+     * @return message stating the actual length, the limit and the configuring key
+     */
+    public static String violationMessage(String text, int maxTextChars) {
+        return "input text length " + text.length() + " exceeds the configured maximum of " + maxTextChars
+                + " characters (" + A2ATConfigKeys.Input.MAX_TEXT_CHARS + ")";
+    }
+}

--- a/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/exception/A2ATErrorCodesTest.java
+++ b/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/exception/A2ATErrorCodesTest.java
@@ -23,16 +23,16 @@ import org.junit.jupiter.api.Test;
 class A2ATErrorCodesTest {
 
     /**
-     * Verifies that {@link A2ATErrorCodes} declares exactly the twenty expected error code constants with the expected
-     * values.
+     * Verifies that {@link A2ATErrorCodes} declares exactly the twenty-one expected error code constants with the
+     * expected values.
      *
      * <p>Scenario: Reflection inspects all declared static final String fields of the registry. Expected result: The
-     * field set contains exactly the twenty known constants and no others.
+     * field set contains exactly the twenty-one known constants and no others.
      *
      * @throws IllegalAccessException if a declared field cannot be read
      */
     @Test
-    void should_declareExactlyTwentyConstants_When_reflectingOverDeclaredFields() throws IllegalAccessException {
+    void should_declareExactlyTwentyOneConstants_When_reflectingOverDeclaredFields() throws IllegalAccessException {
         Map<String, String> constants = new TreeMap<>();
         for (Field field : A2ATErrorCodes.class.getDeclaredFields()) {
             if (field.getType() == String.class
@@ -47,6 +47,7 @@ class A2ATErrorCodesTest {
                 Map.ofEntries(
                         Map.entry("SDK_INTERNAL_ERROR", "sdk_internal_error"),
                         Map.entry("PARAM_EXTRACTION_FAILED", "param_extraction_failed"),
+                        Map.entry("INPUT_TEXT_TOO_LONG", "input_text_too_long"),
                         Map.entry("TEMPLATE_NOT_FOUND", "template_not_found"),
                         Map.entry("NEGOTIATION_CONTENT_EXTRACT_FAILED", "negotiation_content_extract_failed"),
                         Map.entry("NEGOTIATION_SEMANTIC_REJECTED", "negotiation_semantic_rejected"),

--- a/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/InputLimitConfigTest.java
+++ b/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/InputLimitConfigTest.java
@@ -20,7 +20,7 @@ class InputLimitConfigTest {
         InputLimitConfig config = InputLimitConfig.fromMap(Map.of());
 
         assertEquals(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS, config.maxTextChars());
-        assertEquals(12288, config.maxTextChars());
+        assertEquals(16384, config.maxTextChars());
     }
 
     @Test
@@ -70,10 +70,10 @@ class InputLimitConfigTest {
 
     @Test
     void violationMessageStatesLengthLimitAndKey() {
-        String message = InputLimitConfig.violationMessage("a".repeat(13000), 12288);
+        String message = InputLimitConfig.violationMessage("a".repeat(13000), 16384);
 
         assertTrue(message.contains("13000"));
-        assertTrue(message.contains("12288"));
+        assertTrue(message.contains("16384"));
         assertTrue(message.contains(A2ATConfigKeys.Input.MAX_TEXT_CHARS));
     }
 }

--- a/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/InputLimitConfigTest.java
+++ b/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/InputLimitConfigTest.java
@@ -1,0 +1,79 @@
+package net.openan.a2at.sdk.core.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link InputLimitConfig} parsing and length-guard helpers.
+ *
+ * @since 2026-08
+ */
+class InputLimitConfigTest {
+
+    @Test
+    void fromMapFallsBackToDefaultWhenKeyAbsent() {
+        InputLimitConfig config = InputLimitConfig.fromMap(Map.of());
+
+        assertEquals(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS, config.maxTextChars());
+        assertEquals(12288, config.maxTextChars());
+    }
+
+    @Test
+    void fromMapParsesConfiguredValue() {
+        InputLimitConfig config =
+                InputLimitConfig.fromMap(Map.of(A2ATConfigKeys.Input.MAX_TEXT_CHARS, " 2048 "));
+
+        assertEquals(2048, config.maxTextChars());
+    }
+
+    @Test
+    void fromMapFallsBackToDefaultOnNonNumericValue() {
+        InputLimitConfig config =
+                InputLimitConfig.fromMap(Map.of(A2ATConfigKeys.Input.MAX_TEXT_CHARS, "not-a-number"));
+
+        assertEquals(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS, config.maxTextChars());
+    }
+
+    @Test
+    void fromMapFallsBackToDefaultOnNonPositiveValue() {
+        InputLimitConfig config =
+                InputLimitConfig.fromMap(Map.of(A2ATConfigKeys.Input.MAX_TEXT_CHARS, "0"));
+
+        assertEquals(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS, config.maxTextChars());
+    }
+
+    @Test
+    void fromMapFallsBackToDefaultOnBlankValue() {
+        InputLimitConfig config = InputLimitConfig.fromMap(Map.of(A2ATConfigKeys.Input.MAX_TEXT_CHARS, "  "));
+
+        assertEquals(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS, config.maxTextChars());
+    }
+
+    @Test
+    void constructorRejectsNonPositiveLimit() {
+        assertThrows(IllegalArgumentException.class, () -> new InputLimitConfig(0));
+        assertThrows(IllegalArgumentException.class, () -> new InputLimitConfig(-1));
+    }
+
+    @Test
+    void isTooLongComparesByLengthAgainstLimit() {
+        assertTrue(InputLimitConfig.isTooLong("a".repeat(101), 100));
+        assertFalse(InputLimitConfig.isTooLong("a".repeat(100), 100));
+        assertFalse(InputLimitConfig.isTooLong("", 100));
+        assertFalse(InputLimitConfig.isTooLong(null, 100));
+    }
+
+    @Test
+    void violationMessageStatesLengthLimitAndKey() {
+        String message = InputLimitConfig.violationMessage("a".repeat(13000), 12288);
+
+        assertTrue(message.contains("13000"));
+        assertTrue(message.contains("12288"));
+        assertTrue(message.contains(A2ATConfigKeys.Input.MAX_TEXT_CHARS));
+    }
+}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationContentService.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationContentService.java
@@ -61,6 +61,7 @@ public final class NegotiationContentService {
                 .localRootDir(config.prompt().localRootDir())
                 .llmClient(llmClient)
                 .maxAttempts(config.llm().maxAttempts())
+                .maxTextChars(config.inputLimits().maxTextChars())
                 .build();
     }
 
@@ -85,6 +86,7 @@ public final class NegotiationContentService {
                 new PromptRuntimeConfig(
                         config.prompt().language(), config.prompt().sourceType(), resolvedLocalRootPath.toString()),
                 config.llm(),
+                config.inputLimits(),
                 config.negotiation(),
                 config.promptCompliance());
     }
@@ -168,7 +170,8 @@ public final class NegotiationContentService {
      * @throws NegotiationGenerationException with the code {@code template_not_found},
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when loading or
      *     extracting fails, {@code negotiation_slot_missing} when the extracted content misses a required field, or
-     *     {@code negotiation_invalid_input} when the text is blank or the extracted content contradicts the performative
+     *     {@code negotiation_invalid_input} when the text is blank or the extracted content contradicts the performative,
+     *     or {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateProposeFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -187,7 +190,8 @@ public final class NegotiationContentService {
      * @throws NegotiationGenerationException with the code {@code template_not_found},
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when loading or
      *     extracting fails, {@code negotiation_slot_missing} when the extracted content misses a required field, or
-     *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Accept}
+     *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Accept},
+     *     or {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateAcceptFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -206,7 +210,8 @@ public final class NegotiationContentService {
      * @throws NegotiationGenerationException with the code {@code template_not_found},
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when loading or
      *     extracting fails, {@code negotiation_slot_missing} when the extracted content misses a required field, or
-     *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Reject}
+     *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Reject},
+     *     or {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateRejectFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -224,7 +229,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the template URI does not address the common abort template
      * @throws NegotiationGenerationException with the code {@code template_not_found},
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when loading or
-     *     extracting fails, or {@code negotiation_slot_missing} when the extracted content misses the termination reason
+     *     extracting fails, {@code negotiation_slot_missing} when the extracted content misses the termination reason,
+     *     or {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateAbortFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -266,8 +272,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the prompt is blank, or the template URI contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input},
      *     {@code negotiation_rule_violation}, {@code negotiation_semantic_rejected},
-     *     {@code negotiation_llm_infrastructure_error} or {@code template_not_found} when the validation pipeline
-     *     fails
+     *     {@code negotiation_llm_infrastructure_error}, {@code input_text_too_long} or {@code template_not_found}
+     *     when the validation pipeline fails
      */
     public FilledParamData validateProposePromptAndDataFilling(
             String prompt,
@@ -290,8 +296,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the prompt is blank, or the template URI contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input},
      *     {@code negotiation_rule_violation}, {@code negotiation_semantic_rejected},
-     *     {@code negotiation_llm_infrastructure_error} or {@code template_not_found} when the validation pipeline
-     *     fails
+     *     {@code negotiation_llm_infrastructure_error}, {@code input_text_too_long} or {@code template_not_found}
+     *     when the validation pipeline fails
      */
     public FilledParamData validateAcceptPromptAndDataFilling(
             String prompt,
@@ -314,8 +320,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the prompt is blank, or the template URI contradicts the method
      * @throws NegotiationParamExtractionException with the code {@code negotiation_invalid_input},
      *     {@code negotiation_rule_violation}, {@code negotiation_semantic_rejected},
-     *     {@code negotiation_llm_infrastructure_error} or {@code template_not_found} when the validation pipeline
-     *     fails
+     *     {@code negotiation_llm_infrastructure_error}, {@code input_text_too_long} or {@code template_not_found}
+     *     when the validation pipeline fails
      */
     public FilledParamData validateRejectPromptAndDataFilling(
             String prompt,
@@ -336,7 +342,8 @@ public final class NegotiationContentService {
      * @return filled parameter data carrying the context parameters and the extracted parameters
      * @throws NullPointerException if the schema or the template URI is null
      * @throws IllegalArgumentException if the template URI does not address the common abort template
-     * @throws NegotiationParamExtractionException when the validation pipeline fails
+     * @throws NegotiationParamExtractionException with the code {@code input_text_too_long} when the prompt exceeds
+     *     the configured maximum length, or another validation pipeline failure code otherwise
      */
     public FilledParamData validateAbortPromptAndDataFilling(
             String prompt,

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
@@ -9,6 +9,7 @@ import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.exception.A2ATParamExtractionError;
 import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.NegotiationPerformative;
@@ -60,6 +61,8 @@ public final class NegotiationGenerationOrchestrator {
 
     private final int maxAttempts;
 
+    private final int maxTextChars;
+
     private final NegotiationTemplateLoader templateLoader;
 
     private final NegotiationContentExtractor contentExtractor;
@@ -75,6 +78,7 @@ public final class NegotiationGenerationOrchestrator {
     NegotiationGenerationOrchestrator(
             String language,
             int maxAttempts,
+            int maxTextChars,
             NegotiationTemplateLoader templateLoader,
             NegotiationContentExtractor contentExtractor,
             ParamExtractor paramExtractor,
@@ -83,6 +87,7 @@ public final class NegotiationGenerationOrchestrator {
             Logger logger) {
         this.language = language;
         this.maxAttempts = maxAttempts;
+        this.maxTextChars = maxTextChars;
         this.templateLoader = templateLoader;
         this.contentExtractor = contentExtractor;
         this.paramExtractor = paramExtractor;
@@ -206,7 +211,8 @@ public final class NegotiationGenerationOrchestrator {
      *     resource exists for the URI and language, {@code negotiation_content_extract_failed} or
      *     {@code negotiation_llm_infrastructure_error} when the extraction step fails after exhausting its retries,
      *     {@code negotiation_slot_missing} when the extracted content misses a required field, or
-     *     {@code negotiation_invalid_input} when the text is blank or the extracted content contradicts the phase
+     *     {@code negotiation_invalid_input} when the text is blank or the extracted content contradicts the phase,
+     *     or {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateProposeFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -233,7 +239,8 @@ public final class NegotiationGenerationOrchestrator {
      *     resource exists for the URI and language, {@code negotiation_content_extract_failed} or
      *     {@code negotiation_llm_infrastructure_error} when the extraction step fails after exhausting its retries,
      *     {@code negotiation_slot_missing} when the extracted content misses a required field, or
-     *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Accept}
+     *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Accept},
+     *     or {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateAcceptFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -260,7 +267,8 @@ public final class NegotiationGenerationOrchestrator {
      *     resource exists for the URI and language, {@code negotiation_content_extract_failed} or
      *     {@code negotiation_llm_infrastructure_error} when the extraction step fails after exhausting its retries,
      *     {@code negotiation_slot_missing} when the extracted content misses a required field, or
-     *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Reject}
+     *     {@code negotiation_invalid_input} when the text is blank or the extracted conclusion is not {@code Reject},
+     *     or {@code input_text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateRejectFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -287,7 +295,8 @@ public final class NegotiationGenerationOrchestrator {
      *     resource exists for the URI and language, {@code negotiation_content_extract_failed} or
      *     {@code negotiation_llm_infrastructure_error} when the extraction step fails after exhausting its retries,
      *     {@code negotiation_slot_missing} when the extracted content misses the termination reason, or
-     *     {@code negotiation_invalid_input} when the text is blank
+     *     {@code negotiation_invalid_input} when the text is blank, or {@code input_text_too_long} when the text
+     *     exceeds the configured maximum length
      */
     public MetadataContent generateAbortFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -367,7 +376,8 @@ public final class NegotiationGenerationOrchestrator {
      *     negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code template_not_found} when the semantic validation prompt resources are missing
+     *     {@code template_not_found} when the semantic validation prompt resources are missing, or
+     *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
      */
     public FilledParamData validateProposePromptAndDataFilling(
             String prompt,
@@ -398,7 +408,8 @@ public final class NegotiationGenerationOrchestrator {
      *     negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code template_not_found} when the semantic validation prompt resources are missing
+     *     {@code template_not_found} when the semantic validation prompt resources are missing, or
+     *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
      */
     public FilledParamData validateAcceptPromptAndDataFilling(
             String prompt,
@@ -429,7 +440,8 @@ public final class NegotiationGenerationOrchestrator {
      *     negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code template_not_found} when the semantic validation prompt resources are missing
+     *     {@code template_not_found} when the semantic validation prompt resources are missing, or
+     *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
      */
     public FilledParamData validateRejectPromptAndDataFilling(
             String prompt,
@@ -459,7 +471,8 @@ public final class NegotiationGenerationOrchestrator {
      *     negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code template_not_found} when the semantic validation prompt resources are missing
+     *     {@code template_not_found} when the semantic validation prompt resources are missing, or
+     *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
      */
     public FilledParamData validateAbortPromptAndDataFilling(
             String prompt,
@@ -490,6 +503,7 @@ public final class NegotiationGenerationOrchestrator {
     private MetadataContent generateFromText(
             String text, NegotiationContext context, TemplateUri templateUri, NegotiationPerformative performative) {
         requireContext(context);
+        requireTextWithinLimit(text);
         try {
             NegotiationReference reference = requireReference(templateUri, performative);
             PromptTemplate template = loadTemplate(reference);
@@ -560,6 +574,7 @@ public final class NegotiationGenerationOrchestrator {
             TemplateUri templateUri,
             NegotiationPerformative performative) {
         Objects.requireNonNull(schema, "Parameter schema must not be null.");
+        requirePromptWithinLimit(prompt);
         NegotiationReference reference = requireReference(templateUri, performative);
         String templateContent;
         try {
@@ -673,5 +688,21 @@ public final class NegotiationGenerationOrchestrator {
 
     private static void requireContext(NegotiationContext context) {
         Objects.requireNonNull(context, "Negotiation context must not be null.");
+    }
+
+    private void requireTextWithinLimit(String text) {
+        if (InputLimitConfig.isTooLong(text, maxTextChars)) {
+            throw new NegotiationGenerationException(
+                    A2ATErrorCodes.INPUT_TEXT_TOO_LONG, InputLimitConfig.violationMessage(text, maxTextChars));
+        }
+    }
+
+    private void requirePromptWithinLimit(String prompt) {
+        if (InputLimitConfig.isTooLong(prompt, maxTextChars)) {
+            throw new NegotiationParamExtractionException(
+                    A2ATErrorCodes.INPUT_TEXT_TOO_LONG,
+                    InputLimitConfig.violationMessage(prompt, maxTextChars),
+                    List.of());
+        }
     }
 }

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilder.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestratorBuilder.java
@@ -1,6 +1,7 @@
 package net.openan.a2at.sdk.negotiation.generation;
 
 import java.nio.file.Path;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
 import net.openan.a2at.sdk.core.model.LlmConfig;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.negotiation.content.Vocabulary;
@@ -34,6 +35,8 @@ public final class NegotiationGenerationOrchestratorBuilder {
     private LLMClient llmClient;
 
     private int maxAttempts = LlmConfig.DEFAULT_MAX_ATTEMPTS;
+
+    private int maxTextChars = InputLimitConfig.DEFAULT_MAX_TEXT_CHARS;
 
     private NegotiationTemplateLoader templateLoader;
 
@@ -98,6 +101,18 @@ public final class NegotiationGenerationOrchestratorBuilder {
      */
     public NegotiationGenerationOrchestratorBuilder maxAttempts(int maxAttempts) {
         this.maxAttempts = maxAttempts;
+        return this;
+    }
+
+    /**
+     * Configures the maximum length in characters accepted for free-text inputs before they reach an LLM step.
+     *
+     * @param maxTextChars maximum accepted length in characters, at least 1; oversized inputs fail fast with the code
+     *     {@code input_text_too_long} instead of overflowing the LLM context
+     * @return current builder
+     */
+    public NegotiationGenerationOrchestratorBuilder maxTextChars(int maxTextChars) {
+        this.maxTextChars = maxTextChars;
         return this;
     }
 
@@ -171,6 +186,10 @@ public final class NegotiationGenerationOrchestratorBuilder {
             throw new IllegalStateException(
                     "Negotiation LLM max attempts must be at least 1 but was " + maxAttempts + ".");
         }
+        if (maxTextChars < 1) {
+            throw new IllegalStateException(
+                    "Negotiation max text chars must be at least 1 but was " + maxTextChars + ".");
+        }
         Path localVocabularyRoot = localRootDir == null || localRootDir.isBlank() ? null : Path.of(localRootDir);
         Vocabulary vocabulary = Vocabulary.forLanguage(language, localVocabularyRoot);
         NegotiationTemplateLoader effectiveTemplateLoader =
@@ -186,6 +205,7 @@ public final class NegotiationGenerationOrchestratorBuilder {
         return new NegotiationGenerationOrchestrator(
                 language,
                 maxAttempts,
+                maxTextChars,
                 effectiveTemplateLoader,
                 effectiveContentExtractor,
                 paramExtractor,

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/contract/NegotiationDeliveredResourceContractTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/contract/NegotiationDeliveredResourceContractTest.java
@@ -68,6 +68,7 @@ class NegotiationDeliveredResourceContractTest {
     void errorCodeConstantsStayExactlyThePinnedRegistry() {
         java.util.Map<String, String> expected = new java.util.LinkedHashMap<>();
         expected.put("SDK_INTERNAL_ERROR", "sdk_internal_error");
+        expected.put("INPUT_TEXT_TOO_LONG", "input_text_too_long");
         expected.put("PARAM_EXTRACTION_FAILED", "param_extraction_failed");
         expected.put("TEMPLATE_NOT_FOUND", "template_not_found");
         expected.put("NEGOTIATION_CONTENT_EXTRACT_FAILED", "negotiation_content_extract_failed");

--- a/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/InputTextLengthLimitTest.java
+++ b/a2a-t-negotiation/src/test/java/net/openan/a2at/sdk/negotiation/generation/InputTextLengthLimitTest.java
@@ -1,0 +1,169 @@
+package net.openan.a2at.sdk.negotiation.generation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
+import net.openan.a2at.sdk.llm.LLMClient;
+import net.openan.a2at.sdk.llm.LLMResponse;
+import net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException;
+import net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException;
+import net.openan.a2at.sdk.negotiation.generation.NegotiationGoldenCases.GoldenCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests of the free-text input length limit of the negotiation pipelines.
+ *
+ * <p>Oversized inputs fail fast with the code {@code input_text_too_long} before any LLM call, inputs at exactly the
+ * limit pass the gate and reach the LLM, and the limit is configurable through the builder.
+ */
+class InputTextLengthLimitTest {
+
+    private static final String ZH_CN = NegotiationGoldenCases.ZH_CN;
+
+    private static final GoldenCase PROPOSE = GoldenCase.INFORMATION_PROPOSE;
+
+    /** A text one character over the default limit must be rejected with the dedicated code before any LLM call. */
+    @Test
+    void rejectsFromTextOverTheDefaultLimitBeforeAnyLlmCall() {
+        CountingClient llm = new CountingClient();
+        NegotiationGenerationOrchestrator orchestrator = defaultOrchestrator(llm);
+
+        NegotiationGenerationException failure = assertThrows(
+                NegotiationGenerationException.class,
+                () -> orchestrator.generateProposeFromText(
+                        textOfLength(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS + 1),
+                        PROPOSE.context(),
+                        PROPOSE.template()));
+
+        assertEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, failure.getCode());
+        assertTrue(
+                failure.getMessage().contains(String.valueOf(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS + 1)),
+                "the violation message must state the actual length but was: " + failure.getMessage());
+        assertTrue(
+                failure.getMessage().contains(String.valueOf(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS)),
+                "the violation message must state the limit but was: " + failure.getMessage());
+        assertEquals(0, llm.calls, "an oversized text must never reach the LLM");
+    }
+
+    /** A text at exactly the default limit passes the gate and reaches the extraction LLM call. */
+    @Test
+    void acceptsFromTextAtExactlyTheDefaultLimit() {
+        CountingClient llm = new CountingClient();
+        NegotiationGenerationOrchestrator orchestrator = defaultOrchestrator(llm);
+
+        NegotiationGenerationException failure = assertThrows(
+                NegotiationGenerationException.class,
+                () -> orchestrator.generateProposeFromText(
+                        textOfLength(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS),
+                        PROPOSE.context(),
+                        PROPOSE.template()));
+
+        assertNotEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, failure.getCode());
+        assertTrue(llm.calls >= 1, "a text at exactly the limit must reach the LLM");
+    }
+
+    /** An oversized prompt of the validation pipeline is rejected with the dedicated code before any LLM call. */
+    @Test
+    void rejectsValidationPromptOverTheDefaultLimitBeforeAnyLlmCall() {
+        CountingClient llm = new CountingClient();
+        NegotiationGenerationOrchestrator orchestrator = defaultOrchestrator(llm);
+
+        NegotiationParamExtractionException failure = assertThrows(
+                NegotiationParamExtractionException.class,
+                () -> orchestrator.validateProposePromptAndDataFilling(
+                        textOfLength(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS + 1),
+                        PROPOSE.context(),
+                        Map.of("type", "object"),
+                        PROPOSE.template()));
+
+        assertEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, failure.getCode());
+        assertEquals(0, llm.calls, "an oversized prompt must never reach the LLM");
+    }
+
+    /** A validation prompt at exactly the default limit passes the gate and reaches the semantic validation LLM call. */
+    @Test
+    void acceptsValidationPromptAtExactlyTheDefaultLimit() {
+        CountingClient llm = new CountingClient();
+        NegotiationGenerationOrchestrator orchestrator = defaultOrchestrator(llm);
+
+        NegotiationParamExtractionException failure = assertThrows(
+                NegotiationParamExtractionException.class,
+                () -> orchestrator.validateProposePromptAndDataFilling(
+                        textOfLength(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS),
+                        PROPOSE.context(),
+                        Map.of("type", "object"),
+                        PROPOSE.template()));
+
+        assertNotEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, failure.getCode());
+        assertTrue(llm.calls >= 1, "a prompt at exactly the limit must reach the LLM");
+    }
+
+    /** A configured limit below the default drives the rejection: a text one character over it fails fast. */
+    @Test
+    void customLimitDrivesTheRejection() {
+        CountingClient llm = new CountingClient();
+        NegotiationGenerationOrchestrator orchestrator = NegotiationGenerationOrchestratorBuilder.builder()
+                .language(ZH_CN)
+                .llmClient(llm)
+                .maxTextChars(10)
+                .build();
+
+        NegotiationGenerationException failure = assertThrows(
+                NegotiationGenerationException.class,
+                () -> orchestrator.generateProposeFromText("01234567890", PROPOSE.context(), PROPOSE.template()));
+
+        assertEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, failure.getCode());
+        assertEquals(0, llm.calls);
+    }
+
+    /** The builder rejects a non-positive limit as a programming error. */
+    @Test
+    void builderRejectsNonPositiveLimit() {
+        IllegalStateException failure = assertThrows(
+                IllegalStateException.class,
+                () -> NegotiationGenerationOrchestratorBuilder.builder()
+                        .language(ZH_CN)
+                        .maxTextChars(0)
+                        .build());
+
+        assertTrue(
+                failure.getMessage().contains("max text chars"),
+                "the failure must point at the limit but was: " + failure.getMessage());
+    }
+
+    private static NegotiationGenerationOrchestrator defaultOrchestrator(LLMClient llmClient) {
+        return NegotiationGenerationOrchestratorBuilder.builder()
+                .language(ZH_CN)
+                .llmClient(llmClient)
+                .build();
+    }
+
+    private static String textOfLength(int length) {
+        return "x".repeat(length);
+    }
+
+    /**
+     * LLM client stub recording every call and returning an empty payload, so the tests can assert both that a call
+     * happened and that the pipeline fails downstream of the length gate instead of inside it.
+     */
+    private static final class CountingClient implements LLMClient {
+
+        private int calls;
+
+        @Override
+        public LLMResponse structured(
+                List<Map<String, String>> messages,
+                Map<String, Object> jsonSchema,
+                Double temperature,
+                Integer maxTokens) {
+            calls++;
+            return new LLMResponse("", "counting-model", Map.of("prompt_tokens", 1, "completion_tokens", 1), Map.of());
+        }
+    }
+}

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
@@ -70,7 +70,7 @@ public final class A2ATServer {
     /**
      * Checks one processed task prompt for server-side compliance.
      *
-     * <p>An input longer than {@code A2AT_INPUT_TEXT_MAX_CHARS} characters (default 12288) fails fast with the code
+     * <p>An input longer than {@code A2AT_INPUT_TEXT_MAX_CHARS} characters (default 16384) fails fast with the code
      * {@code input_text_too_long} before any LLM call.
      *
      * @param processedPromptText processed task prompt text
@@ -228,7 +228,7 @@ public final class A2ATServer {
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
      *     content misses a required field, {@code negotiation_invalid_input} when the text is blank or the extracted
      *     content contradicts the phase, or {@code input_text_too_long} when the text exceeds the configured maximum
-     *     length (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+     *     length (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public MetadataContent generateNegotiationProposePromptFromText(
             @NonNull String text,
@@ -258,7 +258,7 @@ public final class A2ATServer {
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
      *     content misses a required field, {@code negotiation_invalid_input} when the text is blank or the extracted
      *     conclusion is not {@code Accept}, or {@code input_text_too_long} when the text exceeds the configured
-     *     maximum length (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+     *     maximum length (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public MetadataContent generateNegotiationAcceptPromptFromText(
             @NonNull String text,
@@ -288,7 +288,7 @@ public final class A2ATServer {
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
      *     content misses a required field, {@code negotiation_invalid_input} when the text is blank or the extracted
      *     conclusion is not {@code Reject}, or {@code input_text_too_long} when the text exceeds the configured
-     *     maximum length (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+     *     maximum length (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public MetadataContent generateNegotiationRejectPromptFromText(
             @NonNull String text,
@@ -316,7 +316,7 @@ public final class A2ATServer {
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
      *     content misses the termination reason, {@code negotiation_invalid_input} when the text is blank, or
      *     {@code input_text_too_long} when the text exceeds the configured maximum length
-     *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+     *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public MetadataContent generateNegotiationAbortPromptFromText(
             @NonNull String text,
@@ -405,7 +405,7 @@ public final class A2ATServer {
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing, or
  *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
- *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateProposePromptAndDataFilling(
             @NonNull String prompt,
@@ -439,7 +439,7 @@ public final class A2ATServer {
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing, or
  *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
- *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateAcceptPromptAndDataFilling(
             @NonNull String prompt,
@@ -473,7 +473,7 @@ public final class A2ATServer {
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing, or
  *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
- *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateRejectPromptAndDataFilling(
             @NonNull String prompt,
@@ -506,7 +506,7 @@ public final class A2ATServer {
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code template_not_found} when the semantic validation prompt resources are missing, or
  *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
- *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateAbortPromptAndDataFilling(
             @NonNull String prompt,
@@ -534,7 +534,7 @@ public final class A2ATServer {
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing, or
  *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
- *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateTaskPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
@@ -559,7 +559,7 @@ public final class A2ATServer {
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing, or
  *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
- *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateNotificationPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
@@ -584,7 +584,7 @@ public final class A2ATServer {
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
      *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing, or
  *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
- *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateAuthPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
@@ -70,6 +70,9 @@ public final class A2ATServer {
     /**
      * Checks one processed task prompt for server-side compliance.
      *
+     * <p>An input longer than {@code A2AT_INPUT_TEXT_MAX_CHARS} characters (default 12288) fails fast with the code
+     * {@code input_text_too_long} before any LLM call.
+     *
      * @param processedPromptText processed task prompt text
      * @return compliance result containing only success state or failure details
      */
@@ -223,8 +226,9 @@ public final class A2ATServer {
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
-     *     content misses a required field, or {@code negotiation_invalid_input} when the text is blank or the extracted
-     *     content contradicts the phase
+     *     content misses a required field, {@code negotiation_invalid_input} when the text is blank or the extracted
+     *     content contradicts the phase, or {@code input_text_too_long} when the text exceeds the configured maximum
+     *     length (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public MetadataContent generateNegotiationProposePromptFromText(
             @NonNull String text,
@@ -252,8 +256,9 @@ public final class A2ATServer {
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
-     *     content misses a required field, or {@code negotiation_invalid_input} when the text is blank or the extracted
-     *     conclusion is not {@code Accept}
+     *     content misses a required field, {@code negotiation_invalid_input} when the text is blank or the extracted
+     *     conclusion is not {@code Accept}, or {@code input_text_too_long} when the text exceeds the configured
+     *     maximum length (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public MetadataContent generateNegotiationAcceptPromptFromText(
             @NonNull String text,
@@ -281,8 +286,9 @@ public final class A2ATServer {
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
-     *     content misses a required field, or {@code negotiation_invalid_input} when the text is blank or the extracted
-     *     conclusion is not {@code Reject}
+     *     content misses a required field, {@code negotiation_invalid_input} when the text is blank or the extracted
+     *     conclusion is not {@code Reject}, or {@code input_text_too_long} when the text exceeds the configured
+     *     maximum length (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public MetadataContent generateNegotiationRejectPromptFromText(
             @NonNull String text,
@@ -308,7 +314,9 @@ public final class A2ATServer {
      *     {@code template_not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation_content_extract_failed} or {@code negotiation_llm_infrastructure_error} when the
      *     extraction step fails after exhausting its retries, {@code negotiation_slot_missing} when the extracted
-     *     content misses the termination reason, or {@code negotiation_invalid_input} when the text is blank
+     *     content misses the termination reason, {@code negotiation_invalid_input} when the text is blank, or
+     *     {@code input_text_too_long} when the text exceeds the configured maximum length
+     *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public MetadataContent generateNegotiationAbortPromptFromText(
             @NonNull String text,
@@ -395,7 +403,9 @@ public final class A2ATServer {
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code template_not_found} when the semantic validation prompt resources are missing
+     *     {@code template_not_found} when the semantic validation prompt resources are missing, or
+ *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public FilledParamData validateProposePromptAndDataFilling(
             @NonNull String prompt,
@@ -427,7 +437,9 @@ public final class A2ATServer {
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code template_not_found} when the semantic validation prompt resources are missing
+     *     {@code template_not_found} when the semantic validation prompt resources are missing, or
+ *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public FilledParamData validateAcceptPromptAndDataFilling(
             @NonNull String prompt,
@@ -459,7 +471,9 @@ public final class A2ATServer {
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code template_not_found} when the semantic validation prompt resources are missing
+     *     {@code template_not_found} when the semantic validation prompt resources are missing, or
+ *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public FilledParamData validateRejectPromptAndDataFilling(
             @NonNull String prompt,
@@ -490,7 +504,9 @@ public final class A2ATServer {
      *     {@code negotiation_rule_violation} when the negotiation context violates a rule,
      *     {@code negotiation_semantic_rejected} when the semantic validation rejects the message,
      *     {@code negotiation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code template_not_found} when the semantic validation prompt resources are missing
+     *     {@code template_not_found} when the semantic validation prompt resources are missing, or
+ *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public FilledParamData validateAbortPromptAndDataFilling(
             @NonNull String prompt,
@@ -516,7 +532,9 @@ public final class A2ATServer {
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
      *     {@code validation_semantic_rejected} when the semantic validation rejects the content,
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing
+     *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing, or
+ *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public FilledParamData validateTaskPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
@@ -539,7 +557,9 @@ public final class A2ATServer {
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
      *     {@code validation_semantic_rejected} when the semantic validation rejects the content,
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing
+     *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing, or
+ *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public FilledParamData validateNotificationPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
@@ -562,7 +582,9 @@ public final class A2ATServer {
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
      *     {@code validation_semantic_rejected} when the semantic validation rejects the content,
      *     {@code validation_llm_infrastructure_error} when the semantic step fails after exhausting its retries, or
-     *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing
+     *     {@code validation_prompt_resource_not_found} when the validation prompt resources are missing, or
+ *     {@code input_text_too_long} when the prompt exceeds the configured maximum length
+ *     (A2AT_INPUT_TEXT_MAX_CHARS, default 12288)
      */
     public FilledParamData validateAuthPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilder.java
@@ -21,6 +21,7 @@ import net.openan.a2at.sdk.prompt.resources.model.ScenarioDefinition;
 import net.openan.a2at.sdk.prompt.validation.DefaultContentValidator;
 import net.openan.a2at.sdk.server.compliance.DefaultServerPromptComplianceOrchestrator;
 import net.openan.a2at.sdk.server.metadata.LlmBackedPromptMetadataExtractor;
+import net.openan.a2at.sdk.server.validation.InputLimitedContentValidator;
 import net.openan.a2at.sdk.server.validation.LlmBackedPromptSemanticValidator;
 import org.jspecify.annotations.Nullable;
 
@@ -132,8 +133,8 @@ public final class DefaultA2ATServerBuilder {
                         slotSchemaLoader,
                         new DefaultStructuredPromptSlotValueExtractor(
                                 client, slotSchemaLoader, slotSystemPrompt, slotUserPrompt)),
-                new LlmBackedPromptSemanticValidator(
-                        client, slotSchemaLoader, semanticSystemPrompt, semanticUserPrompt));
+                new LlmBackedPromptSemanticValidator(client, slotSchemaLoader, semanticSystemPrompt, semanticUserPrompt),
+                config.inputLimits().maxTextChars());
         return promptComplianceOrchestrator;
     }
 
@@ -221,12 +222,14 @@ public final class DefaultA2ATServerBuilder {
         require(config, "Unified SDK config must be configured.");
         requireSupportedConfig();
         require(envPath, "Unified SDK env path must be configured.");
-        return new DefaultContentValidator(
-                extensionName,
-                config.prompt().language(),
-                config.llm().maxAttempts(),
-                llmClient(),
-                promptResourceAccess().templateLoader());
+        return new InputLimitedContentValidator(
+                new DefaultContentValidator(
+                        extensionName,
+                        config.prompt().language(),
+                        config.llm().maxAttempts(),
+                        llmClient(),
+                        promptResourceAccess().templateLoader()),
+                config.inputLimits().maxTextChars());
     }
 
     private static void require(Object value, String message) {

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/compliance/DefaultServerPromptComplianceOrchestrator.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/compliance/DefaultServerPromptComplianceOrchestrator.java
@@ -1,5 +1,7 @@
 package net.openan.a2at.sdk.server.compliance;
 
+import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
 import net.openan.a2at.sdk.server.metadata.ServerPromptMetadataExtractor;
 import net.openan.a2at.sdk.server.model.ProcessedPromptMetadata;
 import net.openan.a2at.sdk.server.model.PromptComplianceFailure;
@@ -14,9 +16,14 @@ import net.openan.a2at.sdk.server.validation.ServerPromptSemanticValidator;
  */
 public final class DefaultServerPromptComplianceOrchestrator implements ServerPromptComplianceOrchestrator {
 
+    /** Compliance stage reported when the input gate rejects an oversized prompt before any LLM call. */
+    private static final String INPUT_GATE_STAGE = "input_gate";
+
     private final ServerPromptMetadataExtractor metadataExtractor;
 
     private final ServerPromptSemanticValidator semanticValidator;
+
+    private final int maxTextChars;
 
     /**
      * Creates a compliance orchestrator.
@@ -26,12 +33,35 @@ public final class DefaultServerPromptComplianceOrchestrator implements ServerPr
      */
     public DefaultServerPromptComplianceOrchestrator(
             ServerPromptMetadataExtractor metadataExtractor, ServerPromptSemanticValidator semanticValidator) {
+        this(metadataExtractor, semanticValidator, InputLimitConfig.DEFAULT_MAX_TEXT_CHARS);
+    }
+
+    /**
+     * Creates a compliance orchestrator with an explicit free-text input limit.
+     *
+     * @param metadataExtractor prompt metadata extractor
+     * @param semanticValidator semantic validator
+     * @param maxTextChars maximum length in characters accepted for the processed prompt text
+     */
+    public DefaultServerPromptComplianceOrchestrator(
+            ServerPromptMetadataExtractor metadataExtractor,
+            ServerPromptSemanticValidator semanticValidator,
+            int maxTextChars) {
         this.metadataExtractor = metadataExtractor;
         this.semanticValidator = semanticValidator;
+        this.maxTextChars = maxTextChars;
     }
 
     @Override
     public PromptComplianceResult checkTaskPrompt(String processedPromptText) {
+        if (InputLimitConfig.isTooLong(processedPromptText, maxTextChars)) {
+            return new PromptComplianceResult(
+                    false,
+                    new PromptComplianceFailure(
+                            A2ATErrorCodes.INPUT_TEXT_TOO_LONG,
+                            InputLimitConfig.violationMessage(processedPromptText, maxTextChars),
+                            INPUT_GATE_STAGE));
+        }
         try {
             ProcessedPromptMetadata metadata = metadataExtractor.extract(processedPromptText);
             semanticValidator.validate(processedPromptText, metadata);

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/validation/InputLimitedContentValidator.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/validation/InputLimitedContentValidator.java
@@ -1,0 +1,46 @@
+package net.openan.a2at.sdk.server.validation;
+
+import java.util.Map;
+import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
+import net.openan.a2at.sdk.core.model.FilledParamData;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
+import net.openan.a2at.sdk.core.model.TemplateUri;
+import net.openan.a2at.sdk.core.validation.ContentValidationException;
+import net.openan.a2at.sdk.core.validation.ContentValidator;
+
+/**
+ * Free-text input gate wrapped around one delegated content validator.
+ *
+ * <p>The gate rejects an oversized prompt with the code {@code input_text_too_long} before the delegated pipeline
+ * starts, so no LLM call is made for an input that could not fit the LLM context anyway. The limit is configured
+ * through {@code A2AT_INPUT_TEXT_MAX_CHARS} and defaults to {@link InputLimitConfig#DEFAULT_MAX_TEXT_CHARS}
+ * characters.
+ *
+ * @since 2026-08
+ */
+public final class InputLimitedContentValidator implements ContentValidator {
+
+    private final ContentValidator delegate;
+
+    private final int maxTextChars;
+
+    /**
+     * Creates one gating validator around the given delegate.
+     *
+     * @param delegate content validator carrying the actual validation pipeline
+     * @param maxTextChars maximum length in characters accepted for the prompt text
+     */
+    public InputLimitedContentValidator(ContentValidator delegate, int maxTextChars) {
+        this.delegate = delegate;
+        this.maxTextChars = maxTextChars;
+    }
+
+    @Override
+    public FilledParamData validate(String prompt, Map<String, Object> schema, TemplateUri templateUri) {
+        if (InputLimitConfig.isTooLong(prompt, maxTextChars)) {
+            throw new ContentValidationException(
+                    A2ATErrorCodes.INPUT_TEXT_TOO_LONG, InputLimitConfig.violationMessage(prompt, maxTextChars));
+        }
+        return delegate.validate(prompt, schema, templateUri);
+    }
+}

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/InputTextLengthLimitTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/InputTextLengthLimitTest.java
@@ -59,7 +59,7 @@ class InputTextLengthLimitTest {
     @Test
     void checkTaskPromptDoesNotFailForLengthWhenInputIsExactlyAtDefaultLimit() throws IOException {
         A2ATServer server = new A2ATServer(writeEnv(null));
-        String boundaryInput = "a".repeat(12288);
+        String boundaryInput = "a".repeat(16384);
 
         PromptComplianceResult result = server.checkTaskPrompt(boundaryInput);
 

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/InputTextLengthLimitTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/InputTextLengthLimitTest.java
@@ -1,0 +1,144 @@
+package net.openan.a2at.sdk.server.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
+import net.openan.a2at.sdk.core.model.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.ContentValidationException;
+import net.openan.a2at.sdk.llm.LLMClient;
+import net.openan.a2at.sdk.llm.LLMClientConfig;
+import net.openan.a2at.sdk.llm.LLMClientFactory;
+import net.openan.a2at.sdk.llm.LLMResponse;
+import net.openan.a2at.sdk.server.A2ATServer;
+import net.openan.a2at.sdk.server.model.PromptComplianceResult;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InputTextLengthLimitTest {
+
+    private static final String TEST_MOCK_PROVIDER = "test-input-limit-mock";
+
+    @BeforeAll
+    static void registerMockProvider() {
+        if (!LLMClientFactory.availableProviders().contains(TEST_MOCK_PROVIDER)) {
+            LLMClientFactory.register(TEST_MOCK_PROVIDER, CountingClient.class);
+        }
+    }
+
+    @BeforeEach
+    void resetCounter() {
+        CountingClient.resetCallCount();
+    }
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void checkTaskPromptFailsFastWithoutLlmCallWhenInputExceedsConfiguredLimit() throws IOException {
+        A2ATServer server = new A2ATServer(writeEnv("10"));
+        String oversizedInput = "a".repeat(11);
+
+        PromptComplianceResult result = server.checkTaskPrompt(oversizedInput);
+
+        assertEquals(false, result.success());
+        assertEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, result.failure().code());
+        assertEquals("input_gate", result.failure().stage());
+        assertEquals(0, CountingClient.callCount(), "No LLM call may happen for an oversized input");
+    }
+
+    @Test
+    void checkTaskPromptDoesNotFailForLengthWhenInputIsExactlyAtDefaultLimit() throws IOException {
+        A2ATServer server = new A2ATServer(writeEnv(null));
+        String boundaryInput = "a".repeat(12288);
+
+        PromptComplianceResult result = server.checkTaskPrompt(boundaryInput);
+
+        assertNotEquals(
+                A2ATErrorCodes.INPUT_TEXT_TOO_LONG,
+                result.success() ? null : result.failure().code(),
+                "An input exactly at the default limit must not be rejected for its length");
+    }
+
+    @Test
+    void validateContentPromptAndDataFillingFailsFastWithoutLlmCallWhenPromptExceedsConfiguredLimit()
+            throws IOException {
+        A2ATServer server = new A2ATServer(writeEnv("10"));
+        String oversizedPrompt = "a".repeat(11);
+        Map<String, Object> schema = Map.of();
+
+        ContentValidationException taskError = assertThrows(
+                ContentValidationException.class,
+                () -> server.validateTaskPromptAndDataFilling(oversizedPrompt, schema, StandardTemplates.ENERGY_SAVING));
+        ContentValidationException notificationError = assertThrows(
+                ContentValidationException.class,
+                () -> server.validateNotificationPromptAndDataFilling(
+                        oversizedPrompt, schema, StandardTemplates.SUBSCRIBE_INCIDENT));
+        ContentValidationException authError = assertThrows(
+                ContentValidationException.class,
+                () -> server.validateAuthPromptAndDataFilling(
+                        oversizedPrompt, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT));
+
+        assertEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, taskError.getCode());
+        assertEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, notificationError.getCode());
+        assertEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, authError.getCode());
+        assertEquals(0, CountingClient.callCount(), "No LLM call may happen for an oversized prompt");
+    }
+
+    private Path writeEnv(String maxTextChars) throws IOException {
+        Path envFile = tempDir.resolve("server.env");
+        String limitEntry = maxTextChars == null ? "" : "A2AT_INPUT_TEXT_MAX_CHARS=" + maxTextChars + "\n";
+        Files.writeString(
+                envFile,
+                """
+                A2AT_LANGUAGE=zh-CN
+                A2AT_PROMPT_SOURCE_TYPE=classpath
+                A2AT_PROMPT_RESOURCE_LOCAL_ROOT_DIR=
+                A2AT_LLM_PROVIDER=test-input-limit-mock
+                A2AT_LLM_MODEL=example-model
+                A2AT_LLM_BASE_URL=https://llm.example.test/v1
+                A2AT_LLM_API_KEY=test-key
+                A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
+                """
+                + limitEntry);
+        return envFile;
+    }
+
+    public static final class CountingClient implements LLMClient {
+
+        private static final AtomicInteger CALL_COUNT = new AtomicInteger(0);
+
+        private final LLMClientConfig config;
+
+        public CountingClient(LLMClientConfig config) {
+            this.config = config;
+        }
+
+        static void resetCallCount() {
+            CALL_COUNT.set(0);
+        }
+
+        static int callCount() {
+            return CALL_COUNT.get();
+        }
+
+        @Override
+        public LLMResponse structured(
+                List<Map<String, String>> messages,
+                Map<String, Object> jsonSchema,
+                Double temperature,
+                Integer maxTokens) {
+            CALL_COUNT.incrementAndGet();
+            return new LLMResponse("{}", config.model(), Map.of(), Map.of());
+        }
+    }
+}

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilderTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/assembly/DefaultA2ATServerBuilderTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.openan.a2at.sdk.core.model.A2ATConfig;
+import net.openan.a2at.sdk.core.model.InputLimitConfig;
 import net.openan.a2at.sdk.core.model.LlmConfig;
 import net.openan.a2at.sdk.core.model.NegotiationConfig;
 import net.openan.a2at.sdk.core.model.PromptComplianceConfig;
@@ -99,6 +100,7 @@ class DefaultA2ATServerBuilderTest {
                         null,
                         3,
                         List.of()),
+                new InputLimitConfig(InputLimitConfig.DEFAULT_MAX_TEXT_CHARS),
                 new NegotiationConfig("in_memory"),
                 new PromptComplianceConfig(false));
 

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/compliance/DefaultServerPromptComplianceOrchestratorTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/compliance/DefaultServerPromptComplianceOrchestratorTest.java
@@ -66,6 +66,39 @@ class DefaultServerPromptComplianceOrchestratorTest {
         assertEquals("slot_validation", result.failure().stage());
     }
 
+    @Test
+    void checkTaskPromptReturnsInputTooLongFailureWithoutRunningThePipelineWhenOverLimit() {
+        RecordingPromptMetadataExtractor extractor = new RecordingPromptMetadataExtractor(
+                new ProcessedPromptMetadata("ran-energy-saving", "en-US", "Site: {site}", Map.of("site", "Site A")));
+        RecordingPromptSemanticValidator validator = new RecordingPromptSemanticValidator(null);
+        DefaultServerPromptComplianceOrchestrator orchestrator =
+                new DefaultServerPromptComplianceOrchestrator(extractor, validator, 5);
+        String oversizedInput = "a".repeat(6);
+
+        PromptComplianceResult result = orchestrator.checkTaskPrompt(oversizedInput);
+
+        assertEquals(false, result.success());
+        assertEquals("input_text_too_long", result.failure().code());
+        assertEquals("input_gate", result.failure().stage());
+        assertEquals(null, extractor.lastProcessedPromptText, "Extractor must not run for an oversized input");
+        assertEquals(null, validator.lastProcessedPromptText, "Validator must not run for an oversized input");
+    }
+
+    @Test
+    void checkTaskPromptRunsThePipelineWhenInputIsExactlyAtLimit() {
+        RecordingPromptMetadataExtractor extractor = new RecordingPromptMetadataExtractor(
+                new ProcessedPromptMetadata("ran-energy-saving", "en-US", "Site: {site}", Map.of("site", "Site A")));
+        RecordingPromptSemanticValidator validator = new RecordingPromptSemanticValidator(null);
+        DefaultServerPromptComplianceOrchestrator orchestrator =
+                new DefaultServerPromptComplianceOrchestrator(extractor, validator, 5);
+        String boundaryInput = "a".repeat(5);
+
+        PromptComplianceResult result = orchestrator.checkTaskPrompt(boundaryInput);
+
+        assertTrue(result.success());
+        assertEquals(boundaryInput, extractor.lastProcessedPromptText);
+    }
+
     private static final class RecordingPromptMetadataExtractor implements ServerPromptMetadataExtractor {
         private final ProcessedPromptMetadata metadata;
         private final PromptComplianceCheckException exception;

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/validation/InputLimitedContentValidatorTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/validation/InputLimitedContentValidatorTest.java
@@ -1,0 +1,52 @@
+package net.openan.a2at.sdk.server.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
+import net.openan.a2at.sdk.core.model.FilledParamData;
+import net.openan.a2at.sdk.core.model.StandardTemplates;
+import net.openan.a2at.sdk.core.validation.ContentValidationException;
+import net.openan.a2at.sdk.core.validation.ContentValidator;
+import org.junit.jupiter.api.Test;
+
+class InputLimitedContentValidatorTest {
+
+    @Test
+    void validateThrowsInputTooLongWithoutDelegationWhenPromptExceedsLimit() {
+        RecordingContentValidator delegate = new RecordingContentValidator();
+        InputLimitedContentValidator validator = new InputLimitedContentValidator(delegate, 5);
+        String oversizedPrompt = "a".repeat(6);
+
+        ContentValidationException error = assertThrows(
+                ContentValidationException.class,
+                () -> validator.validate(oversizedPrompt, Map.of(), StandardTemplates.ENERGY_SAVING));
+
+        assertEquals(A2ATErrorCodes.INPUT_TEXT_TOO_LONG, error.getCode());
+        assertEquals(null, delegate.lastPrompt, "Delegate must not run for an oversized prompt");
+    }
+
+    @Test
+    void validateDelegatesWhenPromptIsExactlyAtLimit() {
+        RecordingContentValidator delegate = new RecordingContentValidator();
+        InputLimitedContentValidator validator = new InputLimitedContentValidator(delegate, 5);
+        String boundaryPrompt = "a".repeat(5);
+
+        FilledParamData result = validator.validate(boundaryPrompt, Map.of(), StandardTemplates.ENERGY_SAVING);
+
+        assertEquals(boundaryPrompt, delegate.lastPrompt);
+        assertEquals(FilledParamData.class, result.getClass());
+    }
+
+    private static final class RecordingContentValidator implements ContentValidator {
+
+        private String lastPrompt;
+
+        @Override
+        public FilledParamData validate(String prompt, Map<String, Object> schema, net.openan.a2at.sdk.core.model.TemplateUri templateUri) {
+            this.lastPrompt = prompt;
+            return new FilledParamData(Map.of());
+        }
+    }
+}

--- a/docs/en/developer_guide.md
+++ b/docs/en/developer_guide.md
@@ -327,6 +327,7 @@ A2AT_LLM_MODEL=deepseek-chat
 A2AT_LLM_API_KEY={your_llm_api_key}
 A2AT_LLM_BASE_URL=https://api.deepseek.com
 A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
+A2AT_INPUT_TEXT_MAX_CHARS=16384
 ```
 
 > `A2AT_LLM_API_KEY` is the key used to **call the external large model**. Keep it safe.
@@ -334,6 +335,8 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
 > The SDK connects to external large models through OpenAI-compatible interfaces. `A2AT_LLM_PROVIDER` currently supports only `openai`; when connecting to OpenAI-compatible services such as DeepSeek, specify the service address with `A2AT_LLM_BASE_URL` and the model name with `A2AT_LLM_MODEL`.
 >
 > The prompt resource source is controlled by `A2AT_PROMPT_SOURCE_TYPE`: the default `classpath` loads the resources bundled in the `a2a-t-resources` jar; when set to `local_file`, specify the local resource root directory with `A2AT_PROMPT_RESOURCE_LOCAL_ROOT_DIR` (relative paths are resolved against the directory of the `.env` file).
+>
+> Free-text inputs are length-guarded before any LLM call: every facade entry point that accepts a natural-language `String` (the `FromText` generation methods, `generateTaskPrompt` with a text input, and the prompt-validation entry points such as `checkTaskPrompt` and `validate*PromptAndDataFilling`) rejects an input longer than `A2AT_INPUT_TEXT_MAX_CHARS` characters (`String.length()`) with the error code `input_text_too_long`, so oversized inputs fail fast instead of overflowing the LLM context. The key defaults to `16384` (16×1024); invalid or non-positive values fall back to the default with a warning log. The guard never truncates: the caller keeps full control over how to shorten the input. Structured (`Map`) inputs are not checked.
 
 #### Step3 Initialize the AgentCard
 

--- a/docs/zh/开发指南.md
+++ b/docs/zh/开发指南.md
@@ -327,6 +327,7 @@ A2AT_LLM_MODEL=deepseek-chat
 A2AT_LLM_API_KEY={your_llm_api_key}
 A2AT_LLM_BASE_URL=https://api.deepseek.com
 A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
+A2AT_INPUT_TEXT_MAX_CHARS=16384
 ```
 
 > `A2AT_LLM_API_KEY` 是**调用外部大模型**使用的密钥，请妥善保存
@@ -334,6 +335,8 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
 > SDK 通过 OpenAI-compatible 接入外部大模型，`A2AT_LLM_PROVIDER` 当前仅支持 `openai`；接入 DeepSeek 等 OpenAI 兼容服务时，通过 `A2AT_LLM_BASE_URL` 指定服务地址、`A2AT_LLM_MODEL` 指定模型名。
 >
 > 提示词资源来源由 `A2AT_PROMPT_SOURCE_TYPE` 控制：默认 `classpath` 从 `a2a-t-resources` jar 内置资源加载；配置为 `local_file` 时，通过 `A2AT_PROMPT_RESOURCE_LOCAL_ROOT_DIR` 指定本地资源根目录（相对路径相对于 `.env` 文件所在目录解析）。
+>
+> 自由文本输入在任何 LLM 调用之前都会做长度防护：所有接受自然语言 `String` 的 Facade 入口（`FromText` 生成类方法、文本形式的 `generateTaskPrompt`，以及 `checkTaskPrompt`、`validate*PromptAndDataFilling` 等校验入口）在输入超过 `A2AT_INPUT_TEXT_MAX_CHARS` 字符（按 `String.length()` 计）时，会以错误码 `input_text_too_long` 快速失败，避免超长输入撑爆 LLM 上下文。该键默认 `16384`（16×1024）；非法或非正值回退默认值并输出警告日志。防护不做截断：是否以及如何缩短输入完全由调用方决定。结构化（`Map`）输入不做该检查。
 
 #### Step3 初始化AgentCard
 

--- a/env.example
+++ b/env.example
@@ -14,7 +14,7 @@ A2AT_PROMPT_COMPLIANCE_ENABLED=false
 # Maximum length in characters (String.length()) accepted for free-text inputs (FromText generation and
 # prompt validation entry points) before they reach an LLM step; oversized inputs fail fast with the
 # error code input_text_too_long instead of overflowing the LLM context.
-A2AT_INPUT_TEXT_MAX_CHARS=12288
+A2AT_INPUT_TEXT_MAX_CHARS=16384
 
 # LLM runtime
 # Selects the LLM provider used by the shared client.

--- a/env.example
+++ b/env.example
@@ -10,6 +10,12 @@ A2AT_PROMPT_RESOURCE_LOCAL_ROOT_DIR=
 # Enables or disables prompt compliance checks.
 A2AT_PROMPT_COMPLIANCE_ENABLED=false
 
+# Input limits
+# Maximum length in characters (String.length()) accepted for free-text inputs (FromText generation and
+# prompt validation entry points) before they reach an LLM step; oversized inputs fail fast with the
+# error code input_text_too_long instead of overflowing the LLM context.
+A2AT_INPUT_TEXT_MAX_CHARS=12288
+
 # LLM runtime
 # Selects the LLM provider used by the shared client.
 A2AT_LLM_PROVIDER=


### PR DESCRIPTION
## Description


### Summary

Adds a configurable length limit for every facade API that accepts a free-text `String` and forwards it to an LLM step. Oversized inputs now fail fast with the error code `input_text_too_long` **before any LLM call**, instead of overflowing the LLM context.

- **Limit**: `A2AT_INPUT_TEXT_MAX_CHARS` env key, default `16384` (16×1024), measured by `String.length()`. Invalid or non-positive values fall back to the default with a warning log. No truncation — the caller keeps full control over shortening.
- **Covered entry points**:
  - Client: `generateTaskPrompt` (text branch only; `Map` inputs are not checked), `generateTaskPromptFromText`, `generateAuthPromptFromText`, `generateNotificationPromptFromText`
  - Both facades: `generateNegotiation{Propose|Accept|Reject|Abort}PromptFromText`, `validate*PromptAndDataFilling`
  - Server: `checkTaskPrompt`, `validate{Task|Notification|Auth}PromptAndDataFilling`
- **Error channels follow each API's existing convention**: `PromptGenerationException` / `NegotiationGenerationException` / `NegotiationParamExtractionException` / `ContentValidationException` with the new code `input_text_too_long`; result-shaped APIs (`generateTaskPrompt`, `checkTaskPrompt`) return their existing failure value objects carrying the same code.

### Key changes

| Module | Change |
|--|--|
| `a2a-t-core` | New `InputLimitConfig` (record + `fromMap` + `isTooLong`/`violationMessage` helpers, default 16384), `A2ATConfigKeys.Input.MAX_TEXT_CHARS`, `A2ATConfig.inputLimits()` component, `A2ATErrorCodes.INPUT_TEXT_TOO_LONG` |
| `a2a-t-client` | `maxTextChars` threaded through `ClientPromptGenerationOrchestratorBuilder`/`DefaultClientPromptGenerationOrchestrator`; length gate at the top of the shared FromText path and the String branch of `generateTaskPrompt` |
| `a2a-t-negotiation` | `maxTextChars` on `NegotiationGenerationOrchestratorBuilder`; gates in `generateFromText` (before template load/LLM) and `validatePromptAndDataFilling`; wired via `NegotiationContentService.buildOrchestrator(config, …)` (signature unchanged) |
| `a2a-t-server` | `maxTextChars` on the compliance orchestrator (first step of `checkTaskPrompt`); new `InputLimitedContentValidator` decorator gates the three content-validation entry points before delegation |
| Docs/config | `env.example` entry + bilingual developer guide (§1.5) notes |

### Tests

New boundary tests (exactly at limit passes, limit+1 rejected, LLM zero-interaction asserted, env override effective, Map inputs unchecked) per module:

- `a2a-t-core`: `InputLimitConfigTest` (8), error-code registry sentinel updated to 21 constants
- `a2a-t-negotiation`: `InputTextLengthLimitTest` (6) + contract registry pin
- `a2a-t-client`: +7 across orchestrator/facade tests
- `a2a-t-server`: +7 across `DefaultServerPromptComplianceOrchestratorTest`, `InputLimitedContentValidatorTest`, facade-level `InputTextLengthLimitTest`

Full reactor: `mvn -B clean test` → **2288 tests, 0 failures, 0 errors**.

### Notes for reviewers

- The deprecated negotiation demo runtime (`startNegotiation`/`receiveNegotiation`/`continueNegotiation`) is intentionally not guarded (no LLM involvement, scheduled for removal).
- `A2AT_PROMPT_COMPLIANCE_ENABLED` has no short-circuit in the server module; the new gate is simply the first step of `checkTaskPrompt`.
- Structured (`Map`/`FromData`) inputs are out of scope by design.


## Related Issue(s)

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Type of Change

<!-- Check all that apply. -->

- [] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Other (describe above)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here. -->
