### PR TITLE
refactor(sample): decouple negotiation validation schemas

### DIFF
--- a/a2a-t-sample/README.zh-CN.md
+++ b/a2a-t-sample/README.zh-CN.md
@@ -140,6 +140,8 @@ java @a2a-t-sample/target/fromtext.javaargs.txt /path/to/.env
 
 **LLM 调用证据**：每个步骤还记录 `llm_calls`——该步骤内每次大模型调用的完整请求（system + user prompt 全文、JSON schema、temperature、max_tokens）与响应（content、model、usage、耗时），调用失败时也记录请求与错误。用例失败时可直接从报告看到模型实际收到的 prompt（含槽位描述、值约束、schema 注入后的最终形态），据此反向定位是哪段提示词/约束导致了误判并调优。
 
+**校验参数 schema**：专线投诉协商样例的三个校验接口使用独立的业务无关参数 schema，定义在 `shared/InformationNegotiationSchemas`：`propose` 提取 `items[{name, requirement}]` 及可选的 `relationship`，`accept` 提取 `items[{name, value}]`，`reject` 提取 `items[{name, reason}]`。schema 只约束提取结果的结构，具体信息项名称、要求、值和原因均从协商报文中提取，不包含场景固定字段或枚举值。
+
 **协议约定**（两条常见问题）：
 
 1. **服务端发起协商后，客户端是否还需调用 validate？** 是。SDK 在 client/server 两个门面上提供对称的 `validate*PromptAndDataFilling` API：发送方出站自检（步骤 4），接收方入站校验（步骤 5/7）。客户端收到 propose 后应调 `validateProposePromptAndDataFilling` 提取需要补充的槽位清单，再据此补槽。

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/shared/InformationNegotiationSchemas.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/shared/InformationNegotiationSchemas.java
@@ -5,7 +5,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/** Scenario-specific caller schemas for the private-line complaint information negotiation sample. */
+/**
+ * Business-neutral, phase-specific caller schemas for information-negotiation validation.
+ *
+ * <p>The three validation APIs intentionally use independent parameter contracts. The contracts describe the
+ * shape of the extracted result while the information-item names and values come from the negotiation message.
+ */
 public final class InformationNegotiationSchemas {
 
     private static final Map<String, Object> PROPOSE = createProposeSchema();
@@ -32,41 +37,63 @@ public final class InformationNegotiationSchemas {
     private static Map<String, Object> createProposeSchema() {
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put(
-                "access_port_name",
-                stringSchema("Requested access-port information, including the accepted physical or logical port format"));
+                "items",
+                itemArraySchema(
+                        itemSchema(
+                                "requirement",
+                                "Meaning, format, constraint, or example requested for the information item"),
+                        "Requested information items and their requirements"));
         properties.put(
-                "complaint_category",
-                stringSchema("Requested complaint category and its allowed private-line complaint values"));
-        return objectSchema(properties, List.of("access_port_name", "complaint_category"));
+                "relationship",
+                nullableStringSchema("Relationship among requested information items, or null when unspecified"));
+        return objectSchema(properties, List.of("items"));
     }
 
     private static Map<String, Object> createAcceptSchema() {
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put(
-                "access_port_name",
-                stringSchema("Physical or logical access-port name supplied for private-line diagnosis"));
-        properties.put(
-                "complaint_category",
-                Map.of(
-                        "type", "string",
-                        "description", "Private-line complaint category",
-                        "enum", List.of("专线中断", "专线质差")));
-        return objectSchema(properties, List.of("access_port_name", "complaint_category"));
+                "items",
+                itemArraySchema(
+                        itemSchema("value", "Value supplied for the information item"),
+                        "Information items and values supplied by the accepting party"));
+        return objectSchema(properties, List.of("items"));
     }
 
     private static Map<String, Object> createRejectSchema() {
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put(
-                "access_port_name",
-                stringSchema("Reason why the access-port name cannot be supplied"));
-        properties.put(
-                "complaint_category",
-                stringSchema("Reason why the complaint category cannot be supplied"));
-        return objectSchema(properties, List.of("access_port_name", "complaint_category"));
+                "items",
+                itemArraySchema(
+                        itemSchema("reason", "Reason why the information item cannot be supplied"),
+                        "Information items that cannot be supplied and their reasons"));
+        return objectSchema(properties, List.of("items"));
+    }
+
+    private static Map<String, Object> itemArraySchema(Map<String, Object> itemSchema, String description) {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "array");
+        schema.put("items", itemSchema);
+        schema.put("minItems", 1);
+        schema.put("description", description);
+        return Collections.unmodifiableMap(schema);
+    }
+
+    private static Map<String, Object> itemSchema(String valueName, String valueDescription) {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("name", stringSchema("Name of the information item"));
+        properties.put(valueName, nullableStringSchema(valueDescription));
+        return objectSchema(properties, List.of("name", valueName));
     }
 
     private static Map<String, Object> stringSchema(String description) {
         return Map.of("type", "string", "description", description);
+    }
+
+    private static Map<String, Object> nullableStringSchema(String description) {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", List.of("string", "null"));
+        schema.put("description", description);
+        return Collections.unmodifiableMap(schema);
     }
 
     private static Map<String, Object> objectSchema(Map<String, Object> properties, List<String> required) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/shared/mock/NegotiationMockLLMClient.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/shared/mock/NegotiationMockLLMClient.java
@@ -32,18 +32,18 @@ public final class NegotiationMockLLMClient implements LLMClient {
             """;
 
     private static final String PROPOSE_PARAMS = """
-            {"access_port_name":"物理端口或逻辑端口名称",
-            "complaint_category":"专线中断或专线质差"}
+            {"items":[{"name":"接入端口名称","requirement":"物理端口或逻辑端口名称"},
+            {"name":"投诉分类","requirement":"专线中断或专线质差"}],"relationship":null}
             """;
 
     private static final String ACCEPT_PARAMS = """
-            {"access_port_name":"P781-珠江新城-PTN7900-23-TPA1EG24-17(cvlan=100)",
-            "complaint_category":"专线质差"}
+            {"items":[{"name":"接入端口名称","value":"P781-珠江新城-PTN7900-23-TPA1EG24-17(cvlan=100)"},
+            {"name":"投诉分类","value":"专线质差"}]}
             """;
 
     private static final String REJECT_PARAMS = """
-            {"access_port_name":"当前账号没有资源系统查询权限",
-            "complaint_category":"当前账号没有资源系统查询权限"}
+            {"items":[{"name":"接入端口名称","reason":"当前账号没有资源系统查询权限"},
+            {"name":"投诉分类","reason":"当前账号没有资源系统查询权限"}]}
             """;
 
     public NegotiationMockLLMClient(LLMClientConfig config) {

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/private_line_complaint/negotiation/InformationNegotiationSchemasTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/private_line_complaint/negotiation/InformationNegotiationSchemasTest.java
@@ -2,53 +2,101 @@ package net.openan.a2at.sample.private_line_complaint.negotiation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import net.openan.a2at.sample.private_line_complaint.negotiation.shared.InformationNegotiationSchemas;
 import org.junit.jupiter.api.Test;
 
 class InformationNegotiationSchemasTest {
 
     @Test
-    void proposeSchemaDefinesRequestedComplaintInformation() {
+    void proposeSchemaDefinesRequestedItemsAndTheirRequirements() {
         Map<String, Object> schema = InformationNegotiationSchemas.propose();
         Map<?, ?> properties = propertiesOf(schema);
 
-        assertEquals("object", schema.get("type"));
-        assertFalse((Boolean) schema.get("additionalProperties"));
-        assertEquals(List.of("access_port_name", "complaint_category"), schema.get("required"));
-        assertStringProperty(properties, "access_port_name");
-        assertStringProperty(properties, "complaint_category");
-        assertThrows(UnsupportedOperationException.class, () -> schema.put("unexpected", true));
+        assertBaseSchema(schema, List.of("items"));
+        assertEquals(Set.of("items", "relationship"), properties.keySet());
+        assertItemArray(properties.get("items"), "requirement");
+        assertNullableString((Map<?, ?>) properties.get("relationship"));
+        assertFalse(properties.containsKey("access_port_name"));
+        assertFalse(properties.containsKey("complaint_category"));
     }
 
     @Test
-    void acceptSchemaDefinesSuppliedComplaintInformation() {
+    void acceptSchemaDefinesItemsAndSuppliedValues() {
         Map<String, Object> schema = InformationNegotiationSchemas.accept();
         Map<?, ?> properties = propertiesOf(schema);
 
-        assertEquals(List.of("access_port_name", "complaint_category"), schema.get("required"));
-        assertStringProperty(properties, "access_port_name");
-        assertEquals(List.of("专线中断", "专线质差"), ((Map<?, ?>) properties.get("complaint_category")).get("enum"));
+        assertBaseSchema(schema, List.of("items"));
+        assertEquals(Set.of("items"), properties.keySet());
+        assertItemArray(properties.get("items"), "value");
     }
 
     @Test
-    void rejectSchemaRequiresReasonForEachRequestedItem() {
+    void rejectSchemaDefinesItemsAndRejectionReasons() {
         Map<String, Object> schema = InformationNegotiationSchemas.reject();
         Map<?, ?> properties = propertiesOf(schema);
 
-        assertEquals(List.of("access_port_name", "complaint_category"), schema.get("required"));
-        assertStringProperty(properties, "access_port_name");
-        assertStringProperty(properties, "complaint_category");
+        assertBaseSchema(schema, List.of("items"));
+        assertEquals(Set.of("items"), properties.keySet());
+        assertItemArray(properties.get("items"), "reason");
     }
 
-    private static void assertStringProperty(Map<?, ?> properties, String name) {
-        assertEquals("string", ((Map<?, ?>) properties.get(name)).get("type"));
+    @Test
+    void phaseSchemasAreIndependentAndDeeplyImmutable() {
+        Map<String, Object> propose = InformationNegotiationSchemas.propose();
+        Map<String, Object> accept = InformationNegotiationSchemas.accept();
+        Map<String, Object> reject = InformationNegotiationSchemas.reject();
+
+        assertNotSame(propose, accept);
+        assertNotSame(propose, reject);
+        assertNotSame(accept, reject);
+        assertFalse(propose.equals(accept));
+        assertFalse(propose.equals(reject));
+        assertFalse(accept.equals(reject));
+
+        assertImmutable(propose);
+        assertImmutable(propertiesOf(propose));
+        Map<?, ?> proposeItems = (Map<?, ?>) propertiesOf(propose).get("items");
+        assertImmutable(proposeItems);
+        assertImmutable((Map<?, ?>) proposeItems.get("items"));
+        assertImmutable(propertiesOf((Map<?, ?>) proposeItems.get("items")));
+    }
+
+    private static void assertBaseSchema(Map<?, ?> schema, List<String> required) {
+        assertEquals("object", schema.get("type"));
+        assertEquals(false, schema.get("additionalProperties"));
+        assertEquals(required, schema.get("required"));
+    }
+
+    private static void assertItemArray(Object rawArray, String valueName) {
+        Map<?, ?> array = (Map<?, ?>) rawArray;
+        assertEquals("array", array.get("type"));
+        assertEquals(1, array.get("minItems"));
+        assertEquals("object", ((Map<?, ?>) array.get("items")).get("type"));
+
+        Map<?, ?> itemSchema = (Map<?, ?>) array.get("items");
+        assertEquals(false, itemSchema.get("additionalProperties"));
+        assertEquals(List.of("name", valueName), itemSchema.get("required"));
+        assertEquals(Set.of("name", valueName), propertiesOf(itemSchema).keySet());
+        assertEquals("string", ((Map<?, ?>) propertiesOf(itemSchema).get("name")).get("type"));
+        assertNullableString((Map<?, ?>) propertiesOf(itemSchema).get(valueName));
+    }
+
+    private static void assertNullableString(Map<?, ?> schema) {
+        assertEquals(List.of("string", "null"), schema.get("type"));
     }
 
     private static Map<?, ?> propertiesOf(Map<?, ?> schema) {
         return (Map<?, ?>) schema.get("properties");
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void assertImmutable(Map<?, ?> map) {
+        assertThrows(UnsupportedOperationException.class, () -> ((Map) map).put("unexpected", true));
     }
 }

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/private_line_complaint/negotiation/NegotiationSampleFlowTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/private_line_complaint/negotiation/NegotiationSampleFlowTest.java
@@ -1,10 +1,13 @@
 package net.openan.a2at.sample.private_line_complaint.negotiation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sample.private_line_complaint.negotiation.shared.NegotiationDecision;
 import net.openan.a2at.sample.private_line_complaint.negotiation.shared.NegotiationSampleFlow;
@@ -37,9 +40,12 @@ class NegotiationSampleFlowTest {
         assertEquals(ExtensionUriConstants.NEGOTIATION_T_EXTENSION_URI, result.propose().extensionUri());
         assertContextIsShared(result);
         assertEquals(
-                "P781-珠江新城-PTN7900-23-TPA1EG24-17(cvlan=100)",
-                result.endingData().data().get("access_port_name"));
-        assertEquals("专线质差", result.endingData().data().get("complaint_category"));
+                List.of(
+                        Map.of(
+                                "name", "接入端口名称",
+                                "value", "P781-珠江新城-PTN7900-23-TPA1EG24-17(cvlan=100)"),
+                        Map.of("name", "投诉分类", "value", "专线质差")),
+                result.endingData().data().get("items"));
     }
 
     @Test
@@ -48,8 +54,11 @@ class NegotiationSampleFlowTest {
 
         assertEquals(NegotiationDecision.REJECT, result.decision());
         assertContextIsShared(result);
-        assertEquals("当前账号没有资源系统查询权限", result.endingData().data().get("access_port_name"));
-        assertEquals("当前账号没有资源系统查询权限", result.endingData().data().get("complaint_category"));
+        assertEquals(
+                List.of(
+                        Map.of("name", "接入端口名称", "reason", "当前账号没有资源系统查询权限"),
+                        Map.of("name", "投诉分类", "reason", "当前账号没有资源系统查询权限")),
+                result.endingData().data().get("items"));
     }
 
     private NegotiationSampleFlow.NegotiationFlowResult run(NegotiationDecision decision) throws IOException {
@@ -87,7 +96,13 @@ class NegotiationSampleFlowTest {
         assertEquals(result.requestContext().round(), ((Number) endingData.get("round")).intValue());
         assertEquals(result.requestContext().maxRounds(), ((Number) proposeData.get("maxRounds")).intValue());
         assertEquals(result.requestContext().maxRounds(), ((Number) endingData.get("maxRounds")).intValue());
-        assertEquals("物理端口或逻辑端口名称", proposeData.get("access_port_name"));
-        assertEquals("专线中断或专线质差", proposeData.get("complaint_category"));
+        assertEquals(
+                List.of(
+                        Map.of("name", "接入端口名称", "requirement", "物理端口或逻辑端口名称"),
+                        Map.of("name", "投诉分类", "requirement", "专线中断或专线质差")),
+                proposeData.get("items"));
+        assertNull(proposeData.get("relationship"));
+        assertFalse(proposeData.containsKey("access_port_name"));
+        assertFalse(endingData.containsKey("complaint_category"));
     }
 }


### PR DESCRIPTION
Decouple the three information-negotiation validation schemas from the private-line complaint business. Use business-neutral item structures for propose (name/requirement), accept (name/value), and reject (name/reason), and update the sample mock and tests accordingly. This PR intentionally excludes environment files, Qwen endpoints, and SDK/sample logging changes.