### PR TITLE
test(sample): add negotiation abnormal evaluations

### DIFF
--- a/a2a-t-sample/pom.xml
+++ b/a2a-t-sample/pom.xml
@@ -141,6 +141,14 @@ net.openan.a2at.sample.private_line_complaint.negotiation.client.NegotiationClie
 ${sample.jar.path}${path.separator}${sample.runtime.classpath}
 net.openan.a2at.sample.private_line_complaint.negotiation.evaluation.NegotiationQwenEvaluationMain
 </echo>
+                                <echo file="${project.build.directory}/negotiation-abnormal-evaluation.javaargs.txt">-cp
+${sample.jar.path}${path.separator}${sample.runtime.classpath}
+net.openan.a2at.sample.private_line_complaint.negotiation.evaluation.NegotiationAbnormalEvaluationMain
+</echo>
+                                <echo file="${project.build.directory}/negotiation-business-abnormal-evaluation.javaargs.txt">-cp
+${sample.jar.path}${path.separator}${sample.runtime.classpath}
+net.openan.a2at.sample.private_line_complaint.negotiation.evaluation.NegotiationBusinessAbnormalEvaluationMain
+</echo>
                                 <echo file="${project.build.directory}/negotiation.javaargs.txt">-cp
 ${sample.jar.path}${path.separator}${sample.runtime.classpath}
 net.openan.a2at.sample.negotiation.NegotiationDemoApp

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationAbnormalEvaluationCase.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationAbnormalEvaluationCase.java
@@ -1,0 +1,21 @@
+package net.openan.a2at.sample.private_line_complaint.negotiation.evaluation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** One deterministic abnormal-input case for the six Negotiation-T facade APIs. */
+public record NegotiationAbnormalEvaluationCase(
+        String id,
+        String api,
+        String input,
+        String template,
+        String performative,
+        @JsonProperty("expected_exception")
+        String expectedException,
+        @JsonProperty("expected_code")
+        String expectedCode,
+        @JsonProperty("context_mode")
+        String contextMode,
+        @JsonProperty("schema_mode")
+        String schemaMode,
+        String description) {
+}

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationAbnormalEvaluationCaseLoader.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationAbnormalEvaluationCaseLoader.java
@@ -1,0 +1,33 @@
+package net.openan.a2at.sample.private_line_complaint.negotiation.evaluation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/** Loads deterministic abnormal-input cases packaged with the private-line sample. */
+public final class NegotiationAbnormalEvaluationCaseLoader {
+
+    public static final String RESOURCE_PATH =
+            "sample/private-line-complaint-negotiation/evaluation/abnormal-cases.json";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private NegotiationAbnormalEvaluationCaseLoader() {
+    }
+
+    public static List<NegotiationAbnormalEvaluationCase> load() {
+        try (InputStream input = NegotiationAbnormalEvaluationCaseLoader.class
+                .getClassLoader()
+                .getResourceAsStream(RESOURCE_PATH)) {
+            if (input == null) {
+                throw new IllegalStateException("Abnormal negotiation cases not found: " + RESOURCE_PATH);
+            }
+            return List.copyOf(OBJECT_MAPPER.readValue(input, new TypeReference<>() {
+            }));
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to read abnormal negotiation cases", exception);
+        }
+    }
+}

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationAbnormalEvaluationMain.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationAbnormalEvaluationMain.java
@@ -1,0 +1,498 @@
+package net.openan.a2at.sample.private_line_complaint.negotiation.evaluation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import net.openan.a2at.sample.private_line_complaint.negotiation.shared.InformationNegotiationSchemas;
+import net.openan.a2at.sample.private_line_complaint.negotiation.shared.NegotiationSampleEnvironment;
+import net.openan.a2at.sample.private_line_complaint.negotiation.shared.NegotiationSampleFlow;
+import net.openan.a2at.sdk.client.A2ATClient;
+import net.openan.a2at.sdk.core.exception.A2ATError;
+import net.openan.a2at.sdk.core.exception.ResourceNotFoundException;
+import net.openan.a2at.sdk.core.model.FilledParamData;
+import net.openan.a2at.sdk.core.model.MetadataContent;
+import net.openan.a2at.sdk.core.model.NegotiationContext;
+import net.openan.a2at.sdk.core.model.NegotiationPerformative;
+import net.openan.a2at.sdk.core.model.PromptTemplate;
+import net.openan.a2at.sdk.core.model.TemplateUri;
+import net.openan.a2at.sdk.llm.LLMClient;
+import net.openan.a2at.sdk.llm.LLMResponse;
+import net.openan.a2at.sdk.server.A2ATServer;
+import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestrator;
+import net.openan.a2at.sdk.negotiation.generation.NegotiationGenerationOrchestratorBuilder;
+import net.openan.a2at.sdk.negotiation.resources.NegotiationReference;
+import net.openan.a2at.sdk.negotiation.resources.NegotiationTemplateLoader;
+
+/** Runs deterministic abnormal-input checks against all six Negotiation-T facade APIs and core pipelines. */
+public final class NegotiationAbnormalEvaluationMain {
+
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private static final DateTimeFormatter FILE_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+    private static final List<String> NEGOTIATION_ERROR_CODES = List.of(
+            "template_not_found",
+            "negotiation_content_extract_failed",
+            "negotiation_semantic_rejected",
+            "negotiation_slot_missing",
+            "negotiation_invalid_input",
+            "negotiation_rule_violation",
+            "negotiation_llm_infrastructure_error");
+
+    private NegotiationAbnormalEvaluationMain() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        Path envPath = args.length > 0
+                ? Path.of(args[0])
+                : Path.of("a2a-t-sample", "src", "main", "resources", "sample",
+                        "private-line-complaint-negotiation", "qwen.env");
+        String suffix = LocalDateTime.now(ZoneId.systemDefault()).format(FILE_TIMESTAMP);
+        Path reportPath = args.length > 1
+                ? Path.of(args[1])
+                : Path.of("a2a-t-sample", "target", "negotiation-abnormal-report-" + suffix + ".json");
+        Path processLogPath = args.length > 2
+                ? Path.of(args[2])
+                : Path.of("a2a-t-sample", "target", "negotiation-abnormal-process-log-" + suffix + ".jsonl");
+
+        A2ATClient client = new A2ATClient(envPath);
+        A2ATServer server = new A2ATServer(envPath);
+        String runId = UUID.randomUUID().toString();
+        List<Map<String, Object>> results = new ArrayList<>();
+        try (NegotiationEvaluationProcessLogger logger =
+                new NegotiationEvaluationProcessLogger(OBJECT_MAPPER, processLogPath)) {
+            logger.write(event("run_started", runId, null, Map.of(
+                    "env_path", envPath.toAbsolutePath().toString(),
+                    "case_count", NegotiationAbnormalEvaluationCaseLoader.load().size() + scriptedCases().size()), null, null));
+            for (NegotiationAbnormalEvaluationCase testCase : NegotiationAbnormalEvaluationCaseLoader.load()) {
+                results.add(runCase(client, server, testCase, runId, logger));
+            }
+            for (ScriptedAbnormalCase testCase : scriptedCases()) {
+                results.add(runScriptedCase(testCase, runId, logger));
+            }
+        }
+
+        long passed = results.stream().filter(result -> Boolean.TRUE.equals(result.get("passed"))).count();
+        Map<String, Object> report = new LinkedHashMap<>();
+        report.put("generated_at", Instant.now().toString());
+        report.put("run_id", runId);
+        report.put("git_revision", gitRevision());
+        report.put("total", results.size());
+        report.put("passed", passed);
+        report.put("failed", results.size() - passed);
+        report.put("success_rate", results.isEmpty() ? 1.0 : (double) passed / results.size());
+        report.put("definition", "异常用例在预期 SDK 异常发生且错误类型/错误码匹配时判定通过；门面用例使用边界输入，脚本化用例注入固定 LLM 响应，不访问外部 LLM。");
+        report.put("error_code_coverage", errorCodeCoverage(results));
+        report.put("process_log", processLogPath.toAbsolutePath().toString());
+        report.put("cases", results);
+        Path parent = reportPath.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        OBJECT_MAPPER.writeValue(reportPath.toFile(), report);
+        System.out.printf("Abnormal negotiation evaluation complete: %d/%d passed; report=%s; process-log=%s%n",
+                passed, results.size(), reportPath.toAbsolutePath(), processLogPath.toAbsolutePath());
+    }
+
+    private static Map<String, Object> errorCodeCoverage(List<Map<String, Object>> results) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        NEGOTIATION_ERROR_CODES.forEach(code -> counts.put(code, 0));
+        Set<String> observed = new LinkedHashSet<>();
+        for (Map<String, Object> result : results) {
+            Object error = result.get("actual_error");
+            if (error instanceof Map<?, ?> errorMap && errorMap.get("code") instanceof String code) {
+                observed.add(code);
+                if (counts.containsKey(code)) {
+                    counts.computeIfPresent(code, (ignored, count) -> count + 1);
+                }
+            }
+        }
+        List<String> missing = NEGOTIATION_ERROR_CODES.stream()
+                .filter(code -> counts.get(code) == 0)
+                .toList();
+        List<String> unexpected = observed.stream()
+                .filter(code -> !counts.containsKey(code))
+                .toList();
+        Map<String, Object> coverage = new LinkedHashMap<>();
+        coverage.put("expected_codes", NEGOTIATION_ERROR_CODES);
+        coverage.put("observed_counts", counts);
+        coverage.put("missing_codes", missing);
+        coverage.put("unexpected_codes", unexpected);
+        coverage.put("all_expected_codes_covered", missing.isEmpty());
+        return coverage;
+    }
+
+    private static Map<String, Object> runCase(
+            A2ATClient client,
+            A2ATServer server,
+            NegotiationAbnormalEvaluationCase testCase,
+            String runId,
+            NegotiationEvaluationProcessLogger logger) throws IOException {
+        long startedAt = System.nanoTime();
+        NegotiationPerformative performative = NegotiationPerformative.valueOf(testCase.performative());
+        NegotiationContext context = contextFor(testCase.contextMode(), performative);
+        TemplateUri templateUri = templateFor(testCase.template());
+        Map<String, Object> request = new LinkedHashMap<>();
+        if (testCase.api().startsWith("generate_")) {
+            request.put("text", testCase.input());
+        } else {
+            request.put("prompt", testCase.input());
+            request.put("schema", schemaFor(testCase.api(), testCase.schemaMode()));
+        }
+        request.put("template_uri", templateUri == null ? null : templateUri.uri());
+        request.put("context", context == null ? null : contextPayload(context));
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("id", testCase.id());
+        result.put("description", testCase.description());
+        result.put("api", apiMethod(testCase.api()));
+        result.put("expected_exception", testCase.expectedException());
+        result.put("expected_code", testCase.expectedCode());
+        result.put("request", request);
+        try {
+            Object response = invoke(client, server, testCase, context, templateUri);
+            result.put("outcome", "unexpected_success");
+            result.put("response", responseSummary(response));
+            result.put("passed", false);
+            logger.write(event("abnormal_case", runId, testCase.id(), request,
+                    Map.of("outcome", "unexpected_success"), result));
+        } catch (RuntimeException exception) {
+            Map<String, Object> actualError = errorDetails(exception);
+            boolean classMatched = testCase.expectedException().equals(actualError.get("class"));
+            boolean codeMatched = testCase.expectedCode() == null
+                    || testCase.expectedCode().equals(actualError.get("code"));
+            result.put("actual_error", actualError);
+            result.put("passed", classMatched && codeMatched);
+            result.put("outcome", classMatched && codeMatched ? "expected_failure" : "unexpected_failure");
+            logger.write(event("abnormal_case", runId, testCase.id(), request, null, result));
+        }
+        result.put("elapsed_ms", (System.nanoTime() - startedAt) / 1_000_000);
+        return result;
+    }
+
+    private static List<ScriptedAbnormalCase> scriptedCases() {
+        return List.of(
+                new ScriptedAbnormalCase("G-PROPOSE-LLM-MALFORMED", "generate_propose",
+                        "请补充接入端口名称和投诉分类。", "not-json", false,
+                        "NegotiationGenerationException", "negotiation_content_extract_failed"),
+                new ScriptedAbnormalCase("G-ACCEPT-LLM-INFRA", "generate_accept",
+                        "接受协商，端口为 PE1-GZ-ETH-0/0/0.200，投诉分类为专线中断。", "throw", false,
+                        "NegotiationGenerationException", "negotiation_llm_infrastructure_error"),
+                new ScriptedAbnormalCase("G-REJECT-SLOT-MISSING", "generate_reject",
+                        "拒绝协商，原因是资源系统暂时无法查询。", "{\"conclusion\":\"Reject\",\"items\":null}", false,
+                        "NegotiationGenerationException", "negotiation_slot_missing"),
+                new ScriptedAbnormalCase("V-PROPOSE-SEMANTIC-REJECTED", "validate_propose",
+                        "## 信息协商\n请根据<所需信息项>补充相关内容。", semanticRejectedPayload(), false,
+                        "NegotiationParamExtractionException", "negotiation_semantic_rejected"),
+                new ScriptedAbnormalCase("V-ACCEPT-LLM-INFRA", "validate_accept",
+                        "## 信息协商结果\nAccept\n\n## 信息协商结果内容\n1. 接入端口名称：PE1-GZ-ETH-0/0/0.200\n2. 投诉分类：专线中断", "throw", false,
+                        "NegotiationParamExtractionException", "negotiation_llm_infrastructure_error"),
+                new ScriptedAbnormalCase("V-REJECT-SEMANTIC-REJECTED", "validate_reject",
+                        "## 信息协商结果\nReject\n\n## 信息协商结果内容\n1. 接入端口名称：无法提供，原因：资源系统暂时无法查询\n2. 投诉分类：无法提供，原因：资源系统暂时无法查询", semanticRejectedPayload(), false,
+                        "NegotiationParamExtractionException", "negotiation_semantic_rejected"),
+                new ScriptedAbnormalCase("G-PROPOSE-TEMPLATE-NOT-FOUND", "generate_propose",
+                        "请补充接入端口名称和投诉分类。", "unused", true,
+                        "NegotiationGenerationException", "template_not_found"),
+                new ScriptedAbnormalCase("V-PROPOSE-TEMPLATE-NOT-FOUND", "validate_propose",
+                        "## 信息协商\n请根据<所需信息项>补充相关内容。", "unused", true,
+                        "NegotiationParamExtractionException", "template_not_found"));
+    }
+
+    private static String semanticRejectedPayload() {
+        return "{\"semantic_verdict\":false,\"negotiation_type\":\"information\","
+                + "\"errors\":[{\"slot_name\":\"section.info_result_content\","
+                + "\"code\":\"missing_result_content\",\"message\":\"The information result content is missing.\"}],"
+                + "\"params\":{}}";
+    }
+
+    private static Map<String, Object> runScriptedCase(
+            ScriptedAbnormalCase testCase,
+            String runId,
+            NegotiationEvaluationProcessLogger logger) throws IOException {
+        long startedAt = System.nanoTime();
+        NegotiationPerformative performative = testCase.api().contains("accept")
+                ? NegotiationPerformative.ACCEPT
+                : testCase.api().contains("reject") ? NegotiationPerformative.REJECT : NegotiationPerformative.PROPOSE;
+        NegotiationContext context = new NegotiationContext(UUID.randomUUID().toString(), 1, 3, performative);
+        TemplateUri template = testCase.api().contains("propose")
+                ? NegotiationSampleFlow.PROPOSE_TEMPLATE_URI : NegotiationSampleFlow.ENDING_TEMPLATE_URI;
+        ScriptedLlmClient llm = new ScriptedLlmClient(testCase.payload());
+        NegotiationGenerationOrchestratorBuilder builder = NegotiationGenerationOrchestratorBuilder.builder()
+                .language("zh-CN").llmClient(llm).maxAttempts(1);
+        if (testCase.missingTemplate()) {
+            builder.templateLoader(new MissingTemplateLoader());
+        }
+        NegotiationGenerationOrchestrator orchestrator = builder.build();
+        Map<String, Object> request = new LinkedHashMap<>();
+        if (testCase.api().startsWith("generate_")) {
+            request.put("text", testCase.input());
+        } else {
+            request.put("prompt", testCase.input());
+            request.put("schema", schemaFor(testCase.api(), null));
+        }
+        request.put("context", contextPayload(context));
+        request.put("template_uri", template.uri());
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("id", testCase.id());
+        result.put("api", scriptedApiMethod(testCase.api()));
+        result.put("request", request);
+        result.put("expected_exception", testCase.expectedException());
+        result.put("expected_code", testCase.expectedCode());
+        try {
+            Object response = invoke(orchestrator, testCase, context, template);
+            result.put("response", responseSummary(response));
+            result.put("outcome", "unexpected_success");
+            result.put("passed", false);
+            logger.write(event("abnormal_scripted_case", runId, testCase.id(), request, responseSummary(response), result));
+        } catch (RuntimeException exception) {
+            Map<String, Object> actualError = errorDetails(exception);
+            boolean matched = testCase.expectedException().equals(actualError.get("class"))
+                    && testCase.expectedCode().equals(actualError.get("code"));
+            result.put("actual_error", actualError);
+            result.put("outcome", matched ? "expected_failure" : "unexpected_failure");
+            result.put("passed", matched);
+            logger.write(event("abnormal_scripted_case", runId, testCase.id(), request, null, result));
+        }
+        result.put("elapsed_ms", (System.nanoTime() - startedAt) / 1_000_000);
+        return result;
+    }
+
+    private static Object invoke(
+            NegotiationGenerationOrchestrator orchestrator,
+            ScriptedAbnormalCase testCase,
+            NegotiationContext context,
+            TemplateUri template) {
+        return switch (testCase.api()) {
+            case "generate_propose" -> orchestrator.generateProposeFromText(testCase.input(), context, template);
+            case "generate_accept" -> orchestrator.generateAcceptFromText(testCase.input(), context, template);
+            case "generate_reject" -> orchestrator.generateRejectFromText(testCase.input(), context, template);
+            case "validate_propose" -> orchestrator.validateProposePromptAndDataFilling(
+                    testCase.input(), context, InformationNegotiationSchemas.propose(), template);
+            case "validate_accept" -> orchestrator.validateAcceptPromptAndDataFilling(
+                    testCase.input(), context, InformationNegotiationSchemas.accept(), template);
+            case "validate_reject" -> orchestrator.validateRejectPromptAndDataFilling(
+                    testCase.input(), context, InformationNegotiationSchemas.reject(), template);
+            default -> throw new IllegalArgumentException("Unknown scripted abnormal API: " + testCase.api());
+        };
+    }
+
+    private static Object invoke(
+            A2ATClient client,
+            A2ATServer server,
+            NegotiationAbnormalEvaluationCase testCase,
+            NegotiationContext context,
+            TemplateUri templateUri) {
+        return switch (testCase.api()) {
+            case "generate_propose" -> client.generateNegotiationProposePromptFromText(
+                    testCase.input(), context, templateUri);
+            case "validate_propose" -> server.validateProposePromptAndDataFilling(
+                    testCase.input(), context, schemaFor(testCase.api(), testCase.schemaMode()), templateUri);
+            case "generate_accept" -> server.generateNegotiationAcceptPromptFromText(
+                    testCase.input(), context, templateUri);
+            case "validate_accept" -> client.validateAcceptPromptAndDataFilling(
+                    testCase.input(), context, schemaFor(testCase.api(), testCase.schemaMode()), templateUri);
+            case "generate_reject" -> server.generateNegotiationRejectPromptFromText(
+                    testCase.input(), context, templateUri);
+            case "validate_reject" -> client.validateRejectPromptAndDataFilling(
+                    testCase.input(), context, schemaFor(testCase.api(), testCase.schemaMode()), templateUri);
+            default -> throw new IllegalArgumentException("Unknown abnormal evaluation API: " + testCase.api());
+        };
+    }
+
+    private static Map<String, Object> schemaFor(String api, String mode) {
+        if ("null".equalsIgnoreCase(mode)) {
+            return null;
+        }
+        return switch (api) {
+            case "validate_propose" -> InformationNegotiationSchemas.propose();
+            case "validate_accept" -> InformationNegotiationSchemas.accept();
+            case "validate_reject" -> InformationNegotiationSchemas.reject();
+            default -> Map.of();
+        };
+    }
+
+    private static NegotiationContext contextFor(String mode, NegotiationPerformative performative) {
+        if ("null".equalsIgnoreCase(mode)) {
+            return null;
+        }
+        if ("invalid_id".equalsIgnoreCase(mode)) {
+            return new NegotiationContext("not-a-uuid", 1, 3, performative);
+        }
+        if ("exhausted".equalsIgnoreCase(mode)) {
+            return new NegotiationContext(UUID.randomUUID().toString(), 4, 3, performative);
+        }
+        return new NegotiationContext(UUID.randomUUID().toString(), 1, 3, performative);
+    }
+
+    private static TemplateUri templateFor(String template) {
+        return switch (template == null ? "null" : template.toLowerCase(java.util.Locale.ROOT)) {
+            case "null" -> null;
+            case "propose" -> NegotiationSampleFlow.PROPOSE_TEMPLATE_URI;
+            case "ending" -> NegotiationSampleFlow.ENDING_TEMPLATE_URI;
+            case "unknown_propose" -> TemplateUri.of(
+                    "Negotiation-T", List.of("information-negotiation", "propose"), "v999");
+            case "unknown_ending" -> TemplateUri.of(
+                    "Negotiation-T", List.of("information-negotiation", "accept-reject"), "v999");
+            default -> throw new IllegalArgumentException("Unknown abnormal evaluation template: " + template);
+        };
+    }
+
+    private static String apiMethod(String api) {
+        return switch (api) {
+            case "generate_propose" -> "A2ATClient.generateNegotiationProposePromptFromText";
+            case "validate_propose" -> "A2ATServer.validateProposePromptAndDataFilling";
+            case "generate_accept" -> "A2ATServer.generateNegotiationAcceptPromptFromText";
+            case "validate_accept" -> "A2ATClient.validateAcceptPromptAndDataFilling";
+            case "generate_reject" -> "A2ATServer.generateNegotiationRejectPromptFromText";
+            case "validate_reject" -> "A2ATClient.validateRejectPromptAndDataFilling";
+            default -> api;
+        };
+    }
+
+    private static Map<String, Object> responseSummary(Object response) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        if (response instanceof MetadataContent metadata) {
+            summary.put("type", "MetadataContent");
+            summary.put("prompt", metadata.promptText());
+            summary.put("template_uri", metadata.templateUri());
+        } else if (response instanceof FilledParamData filled) {
+            summary.put("type", "FilledParamData");
+            summary.put("data", filled.data());
+        } else {
+            summary.put("type", response == null ? "null" : response.getClass().getName());
+        }
+        return summary;
+    }
+
+    private static Map<String, Object> event(
+            String stage,
+            String runId,
+            String caseId,
+            Map<String, Object> request,
+            Map<String, Object> response,
+            Map<String, Object> result) {
+        Map<String, Object> event = new LinkedHashMap<>();
+        event.put("timestamp", Instant.now().toString());
+        event.put("run_id", runId);
+        event.put("stage", stage);
+        if (result != null && result.get("api") != null) {
+            event.put("api", result.get("api"));
+        }
+        if (caseId != null) {
+            event.put("case_id", caseId);
+        }
+        event.put("request", request);
+        if (response != null) {
+            event.put("response", response);
+        }
+        if (result != null) {
+            event.put("result", result);
+        }
+        return event;
+    }
+
+    private static Map<String, Object> errorDetails(RuntimeException exception) {
+        Map<String, Object> error = new LinkedHashMap<>();
+        error.put("class", exception.getClass().getSimpleName());
+        error.put("message", exception.getMessage());
+        if (exception instanceof A2ATError a2atError) {
+            error.put("code", a2atError.getCode());
+        }
+        return error;
+    }
+
+    private static Map<String, Object> contextPayload(NegotiationContext context) {
+        return Map.of(
+                "id", context.id(),
+                "round", context.round(),
+                "maxRounds", context.maxRounds(),
+                "performative", context.performative().name());
+    }
+
+    private static String scriptedApiMethod(String api) {
+        return switch (api) {
+            case "generate_propose" -> "NegotiationGenerationOrchestrator.generateProposeFromText";
+            case "generate_accept" -> "NegotiationGenerationOrchestrator.generateAcceptFromText";
+            case "generate_reject" -> "NegotiationGenerationOrchestrator.generateRejectFromText";
+            case "validate_propose" -> "NegotiationGenerationOrchestrator.validateProposePromptAndDataFilling";
+            case "validate_accept" -> "NegotiationGenerationOrchestrator.validateAcceptPromptAndDataFilling";
+            case "validate_reject" -> "NegotiationGenerationOrchestrator.validateRejectPromptAndDataFilling";
+            default -> api;
+        };
+    }
+
+    private record ScriptedAbnormalCase(
+            String id,
+            String api,
+            String input,
+            String payload,
+            boolean missingTemplate,
+            String expectedException,
+            String expectedCode) {
+    }
+
+    private static final class ScriptedLlmClient implements LLMClient {
+
+        private final String payload;
+
+        private ScriptedLlmClient(String payload) {
+            this.payload = payload;
+        }
+
+        @Override
+        public LLMResponse structured(
+                List<Map<String, String>> messages,
+                Map<String, Object> jsonSchema,
+                Double temperature,
+                Integer maxTokens) {
+            if ("throw".equals(payload)) {
+                throw new IllegalStateException("scripted LLM infrastructure failure");
+            }
+            return new LLMResponse(payload, "sample-scripted-model",
+                    Map.of("prompt_tokens", 1, "completion_tokens", 1), Map.of());
+        }
+    }
+
+    private static final class MissingTemplateLoader implements NegotiationTemplateLoader {
+
+        @Override
+        public PromptTemplate load(NegotiationReference reference) {
+            throw new ResourceNotFoundException("Negotiation template does not exist.", reference.uri());
+        }
+
+        @Override
+        public List<PromptTemplate> loadAll() {
+            return List.of();
+        }
+    }
+
+    private static String gitRevision() {
+        try {
+            Process process = new ProcessBuilder("git", "rev-parse", "HEAD")
+                    .redirectErrorStream(true)
+                    .start();
+            String revision;
+            try (var input = process.getInputStream()) {
+                revision = new String(input.readAllBytes(), StandardCharsets.UTF_8).trim();
+            }
+            return process.waitFor() == 0 && !revision.isBlank() ? revision : "unknown";
+        } catch (IOException exception) {
+            return "unknown";
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return "unknown";
+        }
+    }
+}

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationBusinessAbnormalEvaluationCase.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationBusinessAbnormalEvaluationCase.java
@@ -1,0 +1,12 @@
+package net.openan.a2at.sample.private_line_complaint.negotiation.evaluation;
+
+import java.util.List;
+
+/** One business-level malformed-content case executed against a real LLM. */
+public record NegotiationBusinessAbnormalEvaluationCase(
+        String id,
+        String api,
+        String input,
+        String description,
+        List<String> expectedCodes) {
+}

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationBusinessAbnormalEvaluationCaseLoader.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationBusinessAbnormalEvaluationCaseLoader.java
@@ -1,0 +1,29 @@
+package net.openan.a2at.sample.private_line_complaint.negotiation.evaluation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/** Loads business-level malformed-content cases bundled with the sample. */
+final class NegotiationBusinessAbnormalEvaluationCaseLoader {
+
+    private static final String RESOURCE =
+            "/sample/private-line-complaint-negotiation/evaluation/business-abnormal-cases.json";
+
+    private NegotiationBusinessAbnormalEvaluationCaseLoader() {
+    }
+
+    static List<NegotiationBusinessAbnormalEvaluationCase> load() {
+        ObjectMapper mapper = new ObjectMapper();
+        try (InputStream input = NegotiationBusinessAbnormalEvaluationCaseLoader.class.getResourceAsStream(RESOURCE)) {
+            if (input == null) {
+                throw new IllegalStateException("Business abnormal case resource not found: " + RESOURCE);
+            }
+            return mapper.readValue(input, new TypeReference<>() {});
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to load business abnormal cases: " + RESOURCE, exception);
+        }
+    }
+}

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationBusinessAbnormalEvaluationMain.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationBusinessAbnormalEvaluationMain.java
@@ -1,0 +1,279 @@
+package net.openan.a2at.sample.private_line_complaint.negotiation.evaluation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import net.openan.a2at.sample.private_line_complaint.negotiation.shared.InformationNegotiationSchemas;
+import net.openan.a2at.sample.private_line_complaint.negotiation.shared.NegotiationSampleEnvironment;
+import net.openan.a2at.sample.private_line_complaint.negotiation.shared.NegotiationSampleFlow;
+import net.openan.a2at.sdk.client.A2ATClient;
+import net.openan.a2at.sdk.core.exception.A2ATError;
+import net.openan.a2at.sdk.core.model.FilledParamData;
+import net.openan.a2at.sdk.core.model.MetadataContent;
+import net.openan.a2at.sdk.core.model.NegotiationContext;
+import net.openan.a2at.sdk.core.model.NegotiationPerformative;
+import net.openan.a2at.sdk.server.A2ATServer;
+
+/** Runs malformed business-content cases against the configured real LLM. */
+public final class NegotiationBusinessAbnormalEvaluationMain {
+
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private static final DateTimeFormatter FILE_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+
+    private NegotiationBusinessAbnormalEvaluationMain() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        Path envPath = args.length > 0
+                ? Path.of(args[0])
+                : Path.of("a2a-t-sample", "src", "main", "resources", "sample",
+                        "private-line-complaint-negotiation", "qwen.env");
+        String suffix = LocalDateTime.now(ZoneId.systemDefault()).format(FILE_TIMESTAMP);
+        Path reportPath = args.length > 1
+                ? Path.of(args[1])
+                : Path.of("a2a-t-sample", "target", "negotiation-business-abnormal-report-" + suffix + ".json");
+        Path processLogPath = args.length > 2
+                ? Path.of(args[2])
+                : Path.of("a2a-t-sample", "target", "negotiation-business-abnormal-process-log-" + suffix + ".jsonl");
+
+        Map<String, String> environment = NegotiationSampleEnvironment.read(envPath);
+        requireQwenConfiguration(environment);
+        List<NegotiationBusinessAbnormalEvaluationCase> cases =
+                NegotiationBusinessAbnormalEvaluationCaseLoader.load();
+        String runId = UUID.randomUUID().toString();
+        List<Map<String, Object>> results = new ArrayList<>();
+        try (NegotiationEvaluationProcessLogger logger =
+                new NegotiationEvaluationProcessLogger(OBJECT_MAPPER, processLogPath)) {
+            A2ATClient client = new A2ATClient(envPath);
+            A2ATServer server = new A2ATServer(envPath);
+            logger.write(runStartedEvent(runId, envPath, cases.size()));
+            for (NegotiationBusinessAbnormalEvaluationCase testCase : cases) {
+                results.add(runCase(client, server, testCase, runId, logger));
+            }
+        }
+
+        long passed = results.stream().filter(result -> Boolean.TRUE.equals(result.get("passed"))).count();
+        Map<String, Object> report = new LinkedHashMap<>();
+        report.put("generated_at", Instant.now().toString());
+        report.put("run_id", runId);
+        report.put("model", environment.get("A2AT_LLM_MODEL"));
+        report.put("base_url", environment.get("A2AT_LLM_BASE_URL"));
+        report.put("git_revision", gitRevision());
+        report.put("total", results.size());
+        report.put("passed", passed);
+        report.put("failed", results.size() - passed);
+        report.put("success_rate", results.isEmpty() ? 1.0 : (double) passed / results.size());
+        report.put("definition", "业务结构异常用例要求 SDK 识别无法渲染或无法校验的协商报文；这些用例调用真实 LLM，结果可能受模型输出影响。");
+        report.put("process_log", processLogPath.toAbsolutePath().toString());
+        report.put("cases", results);
+        Path parent = reportPath.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        OBJECT_MAPPER.writeValue(reportPath.toFile(), report);
+        System.out.printf("Business abnormal negotiation evaluation complete: %d/%d matched; report=%s; process-log=%s%n",
+                passed, results.size(), reportPath.toAbsolutePath(), processLogPath.toAbsolutePath());
+    }
+
+    private static Map<String, Object> runStartedEvent(String runId, Path envPath, int caseCount) {
+        Map<String, Object> event = new LinkedHashMap<>();
+        event.put("timestamp", Instant.now().toString());
+        event.put("event_type", "run_started");
+        event.put("run_id", runId);
+        event.put("env_path", envPath.toAbsolutePath().toString());
+        event.put("case_count", caseCount);
+        event.put("real_llm", true);
+        return event;
+    }
+
+    private static Map<String, Object> runCase(
+            A2ATClient client,
+            A2ATServer server,
+            NegotiationBusinessAbnormalEvaluationCase testCase,
+            String runId,
+            NegotiationEvaluationProcessLogger logger) throws IOException {
+        long startedAt = System.nanoTime();
+        NegotiationPerformative performative = performativeFor(testCase.api());
+        NegotiationContext context = new NegotiationContext(UUID.randomUUID().toString(), 1, 3, performative);
+        Map<String, Object> request = requestFor(testCase, context);
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("id", testCase.id());
+        result.put("description", testCase.description());
+        result.put("api", apiMethod(testCase.api()));
+        result.put("expected_codes", testCase.expectedCodes());
+        result.put("request", request);
+        try {
+            Object response = invoke(client, server, testCase, context);
+            result.put("response", responseSummary(response));
+            result.put("outcome", "unexpected_success");
+            result.put("passed", false);
+            logger.write(event(runId, testCase, request, responseSummary(response), result, startedAt));
+        } catch (RuntimeException exception) {
+            Map<String, Object> error = errorDetails(exception);
+            boolean matched = testCase.expectedCodes().stream().anyMatch(code -> code.equals(error.get("code")));
+            result.put("actual_error", error);
+            result.put("outcome", matched ? "expected_business_failure" : "unexpected_failure");
+            result.put("passed", matched);
+            logger.write(event(runId, testCase, request, null, result, startedAt));
+        }
+        result.put("elapsed_ms", (System.nanoTime() - startedAt) / 1_000_000);
+        return result;
+    }
+
+    private static Object invoke(
+            A2ATClient client,
+            A2ATServer server,
+            NegotiationBusinessAbnormalEvaluationCase testCase,
+            NegotiationContext context) {
+        return switch (testCase.api()) {
+            case "generate_propose" -> client.generateNegotiationProposePromptFromText(
+                    testCase.input(), context, NegotiationSampleFlow.PROPOSE_TEMPLATE_URI);
+            case "validate_propose" -> server.validateProposePromptAndDataFilling(
+                    testCase.input(), context, InformationNegotiationSchemas.propose(),
+                    NegotiationSampleFlow.PROPOSE_TEMPLATE_URI);
+            case "generate_accept" -> server.generateNegotiationAcceptPromptFromText(
+                    testCase.input(), context, NegotiationSampleFlow.ENDING_TEMPLATE_URI);
+            case "validate_accept" -> client.validateAcceptPromptAndDataFilling(
+                    testCase.input(), context, InformationNegotiationSchemas.accept(),
+                    NegotiationSampleFlow.ENDING_TEMPLATE_URI);
+            case "generate_reject" -> server.generateNegotiationRejectPromptFromText(
+                    testCase.input(), context, NegotiationSampleFlow.ENDING_TEMPLATE_URI);
+            case "validate_reject" -> client.validateRejectPromptAndDataFilling(
+                    testCase.input(), context, InformationNegotiationSchemas.reject(),
+                    NegotiationSampleFlow.ENDING_TEMPLATE_URI);
+            default -> throw new IllegalArgumentException("Unknown business abnormal API: " + testCase.api());
+        };
+    }
+
+    private static Map<String, Object> requestFor(
+            NegotiationBusinessAbnormalEvaluationCase testCase, NegotiationContext context) {
+        Map<String, Object> request = new LinkedHashMap<>();
+        if (testCase.api().startsWith("generate_")) {
+            request.put("text", testCase.input());
+        } else {
+            request.put("prompt", testCase.input());
+            request.put("schema", schemaFor(testCase.api()));
+        }
+        request.put("context", contextPayload(context));
+        request.put("template_uri", testCase.api().contains("propose")
+                ? NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri()
+                : NegotiationSampleFlow.ENDING_TEMPLATE_URI.uri());
+        return request;
+    }
+
+    private static Map<String, Object> event(
+            String runId,
+            NegotiationBusinessAbnormalEvaluationCase testCase,
+            Map<String, Object> request,
+            Map<String, Object> response,
+            Map<String, Object> result,
+            long startedAt) {
+        Map<String, Object> event = new LinkedHashMap<>();
+        event.put("timestamp", Instant.now().toString());
+        event.put("event_type", "business_abnormal_case");
+        event.put("run_id", runId);
+        event.put("case_id", testCase.id());
+        event.put("api", apiMethod(testCase.api()));
+        event.put("request", request);
+        if (response != null) {
+            event.put("response", response);
+        }
+        event.put("result", result);
+        event.put("elapsed_ms", (System.nanoTime() - startedAt) / 1_000_000);
+        return event;
+    }
+
+    private static NegotiationPerformative performativeFor(String api) {
+        return api.contains("accept") ? NegotiationPerformative.ACCEPT
+                : api.contains("reject") ? NegotiationPerformative.REJECT : NegotiationPerformative.PROPOSE;
+    }
+
+    private static Map<String, Object> schemaFor(String api) {
+        return switch (api) {
+            case "validate_propose" -> InformationNegotiationSchemas.propose();
+            case "validate_accept" -> InformationNegotiationSchemas.accept();
+            case "validate_reject" -> InformationNegotiationSchemas.reject();
+            default -> Map.of();
+        };
+    }
+
+    private static String apiMethod(String api) {
+        return switch (api) {
+            case "generate_propose" -> "A2ATClient.generateNegotiationProposePromptFromText";
+            case "validate_propose" -> "A2ATServer.validateProposePromptAndDataFilling";
+            case "generate_accept" -> "A2ATServer.generateNegotiationAcceptPromptFromText";
+            case "validate_accept" -> "A2ATClient.validateAcceptPromptAndDataFilling";
+            case "generate_reject" -> "A2ATServer.generateNegotiationRejectPromptFromText";
+            case "validate_reject" -> "A2ATClient.validateRejectPromptAndDataFilling";
+            default -> api;
+        };
+    }
+
+    private static Map<String, Object> responseSummary(Object response) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        if (response instanceof MetadataContent metadata) {
+            summary.put("type", "MetadataContent");
+            summary.put("prompt", metadata.promptText());
+            summary.put("template_uri", metadata.templateUri());
+            summary.put("extension_uri", metadata.extensionUri());
+        } else if (response instanceof FilledParamData filled) {
+            summary.put("type", "FilledParamData");
+            summary.put("data", filled.data());
+        } else {
+            summary.put("type", response == null ? "null" : response.getClass().getName());
+        }
+        return summary;
+    }
+
+    private static Map<String, Object> errorDetails(RuntimeException exception) {
+        Map<String, Object> error = new LinkedHashMap<>();
+        error.put("class", exception.getClass().getSimpleName());
+        error.put("message", exception.getMessage());
+        if (exception instanceof A2ATError a2atError) {
+            error.put("code", a2atError.getCode());
+        }
+        return error;
+    }
+
+    private static Map<String, Object> contextPayload(NegotiationContext context) {
+        return Map.of("id", context.id(), "round", context.round(), "maxRounds", context.maxRounds(),
+                "performative", context.performative().name());
+    }
+
+    private static void requireQwenConfiguration(Map<String, String> environment) {
+        if (!"openai".equals(environment.get("A2AT_LLM_PROVIDER"))
+                || environment.get("A2AT_LLM_BASE_URL") == null) {
+            throw new IllegalArgumentException(
+                    "Business abnormal evaluation requires A2AT_LLM_PROVIDER=openai and A2AT_LLM_BASE_URL");
+        }
+    }
+
+    private static String gitRevision() {
+        try {
+            Process process = new ProcessBuilder("git", "rev-parse", "HEAD")
+                    .redirectErrorStream(true).start();
+            String revision;
+            try (var input = process.getInputStream()) {
+                revision = new String(input.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8).trim();
+            }
+            return process.waitFor() == 0 && !revision.isBlank() ? revision : "unknown";
+        } catch (IOException exception) {
+            return "unknown";
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return "unknown";
+        }
+    }
+}

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationQwenEvaluationMain.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationQwenEvaluationMain.java
@@ -66,9 +66,6 @@ public final class NegotiationQwenEvaluationMain {
         long endingSucceeded = results.stream()
                 .filter(result -> Boolean.TRUE.equals(result.get("ending_succeeded")))
                 .count();
-        long goldenMatched = results.stream()
-                .filter(result -> Boolean.TRUE.equals(result.get("golden_matched")))
-                .count();
         Map<String, Object> report = new LinkedHashMap<>();
         report.put("generated_at", Instant.now().toString());
         report.put("run_id", runId);
@@ -82,9 +79,7 @@ public final class NegotiationQwenEvaluationMain {
         report.put("ending_succeeded", endingSucceeded);
         report.put("passed", passed);
         report.put("end_to_end_success_rate", (double) passed / results.size());
-        report.put("golden_matched", goldenMatched);
-        report.put("golden_exact_match_rate", (double) goldenMatched / results.size());
-        report.put("note", "A flow passes when all four generation/validation API calls return successfully. Golden exact matching is an auxiliary diagnostic because semantically equivalent natural-language values may differ in wording.");
+        report.put("note", "A flow passes when all four generation/validation API calls return successfully. Natural-language output is evaluated by whether the four API calls can be chained successfully.");
         report.put("process_log", processLogPath.toAbsolutePath().toString());
         report.put("cases", results);
         Files.createDirectories(reportPath.toAbsolutePath().getParent());
@@ -122,7 +117,6 @@ public final class NegotiationQwenEvaluationMain {
         result.put("ending_validation_succeeded", false);
         result.put("propose_succeeded", false);
         result.put("ending_succeeded", false);
-        result.put("golden_matched", false);
         List<Map<String, Object>> apiTrace = new ArrayList<>();
         result.put("api_trace", apiTrace);
         try {
@@ -134,8 +128,6 @@ public final class NegotiationQwenEvaluationMain {
                     server, testCase, propose.promptText(), context, runId, processLogger, apiTrace);
             result.put("propose_validation_succeeded", true);
             result.put("actual_propose", proposeFilled.data());
-            boolean proposeMatched = expectedValuesMatch(testCase.expectedPropose(), proposeFilled.data());
-            result.put("propose_expected_matched", proposeMatched);
             result.put("propose_context_matched", contextMatches(context, proposeFilled.data()));
             result.put("propose_succeeded", true);
 
@@ -150,11 +142,8 @@ public final class NegotiationQwenEvaluationMain {
                     client, testCase, ending.promptText(), responseContext, runId, processLogger, apiTrace);
             result.put("ending_validation_succeeded", true);
             result.put("actual_ending", endingFilled.data());
-            boolean endingMatched = expectedValuesMatch(testCase.expectedEnding(), endingFilled.data());
-            result.put("ending_expected_matched", endingMatched);
             result.put("ending_context_matched", contextMatches(responseContext, endingFilled.data()));
             result.put("ending_succeeded", true);
-            result.put("golden_matched", proposeMatched && endingMatched);
             result.put("passed", true);
         } catch (RuntimeException exception) {
             result.put("passed", false);
@@ -436,10 +425,6 @@ public final class NegotiationQwenEvaluationMain {
         String logFilename = (extensionStart < 0 ? filename : filename.substring(0, extensionStart)) + "-process.jsonl";
         Path parent = reportPath.getParent();
         return parent == null ? Path.of(logFilename) : parent.resolve(logFilename);
-    }
-
-    private static boolean expectedValuesMatch(Map<String, Object> expected, Map<String, Object> actual) {
-        return expected.entrySet().stream().allMatch(entry -> entry.getValue().equals(actual.get(entry.getKey())));
     }
 
     private static boolean contextMatches(NegotiationContext context, Map<String, Object> actual) {

--- a/a2a-t-sample/src/main/resources/sample/private-line-complaint-negotiation/evaluation/abnormal-cases.json
+++ b/a2a-t-sample/src/main/resources/sample/private-line-complaint-negotiation/evaluation/abnormal-cases.json
@@ -1,0 +1,427 @@
+[
+  {
+    "id": "G-PROPOSE-BLANK-TEXT",
+    "api": "generate_propose",
+    "input": "",
+    "template": "propose",
+    "performative": "PROPOSE",
+    "expected_exception": "NegotiationGenerationException",
+    "expected_code": "negotiation_invalid_input",
+    "description": "生成协商发起报文时输入为空"
+  },
+  {
+    "id": "V-PROPOSE-BLANK-PROMPT",
+    "api": "validate_propose",
+    "input": "",
+    "template": "propose",
+    "performative": "PROPOSE",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "校验协商发起报文时输入为空"
+  },
+  {
+    "id": "G-ACCEPT-WRONG-TEMPLATE",
+    "api": "generate_accept",
+    "input": "接受协商，端口为 PE1-GZ-ETH-0/0/0.200，投诉分类为专线中断。",
+    "template": "propose",
+    "performative": "ACCEPT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "接受生成接口误传 propose 模板"
+  },
+  {
+    "id": "V-ACCEPT-WRONG-TEMPLATE",
+    "api": "validate_accept",
+    "input": "## 信息协商\nAccept\n\n## 信息协商结果内容\n1. 接入端口名称：PE1-GZ-ETH-0/0/0.200\n2. 投诉分类：专线中断",
+    "template": "propose",
+    "performative": "ACCEPT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "接受校验接口误传 propose 模板"
+  },
+  {
+    "id": "G-REJECT-WRONG-TEMPLATE",
+    "api": "generate_reject",
+    "input": "拒绝协商，原因是资源系统暂时无法查询。",
+    "template": "propose",
+    "performative": "REJECT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "拒绝生成接口误传 propose 模板"
+  },
+  {
+    "id": "V-REJECT-WRONG-TEMPLATE",
+    "api": "validate_reject",
+    "input": "## 信息协商\nReject\n\n## 信息协商结果内容\n1. 接入端口名称：无法提供，原因：资源系统暂时无法查询\n2. 投诉分类：无法提供，原因：资源系统暂时无法查询",
+    "template": "propose",
+    "performative": "REJECT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "拒绝校验接口误传 propose 模板"
+  },
+  {
+    "id": "G-PROPOSE-NULL-TEXT",
+    "api": "generate_propose",
+    "input": null,
+    "template": "propose",
+    "performative": "PROPOSE",
+    "expected_exception": "NegotiationGenerationException",
+    "expected_code": "negotiation_invalid_input",
+    "description": "生成协商发起报文时文本为 null"
+  },
+  {
+    "id": "G-PROPOSE-NULL-CONTEXT",
+    "api": "generate_propose",
+    "input": "请补充接入端口名称和投诉分类。",
+    "template": "propose",
+    "performative": "PROPOSE",
+    "context_mode": "null",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "生成协商发起报文时上下文为 null"
+  },
+  {
+    "id": "G-PROPOSE-NULL-TEMPLATE",
+    "api": "generate_propose",
+    "input": "请补充接入端口名称和投诉分类。",
+    "template": "null",
+    "performative": "PROPOSE",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "生成协商发起报文时模板 URI 为 null"
+  },
+  {
+    "id": "G-PROPOSE-UNKNOWN-TEMPLATE",
+    "api": "generate_propose",
+    "input": "请补充接入端口名称和投诉分类。",
+    "template": "unknown_propose",
+    "performative": "PROPOSE",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "生成协商发起报文时模板 URI 版本非法"
+  },
+  {
+    "id": "G-ACCEPT-BLANK-TEXT",
+    "api": "generate_accept",
+    "input": "",
+    "template": "ending",
+    "performative": "ACCEPT",
+    "expected_exception": "NegotiationGenerationException",
+    "expected_code": "negotiation_invalid_input",
+    "description": "接受生成接口输入为空"
+  },
+  {
+    "id": "G-ACCEPT-NULL-CONTEXT",
+    "api": "generate_accept",
+    "input": "接受协商，端口为 PE1-GZ-ETH-0/0/0.200，投诉分类为专线中断。",
+    "template": "ending",
+    "performative": "ACCEPT",
+    "context_mode": "null",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "接受生成接口上下文为 null"
+  },
+  {
+    "id": "G-ACCEPT-NULL-TEMPLATE",
+    "api": "generate_accept",
+    "input": "接受协商，端口为 PE1-GZ-ETH-0/0/0.200，投诉分类为专线中断。",
+    "template": "null",
+    "performative": "ACCEPT",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "接受生成接口模板 URI 为 null"
+  },
+  {
+    "id": "G-ACCEPT-UNKNOWN-TEMPLATE",
+    "api": "generate_accept",
+    "input": "接受协商，端口为 PE1-GZ-ETH-0/0/0.200，投诉分类为专线中断。",
+    "template": "unknown_ending",
+    "performative": "ACCEPT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "接受生成接口模板 URI 版本非法"
+  },
+  {
+    "id": "G-REJECT-BLANK-TEXT",
+    "api": "generate_reject",
+    "input": "",
+    "template": "ending",
+    "performative": "REJECT",
+    "expected_exception": "NegotiationGenerationException",
+    "expected_code": "negotiation_invalid_input",
+    "description": "拒绝生成接口输入为空"
+  },
+  {
+    "id": "G-REJECT-NULL-CONTEXT",
+    "api": "generate_reject",
+    "input": "拒绝协商，原因是资源系统暂时无法查询。",
+    "template": "ending",
+    "performative": "REJECT",
+    "context_mode": "null",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "拒绝生成接口上下文为 null"
+  },
+  {
+    "id": "G-REJECT-NULL-TEMPLATE",
+    "api": "generate_reject",
+    "input": "拒绝协商，原因是资源系统暂时无法查询。",
+    "template": "null",
+    "performative": "REJECT",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "拒绝生成接口模板 URI 为 null"
+  },
+  {
+    "id": "G-REJECT-UNKNOWN-TEMPLATE",
+    "api": "generate_reject",
+    "input": "拒绝协商，原因是资源系统暂时无法查询。",
+    "template": "unknown_ending",
+    "performative": "REJECT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "拒绝生成接口模板 URI 版本非法"
+  },
+  {
+    "id": "V-PROPOSE-NULL-PROMPT",
+    "api": "validate_propose",
+    "input": null,
+    "template": "propose",
+    "performative": "PROPOSE",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "校验协商发起报文时 prompt 为 null"
+  },
+  {
+    "id": "V-PROPOSE-NULL-CONTEXT",
+    "api": "validate_propose",
+    "input": "## 信息协商\n请根据<所需信息项>补充相关内容。",
+    "template": "propose",
+    "performative": "PROPOSE",
+    "context_mode": "null",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_invalid_input",
+    "description": "校验协商发起报文时上下文为 null"
+  },
+  {
+    "id": "V-PROPOSE-NULL-SCHEMA",
+    "api": "validate_propose",
+    "input": "## 信息协商\n请根据<所需信息项>补充相关内容。",
+    "template": "propose",
+    "performative": "PROPOSE",
+    "schema_mode": "null",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "校验协商发起报文时业务 schema 为 null"
+  },
+  {
+    "id": "V-PROPOSE-NULL-TEMPLATE",
+    "api": "validate_propose",
+    "input": "## 信息协商\n请根据<所需信息项>补充相关内容。",
+    "template": "null",
+    "performative": "PROPOSE",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "校验协商发起报文时模板 URI 为 null"
+  },
+  {
+    "id": "V-PROPOSE-UNKNOWN-TEMPLATE",
+    "api": "validate_propose",
+    "input": "## 信息协商\n请根据<所需信息项>补充相关内容。",
+    "template": "unknown_propose",
+    "performative": "PROPOSE",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "校验协商发起报文时模板 URI 版本非法"
+  },
+  {
+    "id": "V-PROPOSE-INVALID-ID",
+    "api": "validate_propose",
+    "input": "## 信息协商\n请根据<所需信息项>补充相关内容。",
+    "template": "propose",
+    "performative": "PROPOSE",
+    "context_mode": "invalid_id",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_rule_violation",
+    "description": "校验协商发起报文时上下文 id 不是 UUID"
+  },
+  {
+    "id": "V-PROPOSE-EXHAUSTED-ROUND",
+    "api": "validate_propose",
+    "input": "## 信息协商\n请根据<所需信息项>补充相关内容。",
+    "template": "propose",
+    "performative": "PROPOSE",
+    "context_mode": "exhausted",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_rule_violation",
+    "description": "校验协商发起报文时 round 超过 maxRounds"
+  },
+  {
+    "id": "V-ACCEPT-BLANK-PROMPT",
+    "api": "validate_accept",
+    "input": "",
+    "template": "ending",
+    "performative": "ACCEPT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "接受校验接口 prompt 为空"
+  },
+  {
+    "id": "V-ACCEPT-NULL-PROMPT",
+    "api": "validate_accept",
+    "input": null,
+    "template": "ending",
+    "performative": "ACCEPT",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "接受校验接口 prompt 为 null"
+  },
+  {
+    "id": "V-ACCEPT-NULL-CONTEXT",
+    "api": "validate_accept",
+    "input": "## 信息协商结果\nAccept\n\n## 信息协商结果内容\n1. 接入端口名称：PE1-GZ-ETH-0/0/0.200\n2. 投诉分类：专线中断",
+    "template": "ending",
+    "performative": "ACCEPT",
+    "context_mode": "null",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_invalid_input",
+    "description": "接受校验接口上下文为 null"
+  },
+  {
+    "id": "V-ACCEPT-NULL-SCHEMA",
+    "api": "validate_accept",
+    "input": "## 信息协商结果\nAccept\n\n## 信息协商结果内容\n1. 接入端口名称：PE1-GZ-ETH-0/0/0.200\n2. 投诉分类：专线中断",
+    "template": "ending",
+    "performative": "ACCEPT",
+    "schema_mode": "null",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "接受校验接口业务 schema 为 null"
+  },
+  {
+    "id": "V-ACCEPT-NULL-TEMPLATE",
+    "api": "validate_accept",
+    "input": "## 信息协商结果\nAccept\n\n## 信息协商结果内容\n1. 接入端口名称：PE1-GZ-ETH-0/0/0.200\n2. 投诉分类：专线中断",
+    "template": "null",
+    "performative": "ACCEPT",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "接受校验接口模板 URI 为 null"
+  },
+  {
+    "id": "V-ACCEPT-UNKNOWN-TEMPLATE",
+    "api": "validate_accept",
+    "input": "## 信息协商结果\nAccept\n\n## 信息协商结果内容\n1. 接入端口名称：PE1-GZ-ETH-0/0/0.200\n2. 投诉分类：专线中断",
+    "template": "unknown_ending",
+    "performative": "ACCEPT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "接受校验接口模板 URI 版本非法"
+  },
+  {
+    "id": "V-ACCEPT-INVALID-ID",
+    "api": "validate_accept",
+    "input": "## 信息协商结果\nAccept\n\n## 信息协商结果内容\n1. 接入端口名称：PE1-GZ-ETH-0/0/0.200\n2. 投诉分类：专线中断",
+    "template": "ending",
+    "performative": "ACCEPT",
+    "context_mode": "invalid_id",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_rule_violation",
+    "description": "接受校验接口上下文 id 不是 UUID"
+  },
+  {
+    "id": "V-ACCEPT-EXHAUSTED-ROUND",
+    "api": "validate_accept",
+    "input": "## 信息协商结果\nAccept\n\n## 信息协商结果内容\n1. 接入端口名称：PE1-GZ-ETH-0/0/0.200\n2. 投诉分类：专线中断",
+    "template": "ending",
+    "performative": "ACCEPT",
+    "context_mode": "exhausted",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_rule_violation",
+    "description": "接受校验接口 round 超过 maxRounds"
+  },
+  {
+    "id": "V-REJECT-BLANK-PROMPT",
+    "api": "validate_reject",
+    "input": "",
+    "template": "ending",
+    "performative": "REJECT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "拒绝校验接口 prompt 为空"
+  },
+  {
+    "id": "V-REJECT-NULL-PROMPT",
+    "api": "validate_reject",
+    "input": null,
+    "template": "ending",
+    "performative": "REJECT",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "拒绝校验接口 prompt 为 null"
+  },
+  {
+    "id": "V-REJECT-NULL-CONTEXT",
+    "api": "validate_reject",
+    "input": "## 信息协商结果\nReject\n\n## 信息协商结果内容\n1. 接入端口名称：无法提供，原因：资源系统暂时无法查询\n2. 投诉分类：无法提供，原因：资源系统暂时无法查询",
+    "template": "ending",
+    "performative": "REJECT",
+    "context_mode": "null",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_invalid_input",
+    "description": "拒绝校验接口上下文为 null"
+  },
+  {
+    "id": "V-REJECT-NULL-SCHEMA",
+    "api": "validate_reject",
+    "input": "## 信息协商结果\nReject\n\n## 信息协商结果内容\n1. 接入端口名称：无法提供，原因：资源系统暂时无法查询\n2. 投诉分类：无法提供，原因：资源系统暂时无法查询",
+    "template": "ending",
+    "performative": "REJECT",
+    "schema_mode": "null",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "拒绝校验接口业务 schema 为 null"
+  },
+  {
+    "id": "V-REJECT-NULL-TEMPLATE",
+    "api": "validate_reject",
+    "input": "## 信息协商结果\nReject\n\n## 信息协商结果内容\n1. 接入端口名称：无法提供，原因：资源系统暂时无法查询\n2. 投诉分类：无法提供，原因：资源系统暂时无法查询",
+    "template": "null",
+    "performative": "REJECT",
+    "expected_exception": "NullPointerException",
+    "expected_code": null,
+    "description": "拒绝校验接口模板 URI 为 null"
+  },
+  {
+    "id": "V-REJECT-UNKNOWN-TEMPLATE",
+    "api": "validate_reject",
+    "input": "## 信息协商结果\nReject\n\n## 信息协商结果内容\n1. 接入端口名称：无法提供，原因：资源系统暂时无法查询\n2. 投诉分类：无法提供，原因：资源系统暂时无法查询",
+    "template": "unknown_ending",
+    "performative": "REJECT",
+    "expected_exception": "IllegalArgumentException",
+    "expected_code": null,
+    "description": "拒绝校验接口模板 URI 版本非法"
+  },
+  {
+    "id": "V-REJECT-INVALID-ID",
+    "api": "validate_reject",
+    "input": "## 信息协商结果\nReject\n\n## 信息协商结果内容\n1. 接入端口名称：无法提供，原因：资源系统暂时无法查询\n2. 投诉分类：无法提供，原因：资源系统暂时无法查询",
+    "template": "ending",
+    "performative": "REJECT",
+    "context_mode": "invalid_id",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_rule_violation",
+    "description": "拒绝校验接口上下文 id 不是 UUID"
+  },
+  {
+    "id": "V-REJECT-EXHAUSTED-ROUND",
+    "api": "validate_reject",
+    "input": "## 信息协商结果\nReject\n\n## 信息协商结果内容\n1. 接入端口名称：无法提供，原因：资源系统暂时无法查询\n2. 投诉分类：无法提供，原因：资源系统暂时无法查询",
+    "template": "ending",
+    "performative": "REJECT",
+    "context_mode": "exhausted",
+    "expected_exception": "NegotiationParamExtractionException",
+    "expected_code": "negotiation_rule_violation",
+    "description": "拒绝校验接口 round 超过 maxRounds"
+  }
+]

--- a/a2a-t-sample/src/main/resources/sample/private-line-complaint-negotiation/evaluation/business-abnormal-cases.json
+++ b/a2a-t-sample/src/main/resources/sample/private-line-complaint-negotiation/evaluation/business-abnormal-cases.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "B-G-PROPOSE-NO-ITEM",
+    "api": "generate_propose",
+    "input": "当前只需要继续处理这条专线投诉，请直接给出处理建议，不需要列出待补充信息。",
+    "description": "发起协商文本没有明确的待补充信息项",
+    "expectedCodes": ["negotiation_slot_missing", "negotiation_content_extract_failed"]
+  },
+  {
+    "id": "B-G-PROPOSE-FREEFORM",
+    "api": "generate_propose",
+    "input": "请用一段自然语言概述对端需要提供的资料，不要使用信息项列表或逐项结构。",
+    "description": "发起协商文本明确要求非模板列表结构",
+    "expectedCodes": ["negotiation_slot_missing", "negotiation_content_extract_failed"]
+  },
+  {
+    "id": "B-G-ACCEPT-NO-RESULT",
+    "api": "generate_accept",
+    "input": "接受本次协商，后续再补充具体信息。",
+    "description": "接受文本没有提供任何结果内容",
+    "expectedCodes": ["negotiation_slot_missing", "negotiation_content_extract_failed"]
+  },
+  {
+    "id": "B-G-ACCEPT-VAGUE-RESULT",
+    "api": "generate_accept",
+    "input": "同意，信息按之前说的处理即可。",
+    "description": "接受文本只有结论，没有可渲染的逐项结果",
+    "expectedCodes": ["negotiation_slot_missing", "negotiation_content_extract_failed"]
+  },
+  {
+    "id": "B-G-REJECT-NO-REASON",
+    "api": "generate_reject",
+    "input": "拒绝本次协商。",
+    "description": "拒绝文本没有说明拒绝原因或结果项",
+    "expectedCodes": ["negotiation_slot_missing", "negotiation_content_extract_failed"]
+  },
+  {
+    "id": "B-G-REJECT-FREEFORM",
+    "api": "generate_reject",
+    "input": "这次不方便提供资料，请用一段话说明即可，不需要逐项列出拒绝内容。",
+    "description": "拒绝文本要求非逐项结果结构",
+    "expectedCodes": ["negotiation_slot_missing", "negotiation_content_extract_failed"]
+  },
+  {
+    "id": "B-V-PROPOSE-MISSING-SECTION",
+    "api": "validate_propose",
+    "input": "## 信息协商\n请继续处理当前投诉。",
+    "description": "发起报文缺少所需信息项段落",
+    "expectedCodes": ["negotiation_rule_violation", "negotiation_semantic_rejected"]
+  },
+  {
+    "id": "B-V-PROPOSE-FREEFORM-SECTION",
+    "api": "validate_propose",
+    "input": "## 信息协商\n请根据<所需信息项>补充相关内容。\n\n## 所需信息项\n请提供相关资料即可。",
+    "description": "发起报文的所需信息项不是逐项列表",
+    "expectedCodes": ["negotiation_rule_violation", "negotiation_semantic_rejected"]
+  },
+  {
+    "id": "B-V-ACCEPT-MISSING-RESULT",
+    "api": "validate_accept",
+    "input": "## 信息协商结果\nAccept",
+    "description": "接受报文缺少结果内容段落",
+    "expectedCodes": ["negotiation_rule_violation", "negotiation_semantic_rejected"]
+  },
+  {
+    "id": "B-V-ACCEPT-FREEFORM-RESULT",
+    "api": "validate_accept",
+    "input": "## 信息协商结果\nAccept\n\n## 信息协商结果内容\n相关信息保持不变。",
+    "description": "接受结果内容不是逐项信息",
+    "expectedCodes": ["negotiation_rule_violation", "negotiation_semantic_rejected"]
+  },
+  {
+    "id": "B-V-REJECT-MISSING-RESULT",
+    "api": "validate_reject",
+    "input": "## 信息协商结果\nReject",
+    "description": "拒绝报文缺少结果内容段落",
+    "expectedCodes": ["negotiation_rule_violation", "negotiation_semantic_rejected"]
+  },
+  {
+    "id": "B-V-REJECT-FREEFORM-RESULT",
+    "api": "validate_reject",
+    "input": "## 信息协商结果\nReject\n\n## 信息协商结果内容\n由于当前情况不允许，暂时无法提供。",
+    "description": "拒绝结果内容没有按请求信息项逐项说明",
+    "expectedCodes": ["negotiation_rule_violation", "negotiation_semantic_rejected"]
+  }
+]


### PR DESCRIPTION
Adds deterministic abnormal evaluation cases for all six natural-language Negotiation-T APIs and SDK error codes, real-LLM business-structure abnormal cases, and removes gold/exact-value matching from the Qwen report. Sample sources/resources and POM only; excludes SDK logging, prompt capture, environment files, internal endpoints, and credentials. Run guide remains in PR #166. Verification: mvn -pl a2a-t-sample -am test (all passed).