### PR TITLE
docs: cover the negotiation abort APIs and add detailed reference volumes

### DIFF
--- a/docs/en/A2A-T-Negotiation-API-Reference.md
+++ b/docs/en/A2A-T-Negotiation-API-Reference.md
@@ -1,0 +1,548 @@
+# A2A-T Negotiation (Negotiation-T) API Reference
+
+> Negotiation volume of [A2A-T-SDK-API-Reference.md](../zh/A2A-T-SDK-API-Reference.md), covering the negotiation extension API surface for per-capability lookup.
+
+---
+
+## 1. Capability Overview
+
+The negotiation extension (Negotiation-T) lets client and server align before task execution: information gathering, target alignment, feasibility confirmation, and negotiation termination. The SDK exposes the capability in three layers:
+
+| Layer | Responsibility | Entry points |
+|---|---|---|
+| Runtime state machine | turn/round advancement, state validation, context persistence | `startNegotiation` / `receiveNegotiation` / `continueNegotiation` |
+| Content generation | renders negotiation messages from typed content (fromData deterministic, fromText with one LLM extraction step) | `generateNegotiation*PromptFromData/FromText` |
+| Validation & parameter extraction | rule gate + semantic validation + parameter merge, extracting structured parameters from rendered messages | `validate*PromptAndDataFilling` |
+
+All three layers are exposed through the `A2ATClient` / `A2ATServer` facades with **fully symmetric method signatures** (see [NegotiationV3ApiSurfaceTest](../../a2a-t-sample/src/test/java/net/openan/a2at/sdk/sample/api/NegotiationV3ApiSurfaceTest.java)). The differences are role binding only, plus the server-side prompt compliance check.
+
+### 1.1 Maven coordinates
+
+```xml
+<dependency>
+    <groupId>net.openan.a2a-t.sdk</groupId>
+    <artifactId>a2a-t-client</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+Use `a2a-t-server` instead on the server side. The negotiation module arrives as a transitive dependency of either; no separate dependency is needed.
+
+### 1.2 Negotiation-related `.env` configuration
+
+| Key | Default | Description |
+|---|---|---|
+| A2AT_LANGUAGE | en-US | Message language, `zh-CN` or `en-US` |
+| A2AT_PROMPT_SOURCE_TYPE | local_file | `classpath` uses packaged resources, `local_file` a local directory |
+| A2AT_PROMPT_RESOURCE_LOCAL_ROOT_DIR | (packaged dir) | Local resource root; relative paths resolve against the .env directory |
+| A2AT_LLM_PROVIDER | (required) | Only `openai` is supported (DeepSeek, Azure and other OpenAI-compatible endpoints) |
+| A2AT_LLM_MODEL | (required) | Model name |
+| A2AT_LLM_API_KEY | (required) | API key |
+| A2AT_LLM_BASE_URL | (optional) | Base URL of the OpenAI-compatible API |
+| A2AT_NEGOTIATION_STATE_STORE_TYPE | in_memory | Negotiation state store type; currently only `in_memory` |
+
+---
+
+## 2. Extension URIs
+
+Defined in [ExtensionUriConstants](../../a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/ExtensionUriConstants.java):
+
+| Purpose | URI |
+|---|---|
+| Negotiation-T (canonical, for sending) | `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1` |
+| Negotiation-T (NL legacy, accepted on receive) | `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/NL/v1` |
+
+The SDK sends new messages with the canonical URI as `MetadataContent.extensionUri()`; the receive-side payload mapper also recognizes the NL alias for backward compatibility.
+
+---
+
+## 3. Runtime State Machine API
+
+Both client and server expose the three methods driving the start/receive/continue flow. They operate on the `types.model`-layer `NegotiationContext` (not the content-layer context; the two are not interchangeable, see §7.1).
+
+### 3.1 startNegotiation — start a negotiation
+
+```java
+Map<String, Object> startNegotiation(
+    NegotiationType type,
+    String contentText,
+    Map<String, Object> facts)
+```
+
+- `type`: negotiation type (`INFORMATION` / `TARGET` / `FEASIBILITY`)
+- `contentText`: negotiation message text
+- `facts`: structured facts to attach; when non-empty they land in the top-level `facts` of the payload
+
+Generates a UUID as `negotiationId`, creates a round=1, status=`in-progress` context, stores it, and returns the initial round payload:
+
+```json
+{
+  "https://.../Negotiation-T/NL/v1": {
+    "message": "negotiation message text",
+    "negotiationType": "target",
+    "negotiationId": "uuid",
+    "round": 1,
+    "status": "in-progress",
+    "extra": {}
+  },
+  "facts": {}
+}
+```
+
+> Starting performs no state validation and throws no state exceptions.
+
+### 3.2 receiveNegotiation — receive a peer negotiation message
+
+```java
+Map<String, Object> receiveNegotiation(
+    String message,
+    Map<String, Object> context)
+```
+
+- `message`: the received negotiation message text
+- `context`: the transport context payload sent by the peer (the map under the extension URI)
+
+First deserializes the context with `NegotiationPayloadMapper.contextFromMap`, then runs state validation in a fixed order:
+
+1. Rollback: reject when incoming round < stored round
+2. Terminal reopen: reject when stored is terminal and incoming is in-progress
+3. Terminal change: reject when stored is terminal and incoming status differs
+4. Max rounds: when in-progress and round >= 8, return a "max rounds reached, please reject" advisory (store not updated)
+5. Round jump: reject when incoming round > stored round + 1
+
+After passing, dispatches to the handler by type and returns:
+
+```json
+{
+  "needResponse": true,
+  "facts": {},
+  "message": "processed message",
+  "context": {
+    "negotiationType": "...",
+    "negotiationId": "...",
+    "round": 1,
+    "status": "in-progress",
+    "extra": {}
+  }
+}
+```
+
+### 3.3 continueNegotiation — advance a negotiation locally
+
+```java
+Map<String, Object> continueNegotiation(
+    NegotiationContext context,
+    NegotiationStatus status,
+    String contentText)
+```
+
+- `context`: current negotiation context snapshot (must match local storage exactly, preventing forked branches)
+- `status`: next-round status (`IN_PROGRESS` / `AGREED` / `REJECTED`)
+- `contentText`: next-round message content
+
+Validation: stored record exists, context round equals stored round, stored status is still in-progress. On success round is incremented, the new record is stored, and the payload is returned. **facts is always an empty map.** Only in-progress → agreed / rejected transitions are allowed; terminal states are final.
+
+### 3.4 State machine enums
+
+```java
+enum NegotiationType   { INFORMATION, TARGET, FEASIBILITY }
+enum NegotiationStatus { IN_PROGRESS, AGREED, REJECTED }
+enum NegotiationRole   { CLIENT, SERVER }
+```
+
+In payloads, type/status use the lowercased enum name with underscores as hyphens (e.g. `in-progress`); deserialization converts hyphens back to underscores and uppercases.
+
+---
+
+## 4. Content Generation API
+
+Both facades proxy `NegotiationContentService`, which drives `NegotiationGenerationOrchestrator`. Every pipeline has a `fromData` (deterministic; negotiation message generation makes no LLM call) and a `fromText` (one LLM structured-extraction step) variant, covering the propose / accept / reject / abort phases. The eight methods have byte-identical signatures on both facades.
+
+> Note: "no LLM" applies to the **negotiation message rendering step only**. The SDK configuration (`A2AT_LLM_API_KEY` etc.) is always mandatory; other steps (Task-T slot extraction, semantic validation) still call the LLM.
+
+### 4.1 fromData generation (deterministic; no LLM for message rendering)
+
+```java
+MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, TemplateUri templateUri);
+MetadataContent generateNegotiationAcceptPromptFromData (NegotiationEndingData  data, TemplateUri templateUri);
+MetadataContent generateNegotiationRejectPromptFromData (NegotiationEndingData  data, TemplateUri templateUri);
+MetadataContent generateNegotiationAbortPromptFromData  (NegotiationAbortData   data, TemplateUri templateUri);
+```
+
+Flow: parse `templateUri` → load template → `GeneratorRegistry` exact-type dispatch → generator renders → return `MetadataContent`.
+
+- accept requires content conclusion `ACCEPT`, reject requires `REJECT`; otherwise a `NegotiationContentException` is thrown
+- abort is negotiation-type independent, rendered by the single common abort template, carrying only the termination reason (see §4.4)
+
+### 4.2 fromText generation (one LLM extraction step)
+
+```java
+MetadataContent generateNegotiationProposePromptFromText(String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationAcceptPromptFromText (String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationRejectPromptFromText (String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationAbortPromptFromText  (String text, NegotiationContext context, TemplateUri templateUri);
+```
+
+The `NegotiationContext` here is the content-generation one (`net.openan.a2at.sdk.core.model.NegotiationContext`, see §7.1); it is injected into the rendered message and never passes through the LLM.
+
+Flow: parse `templateUri` → load template (before the LLM call) → `DefaultNegotiationContentExtractor` one-step LLM structured extraction → `mapContent` to the typed record → render → return `MetadataContent`.
+
+### 4.3 Return value MetadataContent
+
+```java
+record MetadataContent(
+    String templateUri,    // template URI
+    String promptText,     // rendered message text
+    String extensionUri    // TMF extension URI (canonical Negotiation-T URI)
+)
+```
+
+Builds the A2A-T metadata map directly:
+
+```java
+MetadataContent mc = client.generateNegotiationProposePromptFromData(data, StandardTemplates.TARGET_NEGOTIATION_PROPOSE);
+Map<String, String> metadata = mc.buildMetadataContent();
+// { extensionUri -> promptText, "template_uri" -> templateUri }
+```
+
+### 4.4 Input data models
+
+**Propose phase**
+
+```java
+record NegotiationProposeData(
+    NegotiationContext context,           // content-generation context
+    NegotiationProposeContent content     // typed content
+)
+```
+
+**Ending phase (accept / reject)**
+
+```java
+record NegotiationEndingData(
+    NegotiationContext context,
+    NegotiationEndingContent content
+)
+```
+
+**Abort phase (negotiation termination)**
+
+```java
+record NegotiationAbortData(
+    NegotiationContext context,
+    NegotiationAbortContent content       // carries the termination reason only
+)
+```
+
+### 4.5 Typed content models
+
+**Propose-phase content** (sealed interface `NegotiationProposeContent`)
+
+```java
+// information negotiation: list of missing information items
+record InformationProposeContent(
+    List<NegotiationItem> items,   // required, at least one
+    String relationship            // optional, relationship among the items
+)
+
+// target negotiation: description + intent understanding + alignment + clarification + confirm request
+record TargetProposeContent(
+    String targetNegotiationDescription,               // required
+    List<NegotiationItem> intentUnderstanding,          // optional (first round; null later)
+    List<NegotiationItem> alignmentAndClarification,    // optional (later rounds; null on round one)
+    List<NegotiationItem> requestForClarification,      // optional
+    String targetConfirmRequest                         // optional, text requesting peer confirmation
+)
+
+// feasibility negotiation: description + action + evaluation content / infeasibility details + confirm request
+record FeasibilityProposeContent(
+    String feasibilityNegotiationDescription,               // required
+    NegotiationAction action,                                // required, selects the conditional section
+    List<NegotiationItem> contentsToEvaluate,                // required when action=REQUEST_FEASIBILITY_EVALUATION
+    List<NegotiationItem> infeasibilityDetailsAndProposal,   // required when action=PROPOSE_ALTERNATIVE_ON_FAILURE
+    String feasibilityConfirmRequest                         // optional, text requesting peer confirmation
+)
+```
+
+**Ending-phase content** (sealed interface `NegotiationEndingContent`)
+
+```java
+record InformationEndingContent(NegotiationConclusion conclusion, List<NegotiationItem> items)
+
+record TargetEndingContent(NegotiationConclusion conclusion,
+                           String confirmedIntent,   // required on accept
+                           String failureReason)     // required on reject
+
+record FeasibilityEndingContent(NegotiationConclusion conclusion, String feasibilitySummary)
+```
+
+**Abort-phase content**
+
+```java
+record NegotiationAbortContent(String terminationReason)   // required, negotiation termination reason
+```
+
+### 4.6 Auxiliary types
+
+```java
+record NegotiationItem(String name, String value)  // name non-null, value nullable
+
+enum NegotiationConclusion { ACCEPT, REJECT, ABORT }
+enum NegotiationAction {
+    REQUEST_FEASIBILITY_EVALUATION,
+    PROPOSE_ALTERNATIVE_ON_FAILURE
+}
+```
+
+Accept and reject share the `accept-reject` template, distinguished by the `NegotiationConclusion` value; ABORT uses the separate common abort template (see §5).
+
+---
+
+## 5. Template URIs
+
+Typed templates follow `Negotiation-T/{type-segment}/{phase-segment}/v1`; abort is type independent and uses the common template.
+
+| Scenario | URI |
+|---|---|
+| Information propose | `Negotiation-T/information-negotiation/propose/v1` |
+| Information accept/reject | `Negotiation-T/information-negotiation/accept-reject/v1` |
+| Target propose | `Negotiation-T/target-negotiation/propose/v1` |
+| Target accept/reject | `Negotiation-T/target-negotiation/accept-reject/v1` |
+| Feasibility propose | `Negotiation-T/feasibility-negotiation/propose/v1` |
+| Feasibility accept/reject | `Negotiation-T/feasibility-negotiation/accept-reject/v1` |
+| Negotiation termination (common) | `Negotiation-T/common/abort/v1` |
+
+The template URI layer collapses four performatives into three segments: `ACCEPT` and `REJECT` share the `accept-reject` segment (distinguished by the conclusion value), while `ABORT` is carried by the type-independent common template. Typed templates map to `StandardTemplates` constants (e.g. `INFORMATION_NEGOTIATION_PROPOSE`); abort maps to `StandardTemplates.NEGOTIATION_ABORT`.
+
+URI parsing rules (`NegotiationReference.parse`): exactly 4 slash-separated segments; segment 1 must be `Negotiation-T`; segment 2 is `{type}-negotiation` or `common` (common is abort only); segment 3 must be `propose` or `accept-reject`, and `abort` for the abort template; segment 4 must be `v1`.
+
+### 5.1 Template lookup API
+
+```java
+List<PromptTemplate>       getNegotiationPrompts();              // all negotiation templates of the current language, fixed order
+Optional<PromptTemplate>   getNegotiationPrompt(String uri);    // single lookup by URI
+List<PromptTemplate>       getPrompts();                         // across all extensions
+Optional<PromptTemplate>   getPrompt(String uri);                // by URI across extensions
+```
+
+These methods never throw; missing entries yield an empty list or Optional.empty.
+
+---
+
+## 6. Validation & Parameter Extraction API
+
+### 6.1 Method signatures
+
+```java
+FilledParamData validateProposePromptAndDataFilling(String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateAcceptPromptAndDataFilling (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateRejectPromptAndDataFilling (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateAbortPromptAndDataFilling  (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+```
+
+- `prompt`: the rendered negotiation message text
+- `context`: the content-generation `NegotiationContext` (see §7.1); participates in the rule gate and is merged into the returned data
+- `schema`: caller-provided JSON schema describing the parameters to extract
+- `templateUri`: the expected negotiation type and phase (phase must match the method; the abort method uses the common abort template)
+
+Returns:
+
+```java
+record FilledParamData(Map<String, Object> data)
+```
+
+### 6.2 Validation pipeline
+
+1. **Rule gate** (`DefaultNegotiationComplianceChecker`, deterministic, no LLM)
+   - splits sections on `##` and detects the negotiation context section (via the `Vocabulary` `section.context` key)
+   - validates `id` as a UUID (8-4-4-4-12 hex)
+   - validates `round` and `maxRounds` as positive integers with round <= maxRounds
+   - performs no type inference, conclusion-value checks, or conditional-section mutual exclusion
+   - on success returns the context parameters `{id, round, maxRounds}`
+2. **LLM semantic validation** (`DefaultNegotiationSemanticValidator`, retriable)
+   - one structured LLM call producing the verdict (pass/reject), implied type, semantic error list, and the parameters extracted per the caller schema
+   - when the verdict is true, implied type must match the reference type
+3. **Parameter merge** (deterministic)
+   - context parameters (id, round, maxRounds) are written first, then the LLM-extracted parameters
+   - on collision the context parameters win and a warning is logged
+
+---
+
+## 7. The Two Contexts & Payload Utilities
+
+### 7.1 The two NegotiationContext types (not interchangeable)
+
+| Class | Purpose | Fields |
+|---|---|---|
+| `net.openan.a2at.sdk.core.model.NegotiationContext` | content generation/validation | `id, round, maxRounds, performative` |
+| `net.openan.a2at.sdk.negotiation.types.model.NegotiationContext` | state machine | `negotiationType, negotiationId, round, status` |
+
+State-machine methods (start/receive/continue) use the `types.model` layer; content generation/validation uses the `core.model` layer. The content-generation context is a record with `of(id, round, performative)`, `nextRound()`, `isExhausted()`, and `DEFAULT_MAX_ROUNDS = 5`; `performative` is mandatory and expresses which kind of message the context travels with (`PROPOSE` puts a proposal on the table, `ACCEPT` / `REJECT` respond to a proposal, `ABORT` terminates the negotiation) — the generation API honors it when rendering the outbound message.
+
+### 7.2 NegotiationPayloadMapper
+
+```java
+// deserialize a payload map into a state-machine context
+NegotiationContext ctx = NegotiationPayloadMapper.contextFromMap(contextMap);
+
+// serialize a state-machine context into a payload map (message/type/id/round/status/extra)
+Map<String, Object> payload = NegotiationPayloadMapper.contextPayload(ctx);
+
+// extract the negotiation context map from a full payload (canonical URI and NL alias both accepted)
+Map<String, Object> contextMap = NegotiationPayloadMapper.extractContextMap(payload);
+
+// build a full negotiation payload (extension URI as top-level key; facts at top level when non-empty)
+Map<String, Object> payload = NegotiationPayloadMapper.payload(context, contentText, facts);
+```
+
+---
+
+## 8. Exceptions & Error Codes
+
+### 8.1 Exception taxonomy
+
+| Exception | Nature | Carries |
+|---|---|---|
+| `NegotiationContentException` | programming error | message + field (path of the offending field) |
+| `NegotiationGenerationException` | generation failure | code + message + cause |
+| `NegotiationParamExtractionException` | validation failure | code + message + errors (per-slot) |
+| `NegotiationStateException` | state machine error | message (runtime state machine layer) |
+
+### 8.2 Error codes
+
+| Code | Meaning | Retriable |
+|---|---|---|
+| `template_not_found` | template/prompt resource missing | no |
+| `negotiation_content_extract_failed` | LLM extraction response unparseable | yes |
+| `negotiation_llm_infrastructure_error` | LLM infrastructure failure | yes |
+| `negotiation_slot_missing` | required field missing | no |
+| `negotiation_invalid_input` | input contradicts phase/action | no |
+| `negotiation_rule_violation` | rule gate rejection | no |
+| `negotiation_semantic_rejected` | semantic validation rejection | no |
+| `input_text_too_long` | fromText input exceeds the configured maximum length | no |
+
+### 8.3 Retry policy
+
+`NegotiationGenerationOrchestrator.withRetry` retries LLM steps uniformly: only `negotiation_content_extract_failed` and `negotiation_llm_infrastructure_error` are retriable; every other code fails fast. After exhaustion the original error is rethrown with its code intact; the default `maxAttempts` comes from the LLM config.
+
+---
+
+## 9. State Storage
+
+```java
+public interface NegotiationStore {
+    NegotiationRecord get(String negotiationId);
+    void save(NegotiationRecord record);   // negotiationId must be non-null
+    void delete(String negotiationId);
+    boolean cleanupExpired();
+}
+```
+
+Only `InMemoryNegotiationStore` exists today; it provides no persistence. Inject a custom implementation through `NegotiationHandler.Builder.store()`.
+
+---
+
+## 10. Usage Examples
+
+### 10.1 Start a negotiation and generate a propose message
+
+```java
+A2ATClient client = new A2ATClient(Path.of(".env"));
+
+// 1. render the structured negotiation message with the content engine
+NegotiationContext contentCtx = new NegotiationContext(
+    UUID.randomUUID().toString(), 1,
+    NegotiationContext.DEFAULT_MAX_ROUNDS, NegotiationPerformative.PROPOSE);
+TargetProposeContent content = new TargetProposeContent(
+    "Cross-city private-line outage diagnosis",
+    List.of(new NegotiationItem("intent", "Restore the city1-city2 SPN private line")),
+    null,
+    List.of(new NegotiationItem("city1_omc", "Provide the city1 OMC alarm details")),
+    null);
+MetadataContent mc = client.generateNegotiationProposePromptFromData(
+    new NegotiationProposeData(contentCtx, content),
+    StandardTemplates.TARGET_NEGOTIATION_PROPOSE);
+
+// 2. initialize the state machine with the rendered message text
+Map<String, Object> payload = client.startNegotiation(
+    NegotiationType.TARGET, mc.promptText(), Map.of("agent", "city1-agent"));
+
+// 3. merge the metadata
+Map<String, String> metadata = mc.buildMetadataContent();
+```
+
+### 10.2 Receive and validate a negotiation message
+
+```java
+Map<String, Object> receiveResult = client.receiveNegotiation(message, contextMap);
+
+if (Boolean.TRUE.equals(receiveResult.get("needResponse"))) {
+    Map<String, Object> schema = Map.of(
+        "type", "object",
+        "properties", Map.of(
+            "city1_omc_alarm", Map.of("type", "string"),
+            "optical_power", Map.of("type", "number")));
+    FilledParamData params = client.validateProposePromptAndDataFilling(
+        message, contentCtx, schema, StandardTemplates.TARGET_NEGOTIATION_PROPOSE);
+    // params.data() carries id, round, maxRounds + the LLM-extracted parameters
+}
+```
+
+### 10.3 Advance the negotiation to agreement
+
+```java
+net.openan.a2at.sdk.negotiation.types.model.NegotiationContext ctx =
+    NegotiationPayloadMapper.contextFromMap(
+        (Map<String, Object>) receiveResult.get("context"));
+Map<String, Object> payload = client.continueNegotiation(
+    ctx, NegotiationStatus.AGREED, "Params confirmed, starting execution");
+```
+
+### 10.4 Generate a negotiation message from free text
+
+```java
+NegotiationContext contentCtx = NegotiationContext.of("session-123", 1, NegotiationPerformative.PROPOSE);
+MetadataContent mc = client.generateNegotiationProposePromptFromText(
+    "City1-city2 SPN private line outage; city1 OMC reports port down, optical power -28dBm",
+    contentCtx,
+    StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+// the LLM extracts InformationProposeContent (items + relationship) and renders it
+```
+
+### 10.5 Generate ending messages
+
+```java
+// accept
+MetadataContent acceptMc = client.generateNegotiationAcceptPromptFromData(
+    new NegotiationEndingData(contentCtx,
+        new TargetEndingContent(NegotiationConclusion.ACCEPT, "Confirmed intent: restore the line", null)),
+    StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT);
+
+// reject
+MetadataContent rejectMc = client.generateNegotiationRejectPromptFromData(
+    new NegotiationEndingData(contentCtx,
+        new TargetEndingContent(NegotiationConclusion.REJECT, null, "Insufficient resources")),
+    StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT);
+
+// terminate the negotiation
+MetadataContent abortMc = client.generateNegotiationAbortPromptFromData(
+    new NegotiationAbortData(contentCtx,
+        new NegotiationAbortContent("Parties could not agree on the diagnosis scope; terminating")),
+    StandardTemplates.NEGOTIATION_ABORT);
+```
+
+Runnable end-to-end samples: [a2a-t-sample negotiation samples](../../a2a-t-sample/README.zh-CN.md#协商negotiation样例).
+
+---
+
+## 11. Supported Scope & Limitations
+
+| Capability | Status |
+|---|---|
+| Runtime state machine (start/receive/continue) | complete; all three types registered |
+| Content generation (fromData/fromText) | complete; 8 generators covering propose/accept/reject/abort for all three types |
+| Validation & parameter extraction | complete; propose/accept/reject/abort all supported |
+| Information runtime handler | substantive logic (incl. compliance checker) |
+| Target / Feasibility runtime handlers | echo stubs (content layer complete, runtime not wired) |
+| State persistence | in-memory only |
+| Language coverage | zh-CN and en-US |

--- a/docs/en/API_Reference.md
+++ b/docs/en/API_Reference.md
@@ -17,6 +17,9 @@ The public APIs of the A2A-T SDK converge on two facades: the client facade `A2A
 | Negotiation-T | `validateProposePromptAndDataFilling` | A2A-T Client / A2A-T Server | Validates a negotiation propose message and extracts parameters per a schema | Yes (1 LLM semantic-validation call) |
 | Negotiation-T | `validateAcceptPromptAndDataFilling` | A2A-T Client / A2A-T Server | Validates a negotiation accept message and extracts parameters per a schema | Yes (1 LLM semantic-validation call) |
 | Negotiation-T | `validateRejectPromptAndDataFilling` | A2A-T Client / A2A-T Server | Validates a negotiation reject message and extracts parameters per a schema | Yes (1 LLM semantic-validation call) |
+| Negotiation-T | `generateNegotiationAbortPromptFromText` | A2A-T Client / A2A-T Server | Generates a negotiation abort message from natural-language text | Yes (1 LLM content-extraction call) |
+| Negotiation-T | `generateNegotiationAbortPromptFromData` | A2A-T Client / A2A-T Server | Deterministically generates a negotiation abort message from structured data (no LLM call) | No |
+| Negotiation-T | `validateAbortPromptAndDataFilling` | A2A-T Client / A2A-T Server | Validates a negotiation abort message and extracts parameters per the schema | Yes (1 LLM semantic-validation call) |
 | Task-T | `generateTaskPromptFromText` | A2A-T Client | Generates a task prompt from natural-language text with the specified Task-T template (skips scenario recognition) | Yes (1 LLM slot-extraction call) |
 | Task-T | `generateTaskPromptFromDataWithSchema` | A2A-T Client | Generates a task prompt from structured data plus a semantic schema with the specified Task-T template | Yes (1 LLM slot-extraction call) |
 | Task-T | `validateTaskPromptAndDataFilling` | A2A-T Server | Validates a Task-T task prompt and extracts parameters per a schema | Yes (1 LLM semantic-validation and extraction call) |
@@ -32,7 +35,7 @@ The public APIs of the A2A-T SDK converge on two facades: the client facade `A2A
 **Common Data Types and Conventions**
 
 - **TemplateUri:** the template URI value type. Prefer building it with the `net.openan.a2at.sdk.core.model.StandardTemplates` constants, e.g. `StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE` (URI `Negotiation-T/information-negotiation/propose/v1`); for strings coming from outside the code, parse them with `TemplateUri.parse(String)`, which returns an `Optional<TemplateUri>` and never throws.
-- **Negotiation session context:** `NegotiationContext(id, round, maxRounds)` (id in UUID form, round starting at 1, default round budget `DEFAULT_MAX_ROUNDS = 5`); it travels with the message metadata and never goes through the LLM. `NegotiationContext.of(id, round)` uses the default budget, and `nextRound()` advances the round.
+- **Negotiation session context:** `NegotiationContext(id, round, maxRounds, performative)` (id in UUID form, round starting at 1, default round budget `DEFAULT_MAX_ROUNDS = 5`; performative states which kind of negotiation message the context travels with: `PROPOSE` / `ACCEPT` / `REJECT` / `ABORT`); it travels with the message metadata and never goes through the LLM. `NegotiationContext.of(id, round, performative)` uses the default budget, and `nextRound()` advances the round.
 - **Exception hierarchy:** every SDK processing failure is a subclass of `A2ATError` — generation failures throw `PromptGenerationException` (Task-T / Notification-T / Authorization-T) or `NegotiationGenerationException` (Negotiation-T); validation-plus-extraction failures throw `ContentValidationException` (Task-T / Notification-T / Authorization-T, carrying the `errors()` slot error details and the `params()` partial extraction parameters) or `NegotiationParamExtractionException` (Negotiation-T). Catching `A2ATError` covers all processing failures, and `getCode()` returns the machine-readable error code.
 - **SlotValidationError:** per-slot validation error details, returned with validation-failure exceptions or failure payloads; the failure structures in the "Output" sections of each API all reference this definition:
 
@@ -83,7 +86,8 @@ import net.openan.a2at.sdk.core.model.StandardTemplates;
 A2ATClient client = new A2ATClient(Path.of("client.env"));
 
 NegotiationContext ctx = new NegotiationContext(
-        "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 1, NegotiationContext.DEFAULT_MAX_ROUNDS);
+        "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 1, NegotiationContext.DEFAULT_MAX_ROUNDS,
+        NegotiationPerformative.PROPOSE);
 
 MetadataContent propose = client.generateNegotiationProposePromptFromText(
         "Please provide the following missing information: 1. Access port name: please provide the service access port name; "
@@ -300,7 +304,8 @@ import net.openan.a2at.sdk.negotiation.content.InformationProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
 
-NegotiationContext ctx = new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5);
+NegotiationContext ctx = new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5,
+        NegotiationPerformative.PROPOSE);
 
 MetadataContent propose = client.generateNegotiationProposePromptFromData(
         new NegotiationProposeData(
@@ -1574,7 +1579,175 @@ result.failure() =
 { code=slot_validation_error, message=Required slot 'task_object' is missing., stage=slot_validation }
 ```
 
+### 1.3.21 generateNegotiationAbortPromptFromText
 
+**API Definition**
 
+```java
+public MetadataContent generateNegotiationAbortPromptFromText(
+        String text, NegotiationContext context, TemplateUri templateUri)
+```
 
+**Typical scenario**: either negotiation party concludes that the negotiation cannot continue (round limit reached, timeout, token budget exhausted, etc.) and generates a negotiation abort message from a natural-language termination statement.
 
+**Functionality**: generates a negotiation abort message from natural-language text with one LLM structured-extraction step (extracting the termination reason). The abort message is negotiation-type independent; `templateUri` must be the common abort template (`StandardTemplates.NEGOTIATION_ABORT`, URI `Negotiation-T/common/abort/v1`), and the context performative should be `ABORT`.
+
+**Input**
+
+| Parameter | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| text | String | Yes | Natural-language description of the termination reason |
+| context | `NegotiationContext` | Yes | Negotiation session context (performative `ABORT`) |
+| templateUri | TemplateUri | Yes | Common abort template |
+
+**Request example**
+
+```java
+MetadataContent abort = client.generateNegotiationAbortPromptFromText(
+        "Reached the negotiation round limit. This negotiation is confirmed and ended.",
+        ctx,
+        StandardTemplates.NEGOTIATION_ABORT);
+```
+
+**Output**
+
+On success returns `MetadataContent` (same structure as [1.3.1](#131-generatenegotiationproposepromptfromtext)).
+
+On failure throws `NegotiationGenerationException` (same structure as 1.3.1). Error codes:
+
+- `template_not_found` (template or prompt resource missing)
+
+- `negotiation_content_extract_failed` (termination reason not extractable from the text, retriable)
+
+- `negotiation_llm_infrastructure_error` (LLM infrastructure failure, retriable)
+
+- `negotiation_invalid_input` (text empty or extracted content does not match the abort phase)
+
+- `negotiation_slot_missing` (required slot missing)
+
+A null argument throws `NullPointerException`; a templateUri whose phase segment is not `abort` throws `IllegalArgumentException`.
+
+**Response example**
+
+```text
+templateUri : Negotiation-T/common/abort/v1
+extensionUri: https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1
+promptText  :
+## Negotiation Result
+Abort
+
+## Negotiation Termination Reason
+Reached the negotiation round limit. This negotiation is confirmed and ended.
+```
+
+### 1.3.22 generateNegotiationAbortPromptFromData
+
+**API Definition**
+
+```java
+public MetadataContent generateNegotiationAbortPromptFromData(
+        NegotiationAbortData data, TemplateUri templateUri)
+```
+
+**Typical scenario**: either negotiation party programmatically decides that a termination condition holds and generates the abort message from a structured termination reason.
+
+**Functionality**: deterministically generates a negotiation abort message from typed data, **with no LLM call**. The abort message is negotiation-type independent; `templateUri` must be the common abort template.
+
+**Input**
+
+| Parameter | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| data | `NegotiationAbortData(context, content)` | Yes | Negotiation context (performative `ABORT`) + termination content |
+| templateUri | TemplateUri | Yes | Common abort template |
+
+Termination content: `NegotiationAbortContent(terminationReason)`, where terminationReason is the required termination reason.
+
+**Request example**
+
+```java
+import net.openan.a2at.sdk.negotiation.content.NegotiationAbortContent;
+import net.openan.a2at.sdk.negotiation.content.NegotiationAbortData;
+
+MetadataContent abort = client.generateNegotiationAbortPromptFromData(
+        new NegotiationAbortData(
+                ctx,
+                new NegotiationAbortContent("Reached the negotiation round limit. This negotiation is confirmed and ended.")),
+        StandardTemplates.NEGOTIATION_ABORT);
+```
+
+**Output**
+
+On success returns `MetadataContent` (same structure as [1.3.1](#131-generatenegotiationproposepromptfromtext)).
+
+On failure throws `NegotiationGenerationException` (same structure as 1.3.1). Error codes:
+
+- `template_not_found` (template missing)
+
+- `negotiation_slot_missing` (required slot missing during rendering)
+
+Programming errors: a null argument or null context throws `NullPointerException`; a blank termination reason or a phase segment other than `abort` throws `IllegalArgumentException`.
+
+**Response example**
+
+```text
+templateUri : Negotiation-T/common/abort/v1
+extensionUri: https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1
+promptText  :
+## Negotiation Result
+Abort
+
+## Negotiation Termination Reason
+Reached the negotiation round limit. This negotiation is confirmed and ended.
+```
+
+### 1.3.23 validateAbortPromptAndDataFilling
+
+**API Definition**
+
+```java
+public FilledParamData validateAbortPromptAndDataFilling(
+        String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri)
+```
+
+**Typical scenario**: one party validates the peer abort message, extracts the termination reason, and closes the local negotiation state accordingly.
+
+**Functionality**: validates a negotiation abort message and extracts parameters per the schema. The pipeline is the same as 1.3.7, except that the message must satisfy the abort-phase semantic constraints (conclusion Abort, with a negotiation-termination-reason section) and `templateUri` must be the common abort template.
+
+**Input**: same as 1.3.7, with prompt being the abort message text and templateUri the common abort template.
+
+**Request example**
+
+```java
+FilledParamData abortParams = server.validateAbortPromptAndDataFilling(
+        abortPrompt, ctx, schema, StandardTemplates.NEGOTIATION_ABORT);
+```
+
+**Output**
+
+On success returns `FilledParamData` (same structure as [1.3.7](#137-validateproposepromptanddatafilling)); `data()` carries the parameters extracted from the termination reason per the schema plus the context parameters.
+
+On failure throws `NegotiationParamExtractionException` (same structure as 1.3.7). Error codes:
+
+- `negotiation_invalid_input` (message is not an abort negotiation message or context is null)
+
+- `negotiation_rule_violation` (negotiation context violates the structural rules)
+
+- `negotiation_semantic_rejected` (conclusion is not Abort or the termination-reason section is missing)
+
+- `negotiation_llm_infrastructure_error` (LLM infrastructure failure, retriable)
+
+- `template_not_found` (validation prompt resource missing)
+
+Programming errors: null prompt or schema throws `NullPointerException`; a blank prompt or a phase segment other than `abort` throws `IllegalArgumentException`.
+
+**Response example**
+
+```text
+abortParams.data() =
+{
+  termination_reason=Reached the negotiation round limit. This negotiation is confirmed and ended.,
+  id=3dbc13b5-bd57-4c2b-b503-24e381b6c8d3,
+  round=1,
+  maxRounds=5
+}
+```

--- a/docs/zh/A2A-T-Negotiation-API-Reference.md
+++ b/docs/zh/A2A-T-Negotiation-API-Reference.md
@@ -1,0 +1,548 @@
+# A2A-T 协商（Negotiation-T）API 文档
+
+> 本文是 [A2A-T-SDK-API-Reference.md](A2A-T-SDK-API-Reference.md) 的协商分册，专项覆盖协商扩展的对外 API，便于按能力域查阅。
+
+---
+
+## 一、能力概览
+
+协商扩展（Negotiation-T）让 client 与 server 在执行任务前对齐参数：信息收集、目标对齐、可行性确认，以及协商终止。SDK 把协商能力拆成三层对外暴露：
+
+| 层 | 职责 | 入口 |
+|---|---|---|
+| 运行时状态机 | 管理 turn/round 推进、状态校验、上下文持久化 | `startNegotiation` / `receiveNegotiation` / `continueNegotiation` |
+| 内容生成 | 按类型化内容渲染协商消息（fromData 确定性、fromText 含一步 LLM 抽取） | `generateNegotiation*PromptFromData/FromText` |
+| 校验与参数提取 | 规则门 + 语义校验 + 参数合并，从已渲染消息提取结构化参数 | `validate*PromptAndDataFilling` |
+
+三层通过 `A2ATClient` / `A2ATServer` 两个 facade 暴露，**方法签名完全对称**（见 [NegotiationV3ApiSurfaceTest](../../a2a-t-sample/src/test/java/net/openan/a2at/sdk/sample/api/NegotiationV3ApiSurfaceTest.java)）。差异仅在角色绑定与 server 额外的 prompt 合规校验。
+
+### 1.1 Maven 坐标
+
+```xml
+<dependency>
+    <groupId>net.openan.a2a-t.sdk</groupId>
+    <artifactId>a2a-t-client</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+Server 侧用 `a2a-t-server` 替代。协商模块由二者传递依赖引入，无需单独加依赖。
+
+### 1.2 协商相关 `.env` 配置项
+
+| 配置项 | 默认值 | 说明 |
+|---|---|---|
+| A2AT_LANGUAGE | en-US | 消息语言，`zh-CN` 或 `en-US` |
+| A2AT_PROMPT_SOURCE_TYPE | local_file | `classpath` 用打包资源，`local_file` 用本地目录 |
+| A2AT_PROMPT_RESOURCE_LOCAL_ROOT_DIR | （打包目录） | 本地资源根目录，相对路径基于 .env 所在目录 |
+| A2AT_LLM_PROVIDER | （必填） | 仅支持 `openai`（兼容 DeepSeek、Azure 等） |
+| A2AT_LLM_MODEL | （必填） | 模型名 |
+| A2AT_LLM_API_KEY | （必填） | API key |
+| A2AT_LLM_BASE_URL | （可选） | OpenAI 兼容 API 的 base URL |
+| A2AT_NEGOTIATION_STATE_STORE_TYPE | in_memory | 协商状态存储类型，当前仅 `in_memory` |
+
+---
+
+## 二、扩展 URI
+
+定义在 [ExtensionUriConstants](../../a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/ExtensionUriConstants.java)：
+
+| 用途 | URI |
+|---|---|
+| Negotiation-T（规范，发送用） | `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1` |
+| Negotiation-T（NL legacy，接收兼容） | `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/NL/v1` |
+
+SDK 用规范 URI 作为 `MetadataContent.extensionUri()` 发送新消息；接收侧的 payload mapper 同时识别 NL 别名以兼容旧消息。
+
+---
+
+## 三、运行时状态机 API
+
+Client 与 Server 均提供以下三个方法，驱动协商状态机的 start/receive/continue 流程。它们操作 `types.model` 层的 `NegotiationContext`（非内容层 context，两者不可混用，见 §7.1）。
+
+### 3.1 startNegotiation —— 发起协商
+
+```java
+Map<String, Object> startNegotiation(
+    NegotiationType type,
+    String contentText,
+    Map<String, Object> facts)
+```
+
+- `type`：协商类型（`INFORMATION` / `TARGET` / `FEASIBILITY`）
+- `contentText`：协商消息文本
+- `facts`：附带的结构化事实，非空时进入 payload 顶层 `facts`
+
+内部生成 UUID 作为 `negotiationId`，创建 round=1、status=`in-progress` 的 context，存入 store，返回初始轮 payload：
+
+```json
+{
+  "https://.../Negotiation-T/NL/v1": {
+    "message": "协商消息文本",
+    "negotiationType": "target",
+    "negotiationId": "uuid",
+    "round": 1,
+    "status": "in-progress",
+    "extra": {}
+  },
+  "facts": {}
+}
+```
+
+> 启动不做状态校验，不抛状态异常。
+
+### 3.2 receiveNegotiation —— 接收对端协商消息
+
+```java
+Map<String, Object> receiveNegotiation(
+    String message,
+    Map<String, Object> context)
+```
+
+- `message`：接收到的协商消息文本
+- `context`：对端发来的 transport context payload（即 payload 中扩展 URI 下的那层 map）
+
+先用 `NegotiationPayloadMapper.contextFromMap` 反序列化 context，再执行状态校验（顺序固定）：
+
+1. 回退校验：incoming round < stored round 时拒绝
+2. 终态重开：stored 已终态且 incoming 为 in-progress 时拒绝
+3. 终态变更：stored 已终态且 incoming status 不同时拒绝
+4. 最大轮次：in-progress 且 round >= 8 时返回「已达最大轮次，请拒绝」建议（不更新 store）
+5. 轮次跳跃：incoming round > stored round + 1 时拒绝
+
+通过后按 type 分发到 handler，返回：
+
+```json
+{
+  "needResponse": true,
+  "facts": {},
+  "message": "处理后的消息",
+  "context": {
+    "negotiationType": "...",
+    "negotiationId": "...",
+    "round": 1,
+    "status": "in-progress",
+    "extra": {}
+  }
+}
+```
+
+### 3.3 continueNegotiation —— 本地推进协商
+
+```java
+Map<String, Object> continueNegotiation(
+    NegotiationContext context,
+    NegotiationStatus status,
+    String contentText)
+```
+
+- `context`：当前协商上下文快照（必须与本地存储完全匹配，防止分支分裂）
+- `status`：下一轮状态（`IN_PROGRESS` / `AGREED` / `REJECTED`）
+- `contentText`：下一轮消息内容
+
+校验：stored record 存在、context round 与 stored round 一致、stored status 仍为 in-progress。通过后 round+1，存新 record，返回 payload。**facts 固定为空 map**。状态转换仅允许 in-progress → agreed / rejected；终态不可再变。
+
+### 3.4 状态机枚举
+
+```java
+enum NegotiationType   { INFORMATION, TARGET, FEASIBILITY }
+enum NegotiationStatus { IN_PROGRESS, AGREED, REJECTED }
+enum NegotiationRole   { CLIENT, SERVER }
+```
+
+payload 中 type/status 取枚举名小写、下划线转连字符（如 `in-progress`）；反序列化时连字符转下划线再大写还原。
+
+---
+
+## 四、内容生成 API
+
+Client 与 Server 均通过 `NegotiationContentService` 代理 `NegotiationGenerationOrchestrator`。每条流水线都有 `fromData`（确定性，协商报文生成不调 LLM）和 `fromText`（含一步 LLM 结构化抽取）两个变体，覆盖 propose / accept / reject / abort 四个阶段，两 facade 的这八个方法签名逐字相同。
+
+> 注意："无 LLM"仅指**协商报文生成环节**。SDK 整体配置（`A2AT_LLM_API_KEY` 等）始终必填，其他环节（Task-T 槽位提取、语义校验）仍调用 LLM。
+
+### 4.1 fromData 生成（确定性，协商报文生成不调 LLM）
+
+```java
+MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, TemplateUri templateUri);
+MetadataContent generateNegotiationAcceptPromptFromData (NegotiationEndingData  data, TemplateUri templateUri);
+MetadataContent generateNegotiationRejectPromptFromData (NegotiationEndingData  data, TemplateUri templateUri);
+MetadataContent generateNegotiationAbortPromptFromData  (NegotiationAbortData   data, TemplateUri templateUri);
+```
+
+流程：解析 `templateUri` → 加载模板 → `GeneratorRegistry` 精确类型匹配 dispatch → Generator 渲染 → 返回 `MetadataContent`。
+
+- accept 要求内容 conclusion 必须为 `ACCEPT`，reject 必须为 `REJECT`，否则抛 `NegotiationContentException`
+- abort 与协商类型无关，由唯一的 common abort 模板渲染，只需携带终止原因（见 §4.4）
+
+### 4.2 fromText 生成（含一步 LLM 抽取）
+
+```java
+MetadataContent generateNegotiationProposePromptFromText(String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationAcceptPromptFromText (String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationRejectPromptFromText (String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationAbortPromptFromText  (String text, NegotiationContext context, TemplateUri templateUri);
+```
+
+注意此处的 `NegotiationContext` 是内容生成用的（`net.openan.a2at.sdk.core.model.NegotiationContext`，见 §7.1），只注入到渲染消息里，不经过 LLM。
+
+流程：解析 `templateUri` → 加载模板（LLM 调用前先加载）→ `DefaultNegotiationContentExtractor` 一步 LLM 结构化抽取 → `mapContent` 映射到类型化 record → 渲染 → 返回 `MetadataContent`。
+
+### 4.3 返回值 MetadataContent
+
+```java
+record MetadataContent(
+    String templateUri,    // 模板 URI
+    String promptText,     // 渲染后的消息文本
+    String extensionUri    // TMF 扩展 URI（规范 Negotiation-T URI）
+)
+```
+
+直接生成 A2A-T metadata map：
+
+```java
+MetadataContent mc = client.generateNegotiationProposePromptFromData(data, StandardTemplates.TARGET_NEGOTIATION_PROPOSE);
+Map<String, String> metadata = mc.buildMetadataContent();
+// { extensionUri -> promptText, "template_uri" -> templateUri }
+```
+
+### 4.4 输入数据模型
+
+**Propose 阶段**
+
+```java
+record NegotiationProposeData(
+    NegotiationContext context,           // 内容生成 context
+    NegotiationProposeContent content     // 类型化内容
+)
+```
+
+**Ending 阶段（accept / reject）**
+
+```java
+record NegotiationEndingData(
+    NegotiationContext context,
+    NegotiationEndingContent content
+)
+```
+
+**Abort 阶段（协商终止）**
+
+```java
+record NegotiationAbortData(
+    NegotiationContext context,
+    NegotiationAbortContent content       // 仅携带终止原因
+)
+```
+
+### 4.5 类型化内容模型
+
+**Propose 阶段内容**（sealed 接口 `NegotiationProposeContent`）
+
+```java
+// 信息协商：缺失信息项列表
+record InformationProposeContent(
+    List<NegotiationItem> items,   // 必填，至少一项
+    String relationship            // 可选，项之间关系描述
+)
+
+// 目标协商：目标描述 + 意图理解 + 对齐澄清 + 待澄清 + 确认请求
+record TargetProposeContent(
+    String targetNegotiationDescription,               // 必填
+    List<NegotiationItem> intentUnderstanding,          // 可选（首轮有，后续 null）
+    List<NegotiationItem> alignmentAndClarification,    // 可选（后续轮有，首轮 null）
+    List<NegotiationItem> requestForClarification,      // 可选
+    String targetConfirmRequest                         // 可选，请求对端确认的文本
+)
+
+// 可行性协商：描述 + 动作 + 评估内容 / 不可行详情 + 确认请求
+record FeasibilityProposeContent(
+    String feasibilityNegotiationDescription,               // 必填
+    NegotiationAction action,                                // 必填，选择条件段
+    List<NegotiationItem> contentsToEvaluate,                // action=REQUEST_FEASIBILITY_EVALUATION 时必填
+    List<NegotiationItem> infeasibilityDetailsAndProposal,   // action=PROPOSE_ALTERNATIVE_ON_FAILURE 时必填
+    String feasibilityConfirmRequest                         // 可选，请求对端确认的文本
+)
+```
+
+**Ending 阶段内容**（sealed 接口 `NegotiationEndingContent`）
+
+```java
+record InformationEndingContent(NegotiationConclusion conclusion, List<NegotiationItem> items)
+
+record TargetEndingContent(NegotiationConclusion conclusion,
+                           String confirmedIntent,   // accept 时必填
+                           String failureReason)     // reject 时必填
+
+record FeasibilityEndingContent(NegotiationConclusion conclusion, String feasibilitySummary)
+```
+
+**Abort 阶段内容**
+
+```java
+record NegotiationAbortContent(String terminationReason)   // 必填，协商终止原因
+```
+
+### 4.6 辅助类型
+
+```java
+record NegotiationItem(String name, String value)  // name 非空，value 可空
+
+enum NegotiationConclusion { ACCEPT, REJECT, ABORT }
+enum NegotiationAction {
+    REQUEST_FEASIBILITY_EVALUATION,
+    PROPOSE_ALTERNATIVE_ON_FAILURE
+}
+```
+
+accept 与 reject 共享 `accept-reject` 模板，由 `NegotiationConclusion` 值区分；ABORT 使用独立的 common abort 模板（见 §5）。
+
+---
+
+## 五、模板 URI
+
+类型化模板格式：`Negotiation-T/{type-segment}/{phase-segment}/v1`；abort 与类型无关，使用 common 模板。
+
+| 场景 | URI |
+|---|---|
+| 信息协商提议 | `Negotiation-T/information-negotiation/propose/v1` |
+| 信息协商接受/拒绝 | `Negotiation-T/information-negotiation/accept-reject/v1` |
+| 目标协商提议 | `Negotiation-T/target-negotiation/propose/v1` |
+| 目标协商接受/拒绝 | `Negotiation-T/target-negotiation/accept-reject/v1` |
+| 可行性协商提议 | `Negotiation-T/feasibility-negotiation/propose/v1` |
+| 可行性协商接受/拒绝 | `Negotiation-T/feasibility-negotiation/accept-reject/v1` |
+| 协商终止（通用） | `Negotiation-T/common/abort/v1` |
+
+模板 URI 层把四个 performative 归并为三段：`ACCEPT` 与 `REJECT` 共享 `accept-reject` 段（由 conclusion 值区分），`ABORT` 由类型无关的 common 模板承载。类型化模板对应 `StandardTemplates` 中的常量（如 `INFORMATION_NEGOTIATION_PROPOSE`），abort 对应 `StandardTemplates.NEGOTIATION_ABORT`。
+
+URI 解析规则（`NegotiationReference.parse`）：恰好 4 个 slash 分隔段；第 1 段必须为 `Negotiation-T`；第 2 段为 `{type}-negotiation` 或 `common`（common 仅用于 abort）；第 3 段必须为 `propose` 或 `accept-reject`，abort 模板为 `abort`；第 4 段必须为 `v1`。
+
+### 5.1 模板查询 API
+
+```java
+List<PromptTemplate>       getNegotiationPrompts();              // 当前语言的全部协商模板，固定顺序
+Optional<PromptTemplate>   getNegotiationPrompt(String uri);    // 按 URI 查单个
+List<PromptTemplate>       getPrompts();                         // 跨所有扩展
+Optional<PromptTemplate>   getPrompt(String uri);                // 跨扩展按 URI 查
+```
+
+这些方法不抛异常，缺失返回空列表或 empty。
+
+---
+
+## 六、校验与参数提取 API
+
+### 6.1 方法签名
+
+```java
+FilledParamData validateProposePromptAndDataFilling(String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateAcceptPromptAndDataFilling (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateRejectPromptAndDataFilling (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateAbortPromptAndDataFilling  (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+```
+
+- `prompt`：已渲染的协商消息文本
+- `context`：内容生成用的 `NegotiationContext`（见 §7.1），参与规则门校验并合并进返回数据
+- `schema`：调用方提供的参数 JSON schema，描述要提取的参数
+- `templateUri`：声明预期的协商类型和阶段（phase 必须与方法匹配；abort 方法用 common abort 模板）
+
+返回：
+
+```java
+record FilledParamData(Map<String, Object> data)
+```
+
+### 6.2 校验管线
+
+1. **规则门**（`DefaultNegotiationComplianceChecker`，确定性，无 LLM）
+   - 按 `##` 分段，识别是否含协商上下文段（通过 `Vocabulary` 的 `section.context` 匹配）
+   - 校验 `id` 为 UUID 格式（8-4-4-4-12 十六进制）
+   - 校验 `round` 和 `maxRounds` 为正整数，且 round 不超 maxRounds
+   - 不做类型推断、conclusion 值校验或条件段互斥
+   - 成功返回 context 参数 `{id, round, maxRounds}`
+2. **LLM 语义校验**（`DefaultNegotiationSemanticValidator`，可重试）
+   - 一步结构化 LLM 调用，同时产出 verdict（通过/拒绝）、implied type、语义错误列表、按 callerSchema 提取的参数
+   - verdict 为 true 时强制校验 implied type 与 reference type 一致
+3. **参数合并**（确定性）
+   - 先写 context 参数（id、round、maxRounds），再写 LLM 提取参数
+   - 冲突时 context 参数优先，并记录 warning
+
+---
+
+## 七、两套 Context 与 Payload 工具
+
+### 7.1 两套 NegotiationContext（不可混用）
+
+| 类 | 用途 | 字段 |
+|---|---|---|
+| `net.openan.a2at.sdk.core.model.NegotiationContext` | 内容生成/校验 | `id, round, maxRounds, performative` |
+| `net.openan.a2at.sdk.negotiation.types.model.NegotiationContext` | 状态机 | `negotiationType, negotiationId, round, status` |
+
+状态机方法（start/receive/continue）用 `types.model` 层的；内容生成/校验用 `core.model` 层的。内容生成 context 是 record，带 `of(id, round, performative)`、`nextRound()`、`isExhausted()`，`DEFAULT_MAX_ROUNDS = 5`；`performative` 必填，表达该 context 随哪类消息出行（`PROPOSE` 提出提案，`ACCEPT` / `REJECT` 回应提案，`ABORT` 终止协商），生成 API 渲染出站消息时以此为准。
+
+### 7.2 NegotiationPayloadMapper
+
+```java
+// 从 payload map 反序列化为状态机 context
+NegotiationContext ctx = NegotiationPayloadMapper.contextFromMap(contextMap);
+
+// 把状态机 context 序列化为 payload map（含 message/type/id/round/status/extra）
+Map<String, Object> payload = NegotiationPayloadMapper.contextPayload(ctx);
+
+// 从完整 payload 中提取协商 context map（兼容规范 URI 和 NL 别名）
+Map<String, Object> contextMap = NegotiationPayloadMapper.extractContextMap(payload);
+
+// 构建完整协商 payload（扩展 URI 为顶层 key，facts 非空时放顶层）
+Map<String, Object> payload = NegotiationPayloadMapper.payload(context, contentText, facts);
+```
+
+---
+
+## 八、异常与错误码
+
+### 8.1 异常分类
+
+| 异常类型 | 性质 | 携带信息 |
+|---|---|---|
+| `NegotiationContentException` | 编程错误 | message + field（出错字段路径） |
+| `NegotiationGenerationException` | 生成失败 | code + message + cause |
+| `NegotiationParamExtractionException` | 校验失败 | code + message + errors（逐 slot 错误） |
+| `NegotiationStateException` | 状态机错误 | message（运行时状态机层） |
+
+### 8.2 错误码
+
+| 码 | 含义 | 可重试 |
+|---|---|---|
+| `template_not_found` | 模板/prompt 资源缺失 | 否 |
+| `negotiation_content_extract_failed` | LLM 内容抽取响应不可解析 | 是 |
+| `negotiation_llm_infrastructure_error` | LLM 调用基础设施失败 | 是 |
+| `negotiation_slot_missing` | 必填字段缺失 | 否 |
+| `negotiation_invalid_input` | 输入与 phase/action 矛盾 | 否 |
+| `negotiation_rule_violation` | 规则门校验失败 | 否 |
+| `negotiation_semantic_rejected` | 语义校验拒绝 | 否 |
+| `input_text_too_long` | fromText 输入超出配置的最大长度 | 否 |
+
+### 8.3 重试策略
+
+`NegotiationGenerationOrchestrator.withRetry` 对 LLM 步骤统一重试：只有 `negotiation_content_extract_failed` 与 `negotiation_llm_infrastructure_error` 可重试，其他错误码立即抛出；耗尽后原样重抛（保留原始 error code）；默认 `maxAttempts` 来自 LLM config。
+
+---
+
+## 九、状态存储
+
+```java
+public interface NegotiationStore {
+    NegotiationRecord get(String negotiationId);
+    void save(NegotiationRecord record);   // negotiationId 不可为空
+    void delete(String negotiationId);
+    boolean cleanupExpired();
+}
+```
+
+当前只有 `InMemoryNegotiationStore`，不保证持久化。可通过 `NegotiationHandler.Builder.store()` 注入自定义实现。
+
+---
+
+## 十、使用示例
+
+### 10.1 发起协商并生成提议消息
+
+```java
+A2ATClient client = new A2ATClient(Path.of(".env"));
+
+// 1. 用内容生成引擎渲染结构化协商消息
+NegotiationContext contentCtx = new NegotiationContext(
+    UUID.randomUUID().toString(), 1,
+    NegotiationContext.DEFAULT_MAX_ROUNDS, NegotiationPerformative.PROPOSE);
+TargetProposeContent content = new TargetProposeContent(
+    "跨城市专线中断诊断",
+    List.of(new NegotiationItem("intent", "恢复城市1到城市2的SPN专线")),
+    null,
+    List.of(new NegotiationItem("city1_omc", "请提供城市1 OMC告警详情")),
+    null);
+MetadataContent mc = client.generateNegotiationProposePromptFromData(
+    new NegotiationProposeData(contentCtx, content),
+    StandardTemplates.TARGET_NEGOTIATION_PROPOSE);
+
+// 2. 用渲染好的消息文本初始化状态机
+Map<String, Object> payload = client.startNegotiation(
+    NegotiationType.TARGET, mc.promptText(), Map.of("agent", "city1-agent"));
+
+// 3. 合并 metadata
+Map<String, String> metadata = mc.buildMetadataContent();
+```
+
+### 10.2 接收并校验协商消息
+
+```java
+Map<String, Object> receiveResult = client.receiveNegotiation(message, contextMap);
+
+if (Boolean.TRUE.equals(receiveResult.get("needResponse"))) {
+    Map<String, Object> schema = Map.of(
+        "type", "object",
+        "properties", Map.of(
+            "city1_omc_alarm", Map.of("type", "string"),
+            "optical_power", Map.of("type", "number")));
+    FilledParamData params = client.validateProposePromptAndDataFilling(
+        message, contentCtx, schema, StandardTemplates.TARGET_NEGOTIATION_PROPOSE);
+    // params.data() 含 id, round, maxRounds + LLM 提取参数
+}
+```
+
+### 10.3 推进协商到同意
+
+```java
+net.openan.a2at.sdk.negotiation.types.model.NegotiationContext ctx =
+    NegotiationPayloadMapper.contextFromMap(
+        (Map<String, Object>) receiveResult.get("context"));
+Map<String, Object> payload = client.continueNegotiation(
+    ctx, NegotiationStatus.AGREED, "参数已确认，开始执行");
+```
+
+### 10.4 从自由文本生成协商消息
+
+```java
+NegotiationContext contentCtx = NegotiationContext.of("session-123", 1, NegotiationPerformative.PROPOSE);
+MetadataContent mc = client.generateNegotiationProposePromptFromText(
+    "城市1到城市2的SPN专线中断，城市1 OMC告警端口Down，光功率-28dBm",
+    contentCtx,
+    StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+// LLM 自动抽取 InformationProposeContent（items + relationship）并渲染
+```
+
+### 10.5 生成终态消息
+
+```java
+// 接受
+MetadataContent acceptMc = client.generateNegotiationAcceptPromptFromData(
+    new NegotiationEndingData(contentCtx,
+        new TargetEndingContent(NegotiationConclusion.ACCEPT, "确认意图：恢复专线", null)),
+    StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT);
+
+// 拒绝
+MetadataContent rejectMc = client.generateNegotiationRejectPromptFromData(
+    new NegotiationEndingData(contentCtx,
+        new TargetEndingContent(NegotiationConclusion.REJECT, null, "资源不足无法执行")),
+    StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT);
+
+// 终止协商
+MetadataContent abortMc = client.generateNegotiationAbortPromptFromData(
+    new NegotiationAbortData(contentCtx,
+        new NegotiationAbortContent("双方无法就诊断范围达成一致，终止协商")),
+    StandardTemplates.NEGOTIATION_ABORT);
+```
+
+完整可运行样例见 [a2a-t-sample 协商样例](../../a2a-t-sample/README.zh-CN.md#协商negotiation样例)。
+
+---
+
+## 十一、当前支持范围与局限
+
+| 能力 | 状态 |
+|---|---|
+| 协商运行时状态机（start/receive/continue） | 完整，三种类型均注册 |
+| 协商内容生成（fromData/fromText） | 完整，三种类型 × propose/accept/reject/abort 八个生成器均实现 |
+| 协商校验参数提取（validateAndFilling） | 完整，propose/accept/reject/abort 四个阶段均支持 |
+| Information 运行时 handler | 有实质逻辑（含 compliance checker） |
+| Target / Feasibility 运行时 handler | 空壳 echo（内容层已完整，运行时未对接） |
+| 状态持久化 | 仅 in-memory |
+| 语言覆盖 | zh-CN 和 en-US |

--- a/docs/zh/A2A-T-SDK-API-Reference.md
+++ b/docs/zh/A2A-T-SDK-API-Reference.md
@@ -1,0 +1,656 @@
+# A2A-T SDK Java 对外 API 文档
+
+> 覆盖协商（Negotiation-T）、任务提示（Task-T）、授权（Authorization-T）、通知（Notification-T）四类扩展的对外 API。协商能力的完整说明见分册 [A2A-T-Negotiation-API-Reference.md](A2A-T-Negotiation-API-Reference.md)。
+
+---
+
+## 一、模块与依赖
+
+### 1.1 Maven 坐标
+
+```xml
+<dependency>
+    <groupId>net.openan.a2a-t.sdk</groupId>
+    <artifactId>a2a-t-client</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+Server 侧用 a2a-t-server 替代：
+
+```xml
+<dependency>
+    <groupId>net.openan.a2a-t.sdk</groupId>
+    <artifactId>a2a-t-server</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+版本统一管理用 a2a-t-bom：
+
+```xml
+<dependency>
+    <groupId>net.openan.a2a-t.sdk</groupId>
+    <artifactId>a2a-t-bom</artifactId>
+    <version>1.0.0</version>
+    <type>pom</type>
+    <scope>import</scope>
+</dependency>
+```
+
+### 1.2 模块结构
+
+| 模块 | 作用 |
+|---|---|
+| a2a-t-bom | 版本对齐 BOM |
+| a2a-t-core | 共享配置加载、值类型、JSON 解析、异常体系 |
+| a2a-t-resources | 打包资源和 classpath 加载 |
+| a2a-t-llm | LLM 适配层（默认 OpenAI 兼容） |
+| a2a-t-prompt | 场景识别、slot 抽取、模板渲染 |
+| a2a-t-negotiation | 协商类型、运行时状态机、内容生成引擎、校验流水线 |
+| a2a-t-client | 客户端 facade（A2ATClient） |
+| a2a-t-server | 服务端 facade（A2ATServer） |
+| a2a-t-sample | 可运行的 client/server 示例 |
+
+a2a-t-client 和 a2a-t-server 通过传递依赖引入 negotiation 模块，内容生成和校验能力已可用，无需额外加依赖。
+
+---
+
+## 二、初始化
+
+### 2.1 构造
+
+Client 和 Server 都通过 .env 文件路径构造：
+
+```java
+import net.openan.a2at.sdk.client.A2ATClient;
+import java.nio.file.Path;
+
+A2ATClient client = new A2ATClient(Path.of("/path/to/.env"));
+
+// Server 侧
+import net.openan.a2at.sdk.server.A2ATServer;
+A2ATServer server = new A2ATServer(Path.of("/path/to/.env"));
+```
+
+构造时自动完成：加载 .env 配置 -> 创建 LLM client -> 组装 prompt 生成/合规编排器 -> 组装协商编排器 -> 组装内容生成编排器。
+
+### 2.2 .env 配置项
+
+| 配置项 | 默认值 | 说明 |
+|---|---|---|
+| A2AT_LANGUAGE | en-US | 消息语言，zh-CN 或 en-US |
+| A2AT_PROMPT_SOURCE_TYPE | local_file | classpath 用打包资源，local_file 用本地目录 |
+| A2AT_PROMPT_RESOURCE_LOCAL_ROOT_DIR | （打包目录） | 本地资源根目录，相对路径基于 .env 所在目录 |
+| A2AT_PROMPT_COMPLIANCE_ENABLED | false | 是否启用 prompt 合规校验 |
+| A2AT_LLM_PROVIDER | （必填） | 仅支持 openai（兼容 DeepSeek、Azure 等） |
+| A2AT_LLM_MODEL | （必填） | 模型名 |
+| A2AT_LLM_API_KEY | （必填） | API key |
+| A2AT_LLM_BASE_URL | （可选） | OpenAI 兼容 API 的 base URL |
+| A2AT_LLM_MAX_TOKENS | （可选） | 最大 token 数 |
+| A2AT_LLM_TEMPERATURE | （可选） | 温度 |
+| A2AT_LLM_TIMEOUT_SECONDS | （可选） | 超时秒数 |
+| A2AT_LLM_MAX_ATTEMPTS | （可选） | LLM 步骤重试次数上限 |
+| A2AT_LLM_REASONING_EFFORT | （可选） | 推理强度 |
+| A2AT_LLM_DISABLE_SYSTEM_PROXY | （可选） | 禁用系统代理 |
+| A2AT_INPUT_TEXT_MAX_CHARS | （可选） | fromText 输入的最大字符数 |
+| A2AT_LLM_HISTORY_WINDOW | 10 | 对话历史窗口 |
+| A2AT_LLM_SESSION_MAX_TOTAL | 300 | 会话总数上限 |
+| A2AT_LLM_SESSION_MAX_PER_PROVIDER | 100 | 每 provider 会话数上限 |
+| A2AT_NEGOTIATION_STATE_STORE_TYPE | in_memory | 协商状态存储类型 |
+| A2AT_CRED_KEY | （可选） | 凭据加密密钥（32 字节 hex） |
+
+---
+
+## 三、扩展 URI 常量
+
+定义在 ExtensionUriConstants：
+
+| 扩展 | URI |
+|---|---|
+| Task-T | https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1 |
+| Authorization-T | https://projects.tmforum.org/a2aproject/telecommunication/extensions/Authorization-T/v1 |
+| Notification-T | https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1 |
+| Negotiation-T（规范） | https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1 |
+| Negotiation-T（NL legacy） | https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/NL/v1 |
+
+SDK 用规范 URI 发送新消息，接收侧同时识别 NL 别名以兼容旧消息。
+
+---
+
+## 四、协商运行时状态机 API
+
+Client 和 Server 均提供以下三个方法，驱动协商状态机的 start/receive/continue 流程。完整说明（含状态校验顺序、payload 结构）见分册 §3。
+
+```java
+Map<String, Object> startNegotiation(NegotiationType type, String contentText, Map<String, Object> facts)
+Map<String, Object> receiveNegotiation(String message, Map<String, Object> context)
+Map<String, Object> continueNegotiation(NegotiationContext context, NegotiationStatus status, String contentText)
+```
+
+### 4.4 枚举类型
+
+```java
+enum NegotiationType   { INFORMATION, TARGET, FEASIBILITY }
+enum NegotiationStatus { IN_PROGRESS, AGREED, REJECTED }
+enum NegotiationRole   { CLIENT, SERVER }
+```
+
+### 4.5 运行时 Context（两套，不可混用）
+
+| 类 | 用途 | 字段 |
+|---|---|---|
+| `net.openan.a2at.sdk.core.model.NegotiationContext` | 内容生成/校验 | `id, round, maxRounds, performative` |
+| `net.openan.a2at.sdk.negotiation.types.model.NegotiationContext` | 状态机 | `negotiationType, negotiationId, round, status` |
+
+内容生成 context 带 `of(id, round, performative)`、`nextRound()`、`isExhausted()`，`DEFAULT_MAX_ROUNDS = 5`；`performative` 必填（`PROPOSE` / `ACCEPT` / `REJECT` / `ABORT`）。
+
+### 4.6 Payload 工具
+
+```java
+NegotiationContext ctx = NegotiationPayloadMapper.contextFromMap(contextMap);   // 反序列化
+Map<String, Object> payload = NegotiationPayloadMapper.contextPayload(ctx);      // 序列化
+Map<String, Object> contextMap = NegotiationPayloadMapper.extractContextMap(payload);  // 提取
+Map<String, Object> payload = NegotiationPayloadMapper.payload(context, contentText, facts);  // 构建
+```
+
+---
+
+## 五、协商内容生成 API
+
+每条流水线都有 `fromData`（确定性，协商报文生成不调 LLM）和 `fromText`（含一步 LLM 结构化抽取）两个变体，覆盖 propose / accept / reject / abort 四个阶段：
+
+```java
+MetadataContent generateNegotiationProposePromptFromData(NegotiationProposeData data, TemplateUri templateUri);
+MetadataContent generateNegotiationAcceptPromptFromData (NegotiationEndingData  data, TemplateUri templateUri);
+MetadataContent generateNegotiationRejectPromptFromData (NegotiationEndingData  data, TemplateUri templateUri);
+MetadataContent generateNegotiationAbortPromptFromData  (NegotiationAbortData   data, TemplateUri templateUri);
+
+MetadataContent generateNegotiationProposePromptFromText(String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationAcceptPromptFromText (String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationRejectPromptFromText (String text, NegotiationContext context, TemplateUri templateUri);
+MetadataContent generateNegotiationAbortPromptFromText  (String text, NegotiationContext context, TemplateUri templateUri);
+```
+
+### 5.3 返回值 MetadataContent
+
+```java
+record MetadataContent(
+    String templateUri,    // 模板 URI
+    String promptText,     // 渲染后的消息文本
+    String extensionUri    // TMF 扩展 URI（规范 Negotiation-T URI）
+)
+```
+
+### 5.4 输入数据模型
+
+```java
+record NegotiationProposeData(NegotiationContext context, NegotiationProposeContent content)
+record NegotiationEndingData (NegotiationContext context, NegotiationEndingContent content)
+record NegotiationAbortData  (NegotiationContext context, NegotiationAbortContent content)
+```
+
+### 5.5 类型化内容模型
+
+```java
+record InformationProposeContent(List<NegotiationItem> items, String relationship)
+
+record TargetProposeContent(
+    String targetNegotiationDescription,
+    List<NegotiationItem> intentUnderstanding,
+    List<NegotiationItem> alignmentAndClarification,
+    List<NegotiationItem> requestForClarification,
+    String targetConfirmRequest)
+
+record FeasibilityProposeContent(
+    String feasibilityNegotiationDescription,
+    NegotiationAction action,
+    List<NegotiationItem> contentsToEvaluate,
+    List<NegotiationItem> infeasibilityDetailsAndProposal,
+    String feasibilityConfirmRequest)
+
+record InformationEndingContent(NegotiationConclusion conclusion, List<NegotiationItem> items)
+record TargetEndingContent(NegotiationConclusion conclusion, String confirmedIntent, String failureReason)
+record FeasibilityEndingContent(NegotiationConclusion conclusion, String feasibilitySummary)
+record NegotiationAbortContent(String terminationReason)
+```
+
+字段约束与各字段的语义见分册 §4.4-4.6。
+
+### 5.6 辅助类型
+
+```java
+record NegotiationItem(String name, String value)
+
+enum NegotiationConclusion { ACCEPT, REJECT, ABORT }
+enum NegotiationAction { REQUEST_FEASIBILITY_EVALUATION, PROPOSE_ALTERNATIVE_ON_FAILURE }
+```
+
+### 5.7 模板 URI 格式
+
+类型化模板：`Negotiation-T/{type}-negotiation/{propose|accept-reject}/v1`；协商终止模板与类型无关：`Negotiation-T/common/abort/v1`。`StandardTemplates` 提供全部常量（如 `INFORMATION_NEGOTIATION_PROPOSE`、`NEGOTIATION_ABORT`）。
+
+---
+
+## 六、协商校验与参数提取 API
+
+```java
+FilledParamData validateProposePromptAndDataFilling(String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateAcceptPromptAndDataFilling (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateRejectPromptAndDataFilling (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+FilledParamData validateAbortPromptAndDataFilling  (String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri);
+```
+
+校验管线（规则门 → LLM 语义校验 → 参数合并）与返回值 `FilledParamData(Map<String, Object> data)` 的完整说明见分册 §6。
+
+---
+
+## 七、模板查询 API
+
+```java
+List<PromptTemplate>       getNegotiationPrompts();              // 当前语言的全部协商模板，固定顺序
+Optional<PromptTemplate>   getNegotiationPrompt(String uri);    // 按 URI 查单个
+List<PromptTemplate>       getPrompts();                         // 跨所有扩展
+Optional<PromptTemplate>   getPrompt(String uri);                // 跨扩展按 URI 查
+```
+
+这些方法不会抛异常，缺失返回空列表或 empty。
+
+---
+
+## 八、任务提示 API
+
+### 8.1 Client 侧
+
+```java
+// 从用户输入生成任务提示
+PromptGenerationResult generateTaskPrompt(Object userInput)
+
+// 从自由文本生成（绕过场景识别，直接用指定模板）
+MetadataContent generateTaskPromptFromText(String text, TemplateUri templateUri)
+
+// 从结构化数据生成（带可选 schema）
+MetadataContent generateTaskPromptFromDataWithSchema(
+    Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+
+// 从自由文本生成授权提示（实验性）
+MetadataContent generateAuthPromptFromText(String text, TemplateUri templateUri)
+
+// 从结构化数据生成授权提示（实验性）
+MetadataContent generateAuthPromptFromDataWithSchema(
+    Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+
+// 从自由文本生成通知提示
+MetadataContent generateNotificationPromptFromText(String text, TemplateUri templateUri)
+
+// 从结构化数据生成通知提示
+MetadataContent generateNotificationPromptFromDataWithSchema(
+    Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+```
+
+PromptGenerationResult 结构：
+
+```java
+record PromptGenerationResult(
+    boolean success,
+    String promptText,           // 成功时的渲染文本
+    PromptGenerationFailure failure  // 失败时的详情
+)
+
+record PromptGenerationFailure(String code, String message, String stage)
+```
+
+### 8.2 Server 侧
+
+```java
+// 校验已处理的任务提示
+PromptComplianceResult checkTaskPrompt(String processedPromptText)
+```
+
+PromptComplianceResult 结构：
+
+```java
+record PromptComplianceResult(
+    boolean success,
+    TaskPromptComplianceFailure failure  // 失败时携带 code/message/stage
+)
+```
+
+---
+
+## 九、异常体系
+
+### 9.1 异常分类
+
+| 异常类型 | 性质 | 携带信息 |
+|---|---|---|
+| NegotiationContentException | 编程错误 | message + field（出错字段路径） |
+| NegotiationGenerationException | 生成失败 | code + message + cause |
+| NegotiationParamExtractionException | 校验失败 | code + message + errors（逐 slot 错误） |
+
+### 9.2 错误码
+
+定义在 A2ATErrorCodes：
+
+| 码 | 含义 | 可重试 |
+|---|---|---|
+| template_not_found | 模板/prompt 资源缺失 | 否 |
+| negotiation_content_extract_failed | LLM 内容抽取响应不可解析 | 是 |
+| negotiation_llm_infrastructure_error | LLM 调用基础设施失败 | 是 |
+| negotiation_slot_missing | 必填字段缺失 | 否 |
+| negotiation_invalid_input | 输入与 phase/action 矛盾 | 否 |
+| negotiation_rule_violation | 规则门校验失败 | 否 |
+| negotiation_semantic_rejected | 语义校验拒绝 | 否 |
+| input_text_too_long | fromText 输入超出配置的最大长度 | 否 |
+| param_extraction_failed | 参数提取默认失败码 | 否 |
+
+### 9.3 重试策略
+
+NegotiationGenerationOrchestrator.withRetry 对 LLM 步骤统一重试：
+- 只有 negotiation_content_extract_failed 和 negotiation_llm_infrastructure_error 可重试
+- 其他错误码立即抛出
+- 耗尽后原样重抛（保留原始 error code）
+- 默认 maxAttempts 来自 LLM config（A2AT_LLM_MAX_ATTEMPTS）
+
+---
+
+## 十、LLM 适配层
+
+### 10.1 LLMClient 接口
+
+```java
+public interface LLMClient {
+    LLMResponse structured(
+        List<Map<String, String>> messages,
+        Map<String, Object> jsonSchema,
+        Double temperature,
+        Integer maxTokens
+    );
+}
+
+record LLMResponse(
+    String content,
+    String model,
+    Map<String, Integer> usage,
+    Map<String, Object> metadata,
+    String sessionId
+)
+```
+
+### 10.2 默认实现
+
+LLMClientFactory 注册了 openai provider：
+
+```java
+// 注册自定义 provider
+LLMClientFactory.register("my-provider", MyClient.class);
+
+// 创建 client
+LLMClient client = LLMClientFactory.create(provider, config, logger);
+```
+
+默认 OpenAIClient 兼容所有 OpenAI 规范的 API（DeepSeek、Azure OpenAI 等），通过 A2AT_LLM_BASE_URL 配置。
+
+---
+
+## 十一、多语言词汇表（Vocabulary）
+
+```java
+Vocabulary vocab = Vocabulary.forLanguage("zh-CN");
+String sectionTitle = vocab.get("section.context");       // "协商上下文"
+String slotName = vocab.get("slot.target");               // "目标协商概述"
+String punct = vocab.get("punct.list_colon");             // "："
+```
+
+支持 zh-CN 和 en-US，两者暴露相同的 37 个 canonical key 集合（其中 section.* 18 个）。section.* 值是模板中 ## 标题的逐字副本，slot.* 值是 {{...}} 占位符名。不支持的语言抛 NegotiationContentException。
+
+---
+
+## 十二、状态存储
+
+```java
+public interface NegotiationStore {
+    NegotiationRecord get(String negotiationId);
+    void save(NegotiationRecord record);
+    void delete(String negotiationId);
+    boolean cleanupExpired();
+}
+```
+
+当前只有 InMemoryNegotiationStore 实现，不保证持久化。可通过 NegotiationHandler.Builder.store() 注入自定义实现。
+
+---
+
+## 十三、当前支持范围与局限
+
+| 能力 | 状态 |
+|---|---|
+| 协商运行时状态机（start/receive/continue） | 完整，三种类型均注册 |
+| 协商内容生成（fromData/fromText） | 完整，三种类型 × propose/accept/reject/abort 八个生成器均实现 |
+| 协商校验参数提取（validateAndFilling） | 完整，propose/accept/reject/abort 四个阶段均支持 |
+| Information 运行时 handler | 有实质逻辑（含 compliance checker） |
+| Target / Feasibility 运行时 handler | 空壳 echo（内容层已完整，运行时未对接） |
+| LLM 适配 | 仅 OpenAI 兼容 |
+| 资源加载 | 仅 local file 和 classpath |
+| 状态持久化 | 仅 in-memory |
+| 远程资源加载 | 不支持（无 registry-center） |
+| Authorization-T slot schema | 未打包（实验性） |
+| 语言覆盖 | zh-CN 和 en-US |
+
+---
+
+## 十四、使用示例
+
+### 14.1 发起协商并生成提议消息
+
+```java
+A2ATClient client = new A2ATClient(Path.of(".env"));
+
+// 1. 用内容生成引擎渲染结构化协商消息
+NegotiationContext contentCtx = new NegotiationContext(
+    UUID.randomUUID().toString(), 1,
+    NegotiationContext.DEFAULT_MAX_ROUNDS, NegotiationPerformative.PROPOSE);
+TargetProposeContent content = new TargetProposeContent(
+    "跨城市专线中断诊断",
+    List.of(new NegotiationItem("intent", "恢复城市1到城市2的SPN专线")),
+    null,
+    List.of(new NegotiationItem("city1_omc", "请提供城市1 OMC告警详情")),
+    null);
+MetadataContent mc = client.generateNegotiationProposePromptFromData(
+    new NegotiationProposeData(contentCtx, content),
+    StandardTemplates.TARGET_NEGOTIATION_PROPOSE);
+
+// 2. 用渲染好的消息文本初始化状态机
+Map<String, Object> payload = client.startNegotiation(
+    NegotiationType.TARGET, mc.promptText(), Map.of("agent", "city1-agent"));
+```
+
+### 14.2 接收并校验协商消息
+
+```java
+Map<String, Object> receiveResult = client.receiveNegotiation(message, contextMap);
+
+if (Boolean.TRUE.equals(receiveResult.get("needResponse"))) {
+    Map<String, Object> schema = Map.of(
+        "type", "object",
+        "properties", Map.of(
+            "city1_omc_alarm", Map.of("type", "string"),
+            "optical_power", Map.of("type", "number")));
+    FilledParamData params = client.validateProposePromptAndDataFilling(
+        message, contentCtx, schema, StandardTemplates.TARGET_NEGOTIATION_PROPOSE);
+    // params.data() 含 id, round, maxRounds + LLM 提取参数
+}
+```
+
+### 14.3 推进协商到同意
+
+```java
+net.openan.a2at.sdk.negotiation.types.model.NegotiationContext ctx =
+    NegotiationPayloadMapper.contextFromMap(
+        (Map<String, Object>) receiveResult.get("context"));
+Map<String, Object> payload = client.continueNegotiation(
+    ctx, NegotiationStatus.AGREED, "参数已确认，开始执行");
+```
+
+### 14.4 从自由文本生成协商消息
+
+```java
+NegotiationContext contentCtx = NegotiationContext.of("session-123", 1, NegotiationPerformative.PROPOSE);
+MetadataContent mc = client.generateNegotiationProposePromptFromText(
+    "城市1到城市2的SPN专线中断，城市1 OMC告警端口Down，光功率-28dBm",
+    contentCtx,
+    StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+```
+
+### 14.5 生成终态消息
+
+```java
+// 接受
+MetadataContent acceptMc = client.generateNegotiationAcceptPromptFromData(
+    new NegotiationEndingData(contentCtx,
+        new TargetEndingContent(NegotiationConclusion.ACCEPT, "确认意图：恢复专线", null)),
+    StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT);
+
+// 拒绝
+MetadataContent rejectMc = client.generateNegotiationRejectPromptFromData(
+    new NegotiationEndingData(contentCtx,
+        new TargetEndingContent(NegotiationConclusion.REJECT, null, "资源不足无法执行")),
+    StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT);
+
+// 终止协商
+MetadataContent abortMc = client.generateNegotiationAbortPromptFromData(
+    new NegotiationAbortData(contentCtx,
+        new NegotiationAbortContent("双方无法就诊断范围达成一致，终止协商")),
+    StandardTemplates.NEGOTIATION_ABORT);
+```
+
+### 14.6 查询可用模板
+
+```java
+// 列出所有协商模板
+List<PromptTemplate> templates = client.getNegotiationPrompts();
+for (PromptTemplate t : templates) {
+    System.out.println(t.uri() + " -> " + t.name());
+}
+
+// 查询特定模板
+Optional<PromptTemplate> template = client.getNegotiationPrompt(
+    "Negotiation-T/target-negotiation/propose/v1");
+```
+
+---
+
+## 十五、文件索引
+
+### Facade 层
+
+| 文件 | 作用 |
+|---|---|
+| a2a-t-client/.../A2ATClient.java | 客户端对外 facade |
+| a2a-t-server/.../A2ATServer.java | 服务端对外 facade |
+
+### 核心模型层（a2a-t-core）
+
+| 文件 | 作用 |
+|---|---|
+| a2a-t-core/.../model/ExtensionUriConstants.java | 扩展 URI 常量 |
+| a2a-t-core/.../model/NegotiationContext.java | 内容生成/校验 context（id, round, maxRounds, performative） |
+| a2a-t-core/.../model/NegotiationPerformative.java | 消息言语行为枚举 |
+| a2a-t-core/.../model/MetadataContent.java | 生成消息元数据 |
+| a2a-t-core/.../model/FilledParamData.java | 校验参数提取结果 |
+| a2a-t-core/.../model/StandardTemplates.java | 标准模板 URI 常量 |
+| a2a-t-core/.../model/TemplateUri.java | 模板 URI 值类型 |
+| a2a-t-core/.../model/A2ATConfig.java | 全局配置 |
+| a2a-t-core/.../model/PromptRuntimeConfig.java | prompt 运行时配置 |
+| a2a-t-core/.../exception/A2ATErrorCodes.java | 错误码常量 |
+
+### 协商内容层
+
+| 文件 | 作用 |
+|---|---|
+| a2a-t-negotiation/.../content/NegotiationType.java | 协商类型枚举 |
+| a2a-t-negotiation/.../content/NegotiationConclusion.java | 终态结论枚举 |
+| a2a-t-negotiation/.../content/NegotiationAction.java | feasibility 动作枚举 |
+| a2a-t-negotiation/.../content/NegotiationContent.java | 内容 sealed 接口 |
+| a2a-t-negotiation/.../content/NegotiationProposeContent.java | propose 内容 sealed 接口 |
+| a2a-t-negotiation/.../content/NegotiationEndingContent.java | ending 内容 sealed 接口 |
+| a2a-t-negotiation/.../content/InformationProposeContent.java | 信息协商 propose 内容 |
+| a2a-t-negotiation/.../content/InformationEndingContent.java | 信息协商 ending 内容 |
+| a2a-t-negotiation/.../content/TargetProposeContent.java | 目标协商 propose 内容 |
+| a2a-t-negotiation/.../content/TargetEndingContent.java | 目标协商 ending 内容 |
+| a2a-t-negotiation/.../content/FeasibilityProposeContent.java | 可行性协商 propose 内容 |
+| a2a-t-negotiation/.../content/FeasibilityEndingContent.java | 可行性协商 ending 内容 |
+| a2a-t-negotiation/.../content/NegotiationAbortContent.java | 协商终止内容 |
+| a2a-t-negotiation/.../content/NegotiationItem.java | 协商项 |
+| a2a-t-negotiation/.../content/NegotiationProposeData.java | propose 输入数据 |
+| a2a-t-negotiation/.../content/NegotiationEndingData.java | ending 输入数据 |
+| a2a-t-negotiation/.../content/NegotiationAbortData.java | abort 输入数据 |
+| a2a-t-negotiation/.../content/Vocabulary.java | 多语言词汇表 |
+| a2a-t-negotiation/.../content/NegotiationContentException.java | 内容异常 |
+| a2a-t-negotiation/.../content/NegotiationGenerationException.java | 生成异常 |
+| a2a-t-negotiation/.../content/NegotiationParamExtractionException.java | 参数提取异常 |
+| a2a-t-negotiation/.../content/NegotiationProcessingException.java | 处理异常 |
+
+### 协商生成层
+
+| 文件 | 作用 |
+|---|---|
+| a2a-t-negotiation/.../generation/NegotiationContentService.java | 内容层共享服务 |
+| a2a-t-negotiation/.../generation/NegotiationGenerationOrchestrator.java | 生成引擎核心 |
+| a2a-t-negotiation/.../generation/NegotiationGenerationOrchestratorBuilder.java | 生成引擎 builder |
+| a2a-t-negotiation/.../generation/NegotiationGenerator.java | 生成器接口 |
+| a2a-t-negotiation/.../generation/NegotiationGeneratorRegistry.java | 生成器 dispatch 表 |
+| a2a-t-negotiation/.../generation/AbstractNegotiationGenerator.java | 生成器基类 |
+| a2a-t-negotiation/.../generation/InformationProposeGenerator.java | 信息协商 propose 生成器 |
+| a2a-t-negotiation/.../generation/InformationEndingGenerator.java | 信息协商 ending 生成器 |
+| a2a-t-negotiation/.../generation/TargetProposeGenerator.java | 目标协商 propose 生成器 |
+| a2a-t-negotiation/.../generation/TargetEndingGenerator.java | 目标协商 ending 生成器 |
+| a2a-t-negotiation/.../generation/FeasibilityProposeGenerator.java | 可行性协商 propose 生成器 |
+| a2a-t-negotiation/.../generation/FeasibilityEndingGenerator.java | 可行性协商 ending 生成器 |
+| a2a-t-negotiation/.../generation/AbortGenerator.java | 协商终止生成器 |
+| a2a-t-negotiation/.../generation/NegotiationContentExtractor.java | 内容抽取接口 |
+| a2a-t-negotiation/.../generation/DefaultNegotiationContentExtractor.java | LLM 内容抽取（fromText 用） |
+| a2a-t-negotiation/.../generation/NegotiationPromptRenderer.java | 模板渲染器 |
+| a2a-t-negotiation/.../generation/NegotiationItemFormatter.java | 项列表格式化 |
+| a2a-t-negotiation/.../generation/NegotiationMessageBuilder.java | LLM 消息构建 |
+| a2a-t-negotiation/.../generation/NegotiationJsonSchemaBuilder.java | JSON schema 构建 |
+
+### 协商校验层
+
+| 文件 | 作用 |
+|---|---|
+| a2a-t-negotiation/.../validation/NegotiationComplianceChecker.java | 规则门接口 |
+| a2a-t-negotiation/.../validation/DefaultNegotiationComplianceChecker.java | 规则门实现 |
+| a2a-t-negotiation/.../validation/NegotiationSemanticValidator.java | 语义校验接口 |
+| a2a-t-negotiation/.../validation/DefaultNegotiationSemanticValidator.java | LLM 语义校验实现 |
+| a2a-t-negotiation/.../validation/ParamExtractor.java | 参数提取编排 |
+| a2a-t-negotiation/.../validation/NegotiationRuleCheckResult.java | 规则门结果 |
+| a2a-t-negotiation/.../validation/NegotiationRuleCheckerAdapter.java | 规则门适配器 |
+| a2a-t-negotiation/.../validation/SemanticValidationResult.java | 语义校验结果 |
+| a2a-t-negotiation/.../validation/NegotiationValidationException.java | 校验异常 |
+
+### 协商运行时层
+
+| 文件 | 作用 |
+|---|---|
+| a2a-t-negotiation/.../runtime/NegotiationHandler.java | 状态机 facade |
+| a2a-t-negotiation/.../runtime/NegotiationRuntime.java | 状态机核心 |
+| a2a-t-negotiation/.../runtime/RoleBoundNegotiationOrchestrator.java | 角色绑定 orchestrator |
+| a2a-t-negotiation/.../runtime/helper/NegotiationPayloadMapper.java | payload 序列化/反序列化 |
+
+### 协商 handler 层
+
+| 文件 | 作用 |
+|---|---|
+| a2a-t-negotiation/.../handler/Negotiation.java | handler 接口 |
+| a2a-t-negotiation/.../handler/InformationNegotiation.java | information handler（有合规校验逻辑） |
+| a2a-t-negotiation/.../handler/TargetNegotiation.java | target handler（空壳 echo） |
+| a2a-t-negotiation/.../handler/FeasibilityNegotiation.java | feasibility handler（空壳 echo） |
+
+### 协商资源层
+
+| 文件 | 作用 |
+|---|---|
+| a2a-t-negotiation/.../resources/NegotiationReference.java | 模板引用与 URI 解析 |
+| a2a-t-negotiation/.../resources/NegotiationTemplateLoader.java | 模板加载接口 |
+| a2a-t-negotiation/.../resources/DefaultNegotiationTemplateLoader.java | 模板加载实现 |

--- a/docs/zh/API参考.md
+++ b/docs/zh/API参考.md
@@ -17,6 +17,9 @@ A2A-T SDK 的对外 API 收敛在两个门面上：客户端门面 `A2ATClient`�
 | Negotiation-T | `validateProposePromptAndDataFilling` | A2A-T Client / A2A-T Server | 校验协商发起报文合规性并按Schema提取参数 | 是（1次LLM语义校验） |
 | Negotiation-T | `validateAcceptPromptAndDataFilling` | A2A-T Client / A2A-T Server | 校验协商接受报文合规性并按Schema提取参数 | 是（1次LLM语义校验） |
 | Negotiation-T | `validateRejectPromptAndDataFilling` | A2A-T Client / A2A-T Server | 校验协商拒绝报文合规性并按Schema提取参数 | 是（1次LLM语义校验） |
+| Negotiation-T | `generateNegotiationAbortPromptFromText` | A2A-T Client / A2A-T Server | 从自然语言文本生成协商终止（abort）报文 | 是（1次LLM内容抽取） |
+| Negotiation-T | `generateNegotiationAbortPromptFromData` | A2A-T Client / A2A-T Server | 从结构化数据确定性生成协商终止报文（不调用LLM） | 否 |
+| Negotiation-T | `validateAbortPromptAndDataFilling` | A2A-T Client / A2A-T Server | 校验协商终止报文合规性并按Schema提取参数 | 是（1次LLM语义校验） |
 | Task-T | `generateTaskPromptFromText` | A2A-T Client | 从自然语言文本按指定Task-T模板生成任务提示词（跳过场景识别） | 是（1次LLM槽位提取） |
 | Task-T | `generateTaskPromptFromDataWithSchema` | A2A-T Client | 从结构化数据+语义Schema按指定Task-T模板生成任务提示词 | 是（1次LLM槽位提取） |
 | Task-T | `validateTaskPromptAndDataFilling` | A2A-T Server | 校验Task-T任务提示词合规性并按Schema提取参数 | 是（1次LLM语义校验与提参） |
@@ -32,7 +35,7 @@ A2A-T SDK 的对外 API 收敛在两个门面上：客户端门面 `A2ATClient`�
 **公共数据类型与约定**
 
 - **TemplateUri：**模板 URI 值类型，推荐用 `net.openan.a2at.sdk.core.model.StandardTemplates` 常量构造，如 `StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE`（URI 为 `Negotiation-T/information-negotiation/propose/v1`）；来自外部的字符串用 `TemplateUri.parse(String)` 解析，返回 `Optional<TemplateUri>` 且不抛异常。
-- **协商会话上下文：**`NegotiationContext(id, round, maxRounds)`（id 为 UUID 形态、round 从 1 起、默认轮次预算 `DEFAULT_MAX_ROUNDS = 5`），随消息 metadata 传输、不经 LLM；`NegotiationContext.of(id, round)` 使用默认预算，`nextRound()` 推进轮次。
+- **协商会话上下文：**`NegotiationContext(id, round, maxRounds, performative)`（id 为 UUID 形态、round 从 1 起、默认轮次预算 `DEFAULT_MAX_ROUNDS = 5`，performative 表明 context 随哪类协商消息出行：`PROPOSE` / `ACCEPT` / `REJECT` / `ABORT`），随消息 metadata 传输、不经 LLM；`NegotiationContext.of(id, round, performative)` 使用默认预算，`nextRound()` 推进轮次。
 - **异常体系：**所有 SDK 处理失败均为 `A2ATError` 子类——生成失败抛 `PromptGenerationException`（Task-T / Notification-T / Authorization-T）或 `NegotiationGenerationException`（Negotiation-T），校验+提参失败抛 `ContentValidationException`（Task-T / Notification-T / Authorization-T，携带 `errors()` 槽位错误明细与 `params()` 部分提取参数）或 `NegotiationParamExtractionException`（Negotiation-T）。捕获 `A2ATError` 即可覆盖全部处理失败，`getCode()` 获取机器可读错误码。
 - **SlotValidationError：**逐槽位校验错误明细，随校验失败异常或失败负载返回，各节“输出说明”中的失败结构均引用此定义：
 
@@ -83,7 +86,8 @@ import net.openan.a2at.sdk.core.model.StandardTemplates;
 A2ATClient client = new A2ATClient(Path.of("client.env"));
 
 NegotiationContext ctx = new NegotiationContext(
-        "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 1, NegotiationContext.DEFAULT_MAX_ROUNDS);
+        "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 1, NegotiationContext.DEFAULT_MAX_ROUNDS,
+        NegotiationPerformative.PROPOSE);
 
 MetadataContent propose = client.generateNegotiationProposePromptFromText(
         "请提供以下缺失信息：1. 接入端口名称：请提供业务接入端口名称；"
@@ -298,7 +302,8 @@ import net.openan.a2at.sdk.negotiation.content.InformationProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
 
-NegotiationContext ctx = new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5);
+NegotiationContext ctx = new NegotiationContext("3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5,
+        NegotiationPerformative.PROPOSE);
 
 MetadataContent propose = client.generateNegotiationProposePromptFromData(
         new NegotiationProposeData(
@@ -1566,7 +1571,175 @@ result.failure() =
 { code=slot_validation_error, message=Required slot '任务对象' is missing., stage=slot_validation }
 ```
 
+### 1.3.21 generateNegotiationAbortPromptFromText
 
+**API定义**
 
+```java
+public MetadataContent generateNegotiationAbortPromptFromText(
+        String text, NegotiationContext context, TemplateUri templateUri)
+```
 
+**典型场景**：协商任一方判定本轮协商无法继续（达到协商轮次上限、超时、token 消耗超限等），从自然语言的终止说明生成协商终止（abort）报文通知对端。
 
+**功能说明**：从自然语言文本生成协商终止报文，含一步 LLM 结构化抽取（抽取终止原因）。终止报文与协商类型无关，`templateUri` 必须为 common abort 模板（`StandardTemplates.NEGOTIATION_ABORT`，URI 为 `Negotiation-T/common/abort/v1`），context 的 performative 应为 `ABORT`。
+
+**输入说明**
+
+| 参数 | 类型 | 必填 | 说明 |
+| ---- | ---- | ---- | ---- |
+| text | String | 是 | 协商终止原因的自然语言描述 |
+| context | `NegotiationContext` | 是 | 协商会话上下文（performative 为 `ABORT`） |
+| templateUri | TemplateUri | 是 | common abort 模板 |
+
+**请求样例**
+
+```java
+MetadataContent abort = client.generateNegotiationAbortPromptFromText(
+        "达到协商轮次上限，本次协商确认结束。",
+        ctx,
+        StandardTemplates.NEGOTIATION_ABORT);
+```
+
+**输出说明**
+
+成功时返回 `MetadataContent`（结构同 [1.3.1](#131-generatenegotiationproposepromptfromtext)）。
+
+失败时抛 `NegotiationGenerationException`（结构同 1.3.1）。错误码：
+
+- `template_not_found`（模板或提示词资源缺失）
+
+- `negotiation_content_extract_failed`（无法从文本抽取终止原因，可重试）
+
+- `negotiation_llm_infrastructure_error`（LLM 基础设施故障，可重试）
+
+- `negotiation_invalid_input`（文本为空或抽取内容与 abort 阶段不符）
+
+- `negotiation_slot_missing`（缺少必需槽位）
+
+入参为 null 抛 `NullPointerException`，templateUri 的 phase 段不是 `abort` 抛 `IllegalArgumentException`。
+
+**响应样例**
+
+```text
+templateUri : Negotiation-T/common/abort/v1
+extensionUri: https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1
+promptText  :
+## 协商结果
+Abort
+
+## 协商终止原因
+达到协商轮次上限，本次协商确认结束。
+```
+
+### 1.3.22 generateNegotiationAbortPromptFromData
+
+**API定义**
+
+```java
+public MetadataContent generateNegotiationAbortPromptFromData(
+        NegotiationAbortData data, TemplateUri templateUri)
+```
+
+**典型场景**：协商任一方程序化判定终止条件成立后，以结构化终止原因生成协商终止报文回传。
+
+**功能说明**：从类型化数据确定性生成协商终止报文，**不调用 LLM**。终止报文与协商类型无关，`templateUri` 必须为 common abort 模板。
+
+**输入说明**
+
+| 参数 | 类型 | 必填 | 说明 |
+| ---- | ---- | ---- | ---- |
+| data | `NegotiationAbortData(context, content)` | 是 | 协商上下文（performative 为 `ABORT`）+ 终止内容 |
+| templateUri | TemplateUri | 是 | common abort 模板 |
+
+终止内容：`NegotiationAbortContent(terminationReason)`，terminationReason 为协商终止原因（必填）。
+
+**请求样例**
+
+```java
+import net.openan.a2at.sdk.negotiation.content.NegotiationAbortContent;
+import net.openan.a2at.sdk.negotiation.content.NegotiationAbortData;
+
+MetadataContent abort = client.generateNegotiationAbortPromptFromData(
+        new NegotiationAbortData(
+                ctx,
+                new NegotiationAbortContent("达到协商轮次上限，本次协商确认结束。")),
+        StandardTemplates.NEGOTIATION_ABORT);
+```
+
+**输出说明**
+
+成功时返回 `MetadataContent`（结构同 [1.3.1](#131-generatenegotiationproposepromptfromtext)）。
+
+失败时抛 `NegotiationGenerationException`（结构同 1.3.1）。错误码：
+
+- `template_not_found`（模板缺失）
+
+- `negotiation_slot_missing`（渲染缺少必需槽位）
+
+编程错误：入参或其 context 为 null 抛 `NullPointerException`；终止原因为空或 phase 段不是 `abort` 抛 `IllegalArgumentException`。
+
+**响应样例**
+
+```text
+templateUri : Negotiation-T/common/abort/v1
+extensionUri: https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/v1
+promptText  :
+## 协商结果
+Abort
+
+## 协商终止原因
+达到协商轮次上限，本次协商确认结束。
+```
+
+### 1.3.23 validateAbortPromptAndDataFilling
+
+**API定义**
+
+```java
+public FilledParamData validateAbortPromptAndDataFilling(
+        String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri)
+```
+
+**典型场景**：协商一方校验对端发来的终止报文，提取终止原因，据此结束本地协商状态并回收任务。
+
+**功能说明**：校验一条协商终止（abort）报文并按 Schema 提取参数。流水线同 1.3.7，区别仅在于：报文须满足 abort 阶段的语义约束（结论为 Abort、携带协商终止原因板块），`templateUri` 必须为 common abort 模板。
+
+**输入说明**：同 1.3.7，prompt 为终止报文文本，templateUri 为 common abort 模板。
+
+**请求样例**
+
+```java
+FilledParamData abortParams = server.validateAbortPromptAndDataFilling(
+        abortPrompt, ctx, schema, StandardTemplates.NEGOTIATION_ABORT);
+```
+
+**输出说明**
+
+成功时返回 `FilledParamData`（结构同 [1.3.7](#137-validateproposepromptanddatafilling)），`data()` 携带终止原因中按 Schema 提取的参数与上下文参数。
+
+失败时抛 `NegotiationParamExtractionException`（结构同 1.3.7）。错误码：
+
+- `negotiation_invalid_input`（报文不是 abort 协商消息或 context 为 null）
+
+- `negotiation_rule_violation`（协商上下文违反结构规则）
+
+- `negotiation_semantic_rejected`（结论不是 Abort 或缺少终止原因板块）
+
+- `negotiation_llm_infrastructure_error`（LLM 基础设施故障，可重试）
+
+- `template_not_found`（校验提示词资源缺失）
+
+编程错误：prompt 或 schema 为 null 抛 `NullPointerException`，prompt 为空白或 phase 段不是 `abort` 抛 `IllegalArgumentException`。
+
+**响应样例**
+
+```text
+abortParams.data() =
+{
+  termination_reason=达到协商轮次上限，本次协商确认结束。,
+  id=3dbc13b5-bd57-4c2b-b503-24e381b6c8d3,
+  round=1,
+  maxRounds=5
+}
+```


### PR DESCRIPTION
Closes #169

## Summary

Two documentation commits on top of latest trunk:

**1. Cover the negotiation abort APIs in the API reference** (`docs/en/API_Reference.md`, `docs/zh/API参考.md`)

- Adds `generateNegotiationAbortPromptFromText`, `generateNegotiationAbortPromptFromData`, and `validateAbortPromptAndDataFilling` to the API overview tables and as full per-API sections (signature, scenario, input, request example, error codes, response example) in both language volumes
- Documents the common abort template (`Negotiation-T/common/abort/v1`, `StandardTemplates.NEGOTIATION_ABORT`) and the `NegotiationAbortData` / `NegotiationAbortContent(terminationReason)` input models
- Fixes the stale three-argument `NegotiationContext` construction examples and the session-context description — the context now carries a mandatory `performative` (`PROPOSE` / `ACCEPT` / `REJECT` / `ABORT`)

Purely additive for the abort sections (appended as 1.3.21-1.3.23; no existing section renumbered or anchor changed).

**2. Add detailed negotiation and SDK API reference volumes**

- `docs/zh/A2A-T-Negotiation-API-Reference.md` + `docs/en/A2A-T-Negotiation-API-Reference.md`: full negotiation surface — runtime state machine (start/receive/continue with the state-validation order), content generation across propose/accept/reject/abort, the validation pipeline (rule gate -> LLM semantic validation -> parameter merge), the two context types and their distinction, payload utilities, the complete error-code table with retry semantics, state storage, and runnable examples
- `docs/zh/A2A-T-SDK-API-Reference.md`: module and dependency overview, initialization and the full `.env` configuration surface, all four extension API surfaces (Negotiation-T / Task-T / Authorization-T / Notification-T), the LLM adapter layer, the multilingual vocabulary, and a source file index

All API signatures, content models, error codes, template URIs, and enum values were verified against the current source before writing.

## Test plan

- [x] Every documented signature/model/error code checked against the current SDK source (incl. the abort surface and the confirm-request fields on `TargetProposeContent` / `FeasibilityProposeContent`)
- [x] Runnable examples match the current constructor and facade signatures (`TemplateUri` parameters, 4-argument `NegotiationContext` with performative)
