### PR TITLE
Feat/facade String template URIs on the A2ATClient / A2ATServer facades

### DIFF
--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
@@ -253,14 +253,16 @@ public final class A2ATClient {
      *
      * @param data typed propose input carrying the negotiation context and the typed content
      * @param templateUri template URI string such as {@code Negotiation-T/information-negotiation/propose/v1}; its
-     *     phase segment must be {@code propose}
+     *     performative segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
      *     method or the content type
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
-     *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
-     *     {@code negotiation.field_missing} when rendering the template fails
+     *     {@code template.not_found} when no template exists for the URI in any resource root, the code
+     *     {@code negotiation.content_invalid} when a required content field is blank or empty, the code
+     *     {@code negotiation.invalid_input} when the content combines a non-blank confirm request with conditional
+     *     sections, or the code {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateNegotiationProposePromptFromData(
             @NonNull NegotiationProposeData data, @NonNull String templateUri) {
@@ -276,14 +278,16 @@ public final class A2ATClient {
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
      * @param templateUri template URI string such as {@code Negotiation-T/information-negotiation/accept-reject/v1};
-     *     its phase segment must be {@code accept-reject}
+     *     its performative segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
-     *     method or the content, or the content conclusion is not {@code Accept}
+     *     method or the content
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
-     *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
-     *     {@code negotiation.field_missing} when rendering the template fails
+     *     {@code template.not_found} when no template exists for the URI in any resource root, the code
+     *     {@code negotiation.conclusion_mismatch} when the content conclusion is not {@code Accept}, the code
+     *     {@code negotiation.content_invalid} when a required content field is blank or empty, or the code
+     *     {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateNegotiationAcceptPromptFromData(
             @NonNull NegotiationEndingData data, @NonNull String templateUri) {
@@ -299,14 +303,16 @@ public final class A2ATClient {
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
      * @param templateUri template URI string such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1};
-     *     its phase segment must be {@code accept-reject}
+     *     its performative segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
-     *     method or the content, or the content conclusion is not {@code Reject}
+     *     method or the content
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
-     *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
-     *     {@code negotiation.field_missing} when rendering the template fails
+     *     {@code template.not_found} when no template exists for the URI in any resource root, the code
+     *     {@code negotiation.conclusion_mismatch} when the content conclusion is not {@code Reject}, the code
+     *     {@code negotiation.content_invalid} when a required content field is blank or empty, or the code
+     *     {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateNegotiationRejectPromptFromData(
             @NonNull NegotiationEndingData data, @NonNull String templateUri) {
@@ -325,10 +331,11 @@ public final class A2ATClient {
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or does not address the common abort
-     *     template, or the termination reason is blank
+     *     template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
-     *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
-     *     {@code negotiation.field_missing} when rendering the template fails
+     *     {@code template.not_found} when no template exists for the URI in any resource root, the code
+     *     {@code negotiation.content_invalid} when the termination reason is blank, or the code
+     *     {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateNegotiationAbortPromptFromData(
             @NonNull NegotiationAbortData data, @NonNull String templateUri) {
@@ -342,26 +349,26 @@ public final class A2ATClient {
      * <p>This variant runs one LLM content-extraction step constrained by the template URI and then renders
      * deterministically like the from-data variant. The template is loaded before the LLM call and the extraction step
      * is retried up to the configured attempt limit on the retryable failure codes
-     * {@code negotiation.content_extract_failed} and {@code llm.invocation_failed}.
+     * {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} and {@code llm.response_invalid}.
      *
      * @param text free-text input describing the message content
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI string such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase
+     * @param templateUri template URI string such as {@code Negotiation-T/target-negotiation/propose/v1}; its performative
      *     segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
-     *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} when the extraction step fails
+     *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid} when the extraction step fails
      *     after exhausting its retries, {@code negotiation.field_missing} when the extracted content misses a required
      *     field, or {@code negotiation.invalid_input} when the text is blank or the extracted content contradicts the
      *     phase, or the code {@code input.text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateNegotiationProposePromptFromText(
             @NonNull String text,
-            net.openan.a2at.sdk.core.model.NegotiationContext context,
+            net.openan.a2at.sdk.core.model.@NonNull NegotiationContext context,
             @NonNull String templateUri) {
         TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
         return negotiationContentService.generateProposeFromText(text, context, parsedTemplateUri);
@@ -378,20 +385,21 @@ public final class A2ATClient {
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
      * @param templateUri template URI string such as {@code Negotiation-T/information-negotiation/accept-reject/v1};
-     *     its phase segment must be {@code accept-reject}
+     *     its performative segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
-     *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} when the extraction step fails
+     *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid} when the extraction step fails
      *     after exhausting its retries, {@code negotiation.field_missing} when the extracted content misses a required
-     *     field, or {@code negotiation.invalid_input} when the text is blank or the extracted conclusion is not
-     *     {@code Accept}, or the code {@code input.text_too_long} when the text exceeds the configured maximum length
+     *     field, or {@code negotiation.invalid_input} when the text is blank, {@code negotiation.conclusion_mismatch}
+     *     when the extracted conclusion is not {@code Accept}, or the code {@code input.text_too_long} when the text
+     *     exceeds the configured maximum length
      */
     public MetadataContent generateNegotiationAcceptPromptFromText(
             @NonNull String text,
-            net.openan.a2at.sdk.core.model.NegotiationContext context,
+            net.openan.a2at.sdk.core.model.@NonNull NegotiationContext context,
             @NonNull String templateUri) {
         TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
         return negotiationContentService.generateAcceptFromText(text, context, parsedTemplateUri);
@@ -408,20 +416,21 @@ public final class A2ATClient {
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
      * @param templateUri template URI string such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1};
-     *     its phase segment must be {@code accept-reject}
+     *     its performative segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
-     *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} when the extraction step fails
+     *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid} when the extraction step fails
      *     after exhausting its retries, {@code negotiation.field_missing} when the extracted content misses a required
-     *     field, or {@code negotiation.invalid_input} when the text is blank or the extracted conclusion is not
-     *     {@code Reject}, or the code {@code input.text_too_long} when the text exceeds the configured maximum length
+     *     field, or {@code negotiation.invalid_input} when the text is blank, {@code negotiation.conclusion_mismatch}
+     *     when the extracted conclusion is not {@code Reject}, or the code {@code input.text_too_long} when the text
+     *     exceeds the configured maximum length
      */
     public MetadataContent generateNegotiationRejectPromptFromText(
             @NonNull String text,
-            net.openan.a2at.sdk.core.model.NegotiationContext context,
+            net.openan.a2at.sdk.core.model.@NonNull NegotiationContext context,
             @NonNull String templateUri) {
         TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
         return negotiationContentService.generateRejectFromText(text, context, parsedTemplateUri);
@@ -433,7 +442,7 @@ public final class A2ATClient {
      * <p>This variant runs one LLM content-extraction step constrained by the common abort template and then renders
      * deterministically like the from-data variant. The template is loaded before the LLM call and the extraction step
      * is retried up to the configured attempt limit on the retryable failure codes
-     * {@code negotiation.content_extract_failed} and {@code llm.invocation_failed}.
+     * {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} and {@code llm.response_invalid}.
      *
      * @param text free-text input stating the termination reason
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
@@ -445,14 +454,14 @@ public final class A2ATClient {
      *     template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
-     *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} when the extraction step fails
+     *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid} when the extraction step fails
      *     after exhausting its retries, {@code negotiation.field_missing} when the extracted content misses the
      *     termination reason, or {@code negotiation.invalid_input} when the text is blank, or the code
      *     {@code input.text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateNegotiationAbortPromptFromText(
             @NonNull String text,
-            net.openan.a2at.sdk.core.model.NegotiationContext context,
+            net.openan.a2at.sdk.core.model.@NonNull NegotiationContext context,
             @NonNull String templateUri) {
         TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
         return negotiationContentService.generateAbortFromText(text, context, parsedTemplateUri);
@@ -502,18 +511,23 @@ public final class A2ATClient {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI string declaring the expected negotiation type and phase; its phase segment must
+     * @param templateUri template URI string declaring the expected negotiation type and phase; its performative segment must
      *     be {@code propose}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or the template
-     *     URI phase contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or the template URI phase contradicts
+     *     the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
-     *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
-     *     {@code negotiation.rule_violation} when the negotiation context violates a rule,
+     *     {@code negotiation.invalid_input} when the prompt is null or blank or is not a negotiation message,
+     *     {@code negotiation.rule_violation} when the negotiation context violates a rule (nested slot error codes
+     *     such as {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded}), one of the closed
+     *     {@code negotiation.*} code set (for example
+     *     {@code negotiation.conclusion_content_mismatch}) when a rule or semantic check rejects the message,
      *     {@code negotiation.semantic_rejected} when the semantic validation rejects the message,
-     *     {@code llm.invocation_failed} when the semantic step fails after exhausting its retries, or
-     *     {@code template.not_found} when the semantic validation prompt resources are missing
+     *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
+     *     its retries, or {@code template.not_found} when the semantic validation prompt resources are missing, or
+     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public FilledParamData validateProposePromptAndDataFilling(
             @NonNull String prompt,
@@ -536,18 +550,23 @@ public final class A2ATClient {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI string declaring the expected negotiation type and phase; its phase segment must
+     * @param templateUri template URI string declaring the expected negotiation type and phase; its performative segment must
      *     be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or the template
-     *     URI phase contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or the template URI phase contradicts
+     *     the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
-     *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
-     *     {@code negotiation.rule_violation} when the negotiation context violates a rule,
+     *     {@code negotiation.invalid_input} when the prompt is null or blank or is not a negotiation message,
+     *     {@code negotiation.rule_violation} when the negotiation context violates a rule (nested slot error codes
+     *     such as {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded}), one of the closed
+     *     {@code negotiation.*} code set (for example
+     *     {@code negotiation.conclusion_content_mismatch}) when a rule or semantic check rejects the message,
      *     {@code negotiation.semantic_rejected} when the semantic validation rejects the message,
-     *     {@code llm.invocation_failed} when the semantic step fails after exhausting its retries, or
-     *     {@code template.not_found} when the semantic validation prompt resources are missing
+     *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
+     *     its retries, or {@code template.not_found} when the semantic validation prompt resources are missing, or
+     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public FilledParamData validateAcceptPromptAndDataFilling(
             @NonNull String prompt,
@@ -569,18 +588,23 @@ public final class A2ATClient {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI string declaring the expected negotiation type and phase; its phase segment must
+     * @param templateUri template URI string declaring the expected negotiation type and phase; its performative segment must
      *     be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or the template
-     *     URI phase contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or the template URI phase contradicts
+     *     the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
-     *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
-     *     {@code negotiation.rule_violation} when the negotiation context violates a rule,
+     *     {@code negotiation.invalid_input} when the prompt is null or blank or is not a negotiation message,
+     *     {@code negotiation.rule_violation} when the negotiation context violates a rule (nested slot error codes
+     *     such as {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded}), one of the closed
+     *     {@code negotiation.*} code set (for example
+     *     {@code negotiation.conclusion_content_mismatch}) when a rule or semantic check rejects the message,
      *     {@code negotiation.semantic_rejected} when the semantic validation rejects the message,
-     *     {@code llm.invocation_failed} when the semantic step fails after exhausting its retries, or
-     *     {@code template.not_found} when the semantic validation prompt resources are missing
+     *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
+     *     its retries, or {@code template.not_found} when the semantic validation prompt resources are missing, or
+     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public FilledParamData validateRejectPromptAndDataFilling(
             @NonNull String prompt,
@@ -604,15 +628,20 @@ public final class A2ATClient {
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri template URI string of the common abort template {@code Negotiation-T/common/abort/v1}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or the template
-     *     URI does not address the common abort template
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or does not address the common abort
+     *     template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
-     *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
-     *     {@code negotiation.rule_violation} when the negotiation context violates a rule,
+     *     {@code negotiation.invalid_input} when the prompt is null or blank or is not a negotiation message,
+     *     {@code negotiation.rule_violation} when the negotiation context violates a rule (nested slot error codes
+     *     such as {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded}), one of the closed
+     *     {@code negotiation.*} code set (for example
+     *     {@code negotiation.conclusion_content_mismatch}) when a rule or semantic check rejects the message,
      *     {@code negotiation.semantic_rejected} when the semantic validation rejects the message,
-     *     {@code llm.invocation_failed} when the semantic step fails after exhausting its retries, or
-     *     {@code template.not_found} when the semantic validation prompt resources are missing
+     *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
+     *     its retries, or {@code template.not_found} when the semantic validation prompt resources are missing, or
+     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public FilledParamData validateAbortPromptAndDataFilling(
             @NonNull String prompt,

--- a/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
+++ b/a2a-t-client/src/main/java/net/openan/a2at/sdk/client/A2ATClient.java
@@ -76,18 +76,20 @@ public final class A2ATClient {
      * URI, bypassing scenario recognition.
      *
      * @param text natural-language task input
-     * @param templateUri template URI identifying the target template
+     * @param templateUri template URI string identifying the target template, such as
+     *     {@code Task-T/network-layer/ran-energy-saving/v1}
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the text or template URI is null
+     * @throws NullPointerException if the text or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template.not_found},
      *     {@code template.load_failed}, {@code slot.schema_not_found}, {@code llm.invocation_failed},
      *     {@code template.render_failed} or {@code slot.not_provided} when generating the prompt fails, or the code
      *     {@code input.text_too_long} when the text exceeds the configured maximum length
      */
-    public MetadataContent generateTaskPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+    public MetadataContent generateTaskPromptFromText(@NonNull String text, @NonNull String templateUri) {
         Objects.requireNonNull(text, "text");
-        Objects.requireNonNull(templateUri, "templateUri");
-        return promptGenerationOrchestrator.generateTaskPromptFromText(text, templateUri);
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return promptGenerationOrchestrator.generateTaskPromptFromText(text, parsedTemplateUri);
     }
 
     /**
@@ -96,20 +98,21 @@ public final class A2ATClient {
      *
      * @param data structured task input as a string-to-object map
      * @param schema data schema map describing the meaning of each input field; must not be null or empty
-     * @param templateUri template URI identifying the target template
+     * @param templateUri template URI string identifying the target template, such as
+     *     {@code Task-T/network-layer/ran-energy-saving/v1}
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the template URI, data or schema is null
-     * @throws IllegalArgumentException if the schema is empty
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or the schema is empty
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template.not_found},
      *     {@code template.load_failed}, {@code slot.schema_not_found}, {@code llm.invocation_failed},
      *     {@code template.render_failed} or {@code slot.not_provided} when generating the prompt fails
      */
     public MetadataContent generateTaskPromptFromDataWithSchema(
-            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull String templateUri) {
         Objects.requireNonNull(data, "data");
         Objects.requireNonNull(schema, "schema");
-        Objects.requireNonNull(templateUri, "templateUri");
-        return promptGenerationOrchestrator.generateTaskPromptFromDataWithSchema(data, schema, templateUri);
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return promptGenerationOrchestrator.generateTaskPromptFromDataWithSchema(data, schema, parsedTemplateUri);
     }
 
     /**
@@ -120,18 +123,20 @@ public final class A2ATClient {
      * classpath resource source.
      *
      * @param text natural-language authorization input
-     * @param templateUri template URI identifying the target template
+     * @param templateUri template URI string identifying the target template, such as
+     *     {@code Authorization-T/authorization-policy-management/v1}
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the text or template URI is null
+     * @throws NullPointerException if the text or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template.not_found},
      *     {@code template.load_failed}, {@code slot.schema_not_found}, {@code llm.invocation_failed},
      *     {@code template.render_failed} or {@code slot.not_provided} when generating the prompt fails, or the code
      *     {@code input.text_too_long} when the text exceeds the configured maximum length
      */
-    public MetadataContent generateAuthPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+    public MetadataContent generateAuthPromptFromText(@NonNull String text, @NonNull String templateUri) {
         Objects.requireNonNull(text, "text");
-        Objects.requireNonNull(templateUri, "templateUri");
-        return promptGenerationOrchestrator.generateAuthPromptFromText(text, templateUri);
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return promptGenerationOrchestrator.generateAuthPromptFromText(text, parsedTemplateUri);
     }
 
     /**
@@ -143,20 +148,21 @@ public final class A2ATClient {
      *
      * @param data structured authorization input as a string-to-object map
      * @param schema data schema map describing the meaning of each input field; must not be null or empty
-     * @param templateUri template URI identifying the target template
+     * @param templateUri template URI string identifying the target template, such as
+     *     {@code Authorization-T/authorization-policy-management/v1}
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the template URI, data or schema is null
-     * @throws IllegalArgumentException if the schema is empty
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or the schema is empty
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template.not_found},
      *     {@code template.load_failed}, {@code slot.schema_not_found}, {@code llm.invocation_failed},
      *     {@code template.render_failed} or {@code slot.not_provided} when generating the prompt fails
      */
     public MetadataContent generateAuthPromptFromDataWithSchema(
-            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull String templateUri) {
         Objects.requireNonNull(data, "data");
         Objects.requireNonNull(schema, "schema");
-        Objects.requireNonNull(templateUri, "templateUri");
-        return promptGenerationOrchestrator.generateAuthPromptFromDataWithSchema(data, schema, templateUri);
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return promptGenerationOrchestrator.generateAuthPromptFromDataWithSchema(data, schema, parsedTemplateUri);
     }
 
     /**
@@ -164,18 +170,20 @@ public final class A2ATClient {
      * template URI, bypassing scenario recognition.
      *
      * @param text natural-language notification input
-     * @param templateUri template URI identifying the target template
+     * @param templateUri template URI string identifying the target template, such as
+     *     {@code Notification-T/network-layer/subscribe-incident/v1}
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
-     * @throws NullPointerException if the text or template URI is null
+     * @throws NullPointerException if the text or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template.not_found},
      *     {@code template.load_failed}, {@code slot.schema_not_found}, {@code llm.invocation_failed},
      *     {@code template.render_failed} or {@code slot.not_provided} when generating the prompt fails, or the code
      *     {@code input.text_too_long} when the text exceeds the configured maximum length
      */
-    public MetadataContent generateNotificationPromptFromText(@NonNull String text, @NonNull TemplateUri templateUri) {
+    public MetadataContent generateNotificationPromptFromText(@NonNull String text, @NonNull String templateUri) {
         Objects.requireNonNull(text, "text");
-        Objects.requireNonNull(templateUri, "templateUri");
-        return promptGenerationOrchestrator.generateNotificationPromptFromText(text, templateUri);
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return promptGenerationOrchestrator.generateNotificationPromptFromText(text, parsedTemplateUri);
     }
 
     /**
@@ -184,20 +192,21 @@ public final class A2ATClient {
      *
      * @param data structured notification input as a string-to-object map
      * @param schema data schema map describing the meaning of each input field; must not be null or empty
-     * @param templateUri template URI identifying the target template
+     * @param templateUri template URI string identifying the target template, such as
+     *     {@code Notification-T/network-layer/subscribe-incident/v1}
      * @return metadata content carrying the resolved template URI, rendered prompt text, and extension URI
      * @throws NullPointerException if the template URI, data or schema is null
-     * @throws IllegalArgumentException if the schema is empty
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or the schema is empty
      * @throws net.openan.a2at.sdk.core.exception.PromptGenerationException with the code {@code template.not_found},
      *     {@code template.load_failed}, {@code slot.schema_not_found}, {@code llm.invocation_failed},
      *     {@code template.render_failed} or {@code slot.not_provided} when generating the prompt fails
      */
     public MetadataContent generateNotificationPromptFromDataWithSchema(
-            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
+            @NonNull Map<String, Object> data, @NonNull Map<String, Object> schema, @NonNull String templateUri) {
         Objects.requireNonNull(data, "data");
         Objects.requireNonNull(schema, "schema");
-        Objects.requireNonNull(templateUri, "templateUri");
-        return promptGenerationOrchestrator.generateNotificationPromptFromDataWithSchema(data, schema, templateUri);
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return promptGenerationOrchestrator.generateNotificationPromptFromDataWithSchema(data, schema, parsedTemplateUri);
     }
 
     /**
@@ -243,18 +252,20 @@ public final class A2ATClient {
      * generator of the negotiation type addressed by the template URI and rendered from that template.
      *
      * @param data typed propose input carrying the negotiation context and the typed content
-     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/propose/v1}; its phase
-     *     segment must be {@code propose}
+     * @param templateUri template URI string such as {@code Negotiation-T/information-negotiation/propose/v1}; its
+     *     phase segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content type
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
+     *     method or the content type
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation.field_missing} when rendering the template fails
      */
     public MetadataContent generateNegotiationProposePromptFromData(
-            @NonNull NegotiationProposeData data, @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateProposeFromData(data, templateUri);
+            @NonNull NegotiationProposeData data, @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.generateProposeFromData(data, parsedTemplateUri);
     }
 
     /**
@@ -264,19 +275,20 @@ public final class A2ATClient {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI string such as {@code Negotiation-T/information-negotiation/accept-reject/v1};
+     *     its phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
-     *     content conclusion is not {@code Accept}
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
+     *     method or the content, or the content conclusion is not {@code Accept}
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation.field_missing} when rendering the template fails
      */
     public MetadataContent generateNegotiationAcceptPromptFromData(
-            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateAcceptFromData(data, templateUri);
+            @NonNull NegotiationEndingData data, @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.generateAcceptFromData(data, parsedTemplateUri);
     }
 
     /**
@@ -286,19 +298,20 @@ public final class A2ATClient {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI string such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1};
+     *     its phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
-     *     content conclusion is not {@code Reject}
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
+     *     method or the content, or the content conclusion is not {@code Reject}
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation.field_missing} when rendering the template fails
      */
     public MetadataContent generateNegotiationRejectPromptFromData(
-            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateRejectFromData(data, templateUri);
+            @NonNull NegotiationEndingData data, @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.generateRejectFromData(data, parsedTemplateUri);
     }
 
     /**
@@ -308,18 +321,19 @@ public final class A2ATClient {
      * template must be the common abort template and the content carries only the termination reason.
      *
      * @param data typed abort input carrying the negotiation context and the termination reason
-     * @param templateUri template URI of the common abort template {@code Negotiation-T/common/abort/v1}
+     * @param templateUri template URI string of the common abort template {@code Negotiation-T/common/abort/v1}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the data or its context is null
-     * @throws IllegalArgumentException if the template URI does not address the common abort template or the
-     *     termination reason is blank
+     * @throws NullPointerException if the data, its context or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or does not address the common abort
+     *     template, or the termination reason is blank
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation.field_missing} when rendering the template fails
      */
     public MetadataContent generateNegotiationAbortPromptFromData(
-            @NonNull NegotiationAbortData data, @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateAbortFromData(data, templateUri);
+            @NonNull NegotiationAbortData data, @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.generateAbortFromData(data, parsedTemplateUri);
     }
 
     /**
@@ -333,11 +347,11 @@ public final class A2ATClient {
      * @param text free-text input describing the message content
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase segment
-     *     must be {@code propose}
+     * @param templateUri template URI string such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase
+     *     segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} when the extraction step fails
@@ -348,8 +362,9 @@ public final class A2ATClient {
     public MetadataContent generateNegotiationProposePromptFromText(
             @NonNull String text,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateProposeFromText(text, context, templateUri);
+            @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.generateProposeFromText(text, context, parsedTemplateUri);
     }
 
     /**
@@ -362,11 +377,11 @@ public final class A2ATClient {
      * @param text free-text input describing the message content
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI string such as {@code Negotiation-T/information-negotiation/accept-reject/v1};
+     *     its phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} when the extraction step fails
@@ -377,8 +392,9 @@ public final class A2ATClient {
     public MetadataContent generateNegotiationAcceptPromptFromText(
             @NonNull String text,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateAcceptFromText(text, context, templateUri);
+            @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.generateAcceptFromText(text, context, parsedTemplateUri);
     }
 
     /**
@@ -391,11 +407,11 @@ public final class A2ATClient {
      * @param text free-text input describing the message content
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri template URI string such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1};
+     *     its phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI phase contradicts the method
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} when the extraction step fails
@@ -406,8 +422,9 @@ public final class A2ATClient {
     public MetadataContent generateNegotiationRejectPromptFromText(
             @NonNull String text,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateRejectFromText(text, context, templateUri);
+            @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.generateRejectFromText(text, context, parsedTemplateUri);
     }
 
     /**
@@ -421,10 +438,11 @@ public final class A2ATClient {
      * @param text free-text input stating the termination reason
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI of the common abort template {@code Negotiation-T/common/abort/v1}
+     * @param templateUri template URI string of the common abort template {@code Negotiation-T/common/abort/v1}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
-     * @throws NullPointerException if the context is null
-     * @throws IllegalArgumentException if the template URI does not address the common abort template
+     * @throws NullPointerException if the context or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or does not address the common abort
+     *     template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} when the extraction step fails
@@ -435,8 +453,9 @@ public final class A2ATClient {
     public MetadataContent generateNegotiationAbortPromptFromText(
             @NonNull String text,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateAbortFromText(text, context, templateUri);
+            @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.generateAbortFromText(text, context, parsedTemplateUri);
     }
 
     /**
@@ -456,15 +475,18 @@ public final class A2ATClient {
     /**
      * Loads one template by its URI, regardless of the extension.
      *
-     * <p>This query never throws: a missing template yields an empty result together with a warning log instead of a
-     * failure.
+     * <p>This query never throws for a well-formed template URI: a missing template yields an empty result together
+     * with a warning log instead of a failure.
      *
-     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1} or
+     * @param templateUri template URI string such as {@code Negotiation-T/target-negotiation/propose/v1} or
      *     {@code Task-T/network-layer/ran-energy-saving/v1}
      * @return the addressed template, or an empty optional when no template exists for it in the configured language
+     * @throws NullPointerException if the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed
      */
-    public Optional<PromptTemplate> getPrompt(@NonNull TemplateUri templateUri) {
-        return templateQueryService.getPrompt(templateUri);
+    public Optional<PromptTemplate> getPrompt(@NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return templateQueryService.getPrompt(parsedTemplateUri);
     }
 
     /**
@@ -480,11 +502,12 @@ public final class A2ATClient {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
-     *     {@code propose}
+     * @param templateUri template URI string declaring the expected negotiation type and phase; its phase segment must
+     *     be {@code propose}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI phase contradicts the method
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or the template
+     *     URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation.rule_violation} when the negotiation context violates a rule,
@@ -496,8 +519,10 @@ public final class A2ATClient {
             @NonNull String prompt,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
             @NonNull Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.validateProposePromptAndDataFilling(prompt, context, schema, templateUri);
+            @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.validateProposePromptAndDataFilling(
+                prompt, context, schema, parsedTemplateUri);
     }
 
     /**
@@ -511,11 +536,12 @@ public final class A2ATClient {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
-     *     {@code accept-reject}
+     * @param templateUri template URI string declaring the expected negotiation type and phase; its phase segment must
+     *     be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI phase contradicts the method
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or the template
+     *     URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation.rule_violation} when the negotiation context violates a rule,
@@ -527,8 +553,9 @@ public final class A2ATClient {
             @NonNull String prompt,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
             @NonNull Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.validateAcceptPromptAndDataFilling(prompt, context, schema, templateUri);
+            @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.validateAcceptPromptAndDataFilling(prompt, context, schema, parsedTemplateUri);
     }
 
     /**
@@ -542,11 +569,12 @@ public final class A2ATClient {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
-     *     {@code accept-reject}
+     * @param templateUri template URI string declaring the expected negotiation type and phase; its phase segment must
+     *     be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI phase contradicts the method
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or the template
+     *     URI phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation.rule_violation} when the negotiation context violates a rule,
@@ -558,8 +586,9 @@ public final class A2ATClient {
             @NonNull String prompt,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
             @NonNull Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.validateRejectPromptAndDataFilling(prompt, context, schema, templateUri);
+            @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.validateRejectPromptAndDataFilling(prompt, context, schema, parsedTemplateUri);
     }
 
     /**
@@ -573,11 +602,11 @@ public final class A2ATClient {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI of the common abort template {@code Negotiation-T/common/abort/v1}
+     * @param templateUri template URI string of the common abort template {@code Negotiation-T/common/abort/v1}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI does not address the common abort
-     *     template
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or the template
+     *     URI does not address the common abort template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation.rule_violation} when the negotiation context violates a rule,
@@ -589,7 +618,14 @@ public final class A2ATClient {
             @NonNull String prompt,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
             @NonNull Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.validateAbortPromptAndDataFilling(prompt, context, schema, templateUri);
+            @NonNull String templateUri) {
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
+        return negotiationContentService.validateAbortPromptAndDataFilling(prompt, context, schema, parsedTemplateUri);
+    }
+
+    private static TemplateUri parseTemplateUri(String templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
+        return TemplateUri.parse(templateUri)
+                .orElseThrow(() -> new IllegalArgumentException("Unparseable template URI: " + templateUri));
     }
 }

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationApiTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationApiTest.java
@@ -2,6 +2,7 @@ package net.openan.a2at.sdk.client.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -53,7 +54,7 @@ class A2ATClientNegotiationApiTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
                         new InformationProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE);
+                INFORMATION_PROPOSE_URI);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -73,7 +74,7 @@ class A2ATClientNegotiationApiTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
                         new InformationProposeContent(List.of(new NegotiationItem("Region", "Songshan Lake")), null)),
-                INFORMATION_PROPOSE);
+                INFORMATION_PROPOSE_URI);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -95,7 +96,7 @@ class A2ATClientNegotiationApiTest {
                 new NegotiationAbortData(
                         new NegotiationContext(UUID, 5, 5, NegotiationPerformative.ABORT),
                         new NegotiationAbortContent("达到协商轮次上限，本次协商确认结束。")),
-                StandardTemplates.NEGOTIATION_ABORT);
+                StandardTemplates.NEGOTIATION_ABORT_URI);
 
         assertEquals(StandardTemplates.NEGOTIATION_ABORT.uri(), result.templateUri());
         assertTrue(result.promptText().contains("## 协商结果\nAbort"));
@@ -113,7 +114,7 @@ class A2ATClientNegotiationApiTest {
                         new NegotiationContext(UUID, 3, 5, NegotiationPerformative.ABORT),
                         new NegotiationAbortContent(
                                 "Reached the negotiation round limit. This negotiation is confirmed and ended.")),
-                StandardTemplates.NEGOTIATION_ABORT);
+                StandardTemplates.NEGOTIATION_ABORT_URI);
 
         assertEquals(StandardTemplates.NEGOTIATION_ABORT.uri(), result.templateUri());
         assertTrue(result.promptText().contains("## Negotiation Result\nAbort"));
@@ -126,7 +127,7 @@ class A2ATClientNegotiationApiTest {
         A2ATClient client = new A2ATClient(writeEnv("zh-CN"));
 
         PromptTemplate template =
-                client.getPrompt(StandardTemplates.NEGOTIATION_ABORT).orElseThrow();
+                client.getPrompt(StandardTemplates.NEGOTIATION_ABORT_URI).orElseThrow();
         assertEquals(StandardTemplates.NEGOTIATION_ABORT, template.templateUri());
         assertFalse(template.content().isBlank());
     }
@@ -135,15 +136,41 @@ class A2ATClientNegotiationApiTest {
     void queriesSingleNegotiationTemplateWithoutThrowing() throws IOException {
         A2ATClient client = new A2ATClient(writeEnv("zh-CN"));
 
-        assertTrue(client.getPrompt(INFORMATION_PROPOSE).isPresent());
-        assertTrue(client.getPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
+        assertTrue(client.getPrompt(INFORMATION_PROPOSE_URI).isPresent());
+        assertTrue(client.getPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI)
                 .isPresent());
-        assertFalse(
-                client.getPrompt(TemplateUri.of("Negotiation-T", List.of("information-negotiation", "propose"), "v9"))
-                        .isPresent());
-        PromptTemplate template = client.getPrompt(INFORMATION_PROPOSE).orElseThrow();
+        assertFalse(client.getPrompt("Negotiation-T/information-negotiation/propose/v9").isPresent());
+        PromptTemplate template = client.getPrompt(INFORMATION_PROPOSE_URI).orElseThrow();
         assertEquals(INFORMATION_PROPOSE, template.templateUri());
         assertFalse(template.content().isBlank());
+    }
+
+    @Test
+    void generateNegotiationPromptFromDataThrowsOnMalformedTemplateUriString() throws IOException {
+        A2ATClient client = new A2ATClient(writeEnv("zh-CN"));
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> client.generateNegotiationProposePromptFromData(
+                        new NegotiationProposeData(
+                                new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
+                                new InformationProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
+                        "Task-T/only-one-segment"));
+        assertTrue(ex.getMessage().contains("Unparseable template URI"), "message was: " + ex.getMessage());
+    }
+
+    @Test
+    void validateNegotiationPromptThrowsOnBlankTemplateUriString() throws IOException {
+        A2ATClient client = new A2ATClient(writeEnv("zh-CN"));
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> client.validateProposePromptAndDataFilling(
+                        "rendered negotiation message",
+                        new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
+                        Map.of("type", "object"),
+                        "  "));
+        assertTrue(ex.getMessage().contains("Unparseable template URI"), "message was: " + ex.getMessage());
     }
 
     private static List<PromptTemplate> negotiationPrompts(A2ATClient client) {

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationEnvConfigTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientNegotiationEnvConfigTest.java
@@ -107,7 +107,7 @@ class A2ATClientNegotiationEnvConfigTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
                         new InformationProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE);
+                INFORMATION_PROPOSE_URI);
 
         assertTrue(result.promptText().contains("所需信息项"), "the zh-CN language must select the Chinese templates");
         assertFalse(
@@ -119,7 +119,7 @@ class A2ATClientNegotiationEnvConfigTest {
                 () -> client.generateNegotiationProposePromptFromText(
                         "请提供节能区域。",
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
-                        INFORMATION_PROPOSE));
+                        INFORMATION_PROPOSE_URI));
         assertEquals(A2ATErrorCodes.NEGOTIATION_LLM_INFRASTRUCTURE_ERROR, failure.getCode());
         assertEquals(
                 1,
@@ -141,19 +141,19 @@ class A2ATClientNegotiationEnvConfigTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
                         new InformationProposeContent(List.of(new NegotiationItem("Region", "Songshan Lake")), null)),
-                INFORMATION_PROPOSE);
+                INFORMATION_PROPOSE_URI);
 
         assertTrue(result.promptText().contains("## Information Negotiation"), "the default language must be en-US");
         assertTrue(result.promptText().contains("Required Information Items"));
         assertEquals(7, negotiationPrompts(client).size(), "the built-in resources must be used by default");
-        assertTrue(client.getPrompt(INFORMATION_PROPOSE).isPresent());
+        assertTrue(client.getPrompt(INFORMATION_PROPOSE_URI).isPresent());
 
         assertThrows(
                 NegotiationGenerationException.class,
                 () -> client.generateNegotiationProposePromptFromText(
                         "Provide the ran-energy-saving region.",
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
-                        INFORMATION_PROPOSE));
+                        INFORMATION_PROPOSE_URI));
         assertEquals(
                 2,
                 retryEventCount(),

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/A2ATClientTest.java
@@ -21,7 +21,6 @@ import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMClientConfig;
 import net.openan.a2at.sdk.llm.LLMClientFactory;
@@ -99,6 +98,7 @@ class A2ATClientTest {
     void doesNotKeepStaticAssemblyHelpersInsideFacade() {
         long staticMethodCount = Arrays.stream(A2ATClient.class.getDeclaredMethods())
                 .filter(method -> java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+                .filter(method -> !java.lang.reflect.Modifier.isPrivate(method.getModifiers()))
                 .count();
 
         assertEquals(0, staticMethodCount);
@@ -317,7 +317,7 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
     void fromTextEntryPointsReturnMetadataContent() throws IOException {
         Path envFile = writeMinimalClientEnvWithoutRequiredSlots(TEST_MOCK_PROVIDER);
         A2ATClient client = new A2ATClient(envFile);
-        TemplateUri unconstrained = TemplateUri.of("Task-T", "network-layer", "unconstrained");
+        String unconstrained = "Task-T/network-layer/unconstrained/v1";
 
         MetadataContent taskResult = client.generateTaskPromptFromText("Please analyze Site A.", unconstrained);
         MetadataContent authResult = client.generateAuthPromptFromText("Authorize access.", unconstrained);
@@ -348,11 +348,11 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
         Map<String, Object> schema = Map.of("type", "object");
 
         MetadataContent taskResult =
-                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
+                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING_URI);
         MetadataContent authResult =
-                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
+                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING_URI);
         MetadataContent notificationResult =
-                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
+                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING_URI);
 
         assertNotNull(taskResult);
         assertEquals(StandardTemplates.ENERGY_SAVING.uri(), taskResult.templateUri());
@@ -374,7 +374,7 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
     void fromTextReturnsCorrectExtensionUriPerContentType() throws IOException {
         Path envFile = writeMinimalClientEnvWithoutRequiredSlots(TEST_MOCK_PROVIDER);
         A2ATClient client = new A2ATClient(envFile);
-        TemplateUri unconstrained = TemplateUri.of("Task-T", "network-layer", "unconstrained");
+        String unconstrained = "Task-T/network-layer/unconstrained/v1";
 
         MetadataContent taskResult = client.generateTaskPromptFromText("Please analyze Site A.", unconstrained);
         MetadataContent authResult = client.generateAuthPromptFromText("Authorize access.", unconstrained);
@@ -394,11 +394,11 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
         Map<String, Object> schema = Map.of("type", "object");
 
         MetadataContent taskResult =
-                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
+                client.generateTaskPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING_URI);
         MetadataContent authResult =
-                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
+                client.generateAuthPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING_URI);
         MetadataContent notificationResult =
-                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING);
+                client.generateNotificationPromptFromDataWithSchema(data, schema, StandardTemplates.ENERGY_SAVING_URI);
 
         assertEquals(ExtensionUriConstants.TASK_T_EXTENSION_URI, taskResult.extensionUri());
         assertEquals(ExtensionUriConstants.AUTHORIZATION_T_EXTENSION_URI, authResult.extensionUri());
@@ -441,6 +441,48 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
     }
 
     @Test
+    void fromTextThrowsOnMalformedTemplateUriString() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        for (String malformed : new String[] {"not-a-uri", "Task-T/only-one-segment", "Task-T/../v1"}) {
+            IllegalArgumentException taskEx = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> client.generateTaskPromptFromText("Please analyze Site A.", malformed));
+            assertTrue(taskEx.getMessage().contains("Unparseable template URI"), "message was: " + taskEx.getMessage());
+            IllegalArgumentException authEx = assertThrows(
+                    IllegalArgumentException.class, () -> client.generateAuthPromptFromText("Authorize access.", malformed));
+            assertTrue(authEx.getMessage().contains("Unparseable template URI"), "message was: " + authEx.getMessage());
+            IllegalArgumentException notifEx = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> client.generateNotificationPromptFromText("Report finished.", malformed));
+            assertTrue(notifEx.getMessage().contains("Unparseable template URI"), "message was: " + notifEx.getMessage());
+        }
+    }
+
+    @Test
+    void fromTextThrowsOnBlankTemplateUriString() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        IllegalArgumentException taskEx = assertThrows(
+                IllegalArgumentException.class, () -> client.generateTaskPromptFromText("Please analyze Site A.", "  "));
+        assertTrue(taskEx.getMessage().contains("Unparseable template URI"), "message was: " + taskEx.getMessage());
+    }
+
+    @Test
+    void getPromptThrowsOnMalformedAndBlankTemplateUriString() throws IOException {
+        Path envFile = writeMinimalLocalClientEnv();
+        A2ATClient client = new A2ATClient(envFile);
+
+        IllegalArgumentException malformedEx =
+                assertThrows(IllegalArgumentException.class, () -> client.getPrompt("not-a-uri"));
+        assertTrue(malformedEx.getMessage().contains("Unparseable template URI"), "message was: " + malformedEx.getMessage());
+        IllegalArgumentException blankEx = assertThrows(IllegalArgumentException.class, () -> client.getPrompt("  "));
+        assertTrue(blankEx.getMessage().contains("Unparseable template URI"), "message was: " + blankEx.getMessage());
+    }
+
+    @Test
     void fromTextRejectsOverLimitTextWhenConfiguredWithSmallLimit() throws IOException {
         Path envFile = writeMinimalClientEnvWithInputLimit(TEST_MOCK_PROVIDER, 100);
         A2ATClient client = new A2ATClient(envFile);
@@ -448,13 +490,13 @@ A2AT_NEGOTIATION_STATE_STORE_TYPE=in_memory
 
         PromptGenerationException taskEx = assertThrows(
                 PromptGenerationException.class,
-                () -> client.generateTaskPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING));
+                () -> client.generateTaskPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING_URI));
         PromptGenerationException authEx = assertThrows(
                 PromptGenerationException.class,
-                () -> client.generateAuthPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING));
+                () -> client.generateAuthPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING_URI));
         PromptGenerationException notificationEx = assertThrows(
                 PromptGenerationException.class,
-                () -> client.generateNotificationPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING));
+                () -> client.generateNotificationPromptFromText(overLimitText, StandardTemplates.ENERGY_SAVING_URI));
 
         assertEquals("input.text_too_long", taskEx.getCode());
         assertEquals("input.text_too_long", authEx.getCode());

--- a/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/AuthorizationEntryPointMetadataTest.java
+++ b/a2a-t-client/src/test/java/net/openan/a2at/sdk/client/api/AuthorizationEntryPointMetadataTest.java
@@ -42,7 +42,7 @@ class AuthorizationEntryPointMetadataTest {
 
         MetadataContent result = client.generateAuthPromptFromText(
                 "新增两条动网操作授权策略：业务投诉诊断/业务抢通/隧道调优/限期生效（2026-06-01~2030-06-18）；载波调度/业务抢通/载波调度/永久生效",
-                StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT);
+                StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
 
         assertNotNull(result);
         assertEquals(
@@ -61,7 +61,7 @@ class AuthorizationEntryPointMetadataTest {
         Map<String, Object> schema = Map.of("操作类型", "授权策略操作类型，取值范围：新增/修改/删除/查询授权策略");
 
         MetadataContent result = client.generateAuthPromptFromDataWithSchema(
-                data, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT);
+                data, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
 
         assertNotNull(result);
         assertEquals(

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/StandardTemplates.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/model/StandardTemplates.java
@@ -6,11 +6,14 @@ import java.util.List;
  * Constants for the built-in content templates shipped with the SDK, in the spirit of
  * {@code java.nio.charset.StandardCharsets}.
  *
- * <p>Each constant is a language-neutral {@link TemplateUri}; the language is global prompt runtime context and is
- * bound by the SDK, not by the caller. Use these constants instead of hand-written URI strings to get compile-time
- * safety against spelling drift.
+ * <p>Each template is published in two spellings: a language-neutral {@link TemplateUri} and its raw {@code uri()}
+ * string (constant name suffixed {@code _URI}). The typed form is the identity representation used for template
+ * comparisons (for example against {@link PromptTemplate#templateUri()}) and by internal seams; the string form is
+ * what the {@code A2ATClient}/{@code A2ATServer} facades take as their {@code templateUri} parameter. The language is
+ * global prompt runtime context and is bound by the SDK, not by the caller. Use these constants instead of hand-written
+ * URI strings to keep the spelling centralized — a consistency test pins the two forms together.
  *
- * <p>Example: {@code StandardTemplates.ENERGY_SAVING.uri()} is {@code Task-T/network-layer/ran-energy-saving/v1}. The
+ * <p>Example: {@code StandardTemplates.ENERGY_SAVING_URI} is {@code Task-T/network-layer/ran-energy-saving/v1}. The
  * Task-T and Notification-T templates carry the {@code network-layer} domain segment; Authorization-T and
  * Negotiation-T templates do not.
  *
@@ -43,58 +46,123 @@ public final class StandardTemplates {
     public static final TemplateUri ENERGY_SAVING =
             TemplateUri.of(TASK_EXTENSION_NAME, NETWORK_LAYER_SEGMENT, "ran-energy-saving");
 
+    /** Raw template URI of {@link #ENERGY_SAVING}: {@code Task-T/network-layer/ran-energy-saving/v1}. */
+    public static final String ENERGY_SAVING_URI = ENERGY_SAVING.uri();
+
     /** Task-T template for the private-line-complaint scenario. */
     public static final TemplateUri PRIVATE_LINE_COMPLAINT =
             TemplateUri.of(TASK_EXTENSION_NAME, NETWORK_LAYER_SEGMENT, "private-line-complaint");
+
+    /** Raw template URI of {@link #PRIVATE_LINE_COMPLAINT}: {@code Task-T/network-layer/private-line-complaint/v1}. */
+    public static final String PRIVATE_LINE_COMPLAINT_URI = PRIVATE_LINE_COMPLAINT.uri();
 
     /** Notification-T template for the subscribe-incident scenario. */
     public static final TemplateUri SUBSCRIBE_INCIDENT =
             TemplateUri.of(NOTIFICATION_EXTENSION_NAME, NETWORK_LAYER_SEGMENT, "subscribe-incident");
 
+    /** Raw template URI of {@link #SUBSCRIBE_INCIDENT}: {@code Notification-T/network-layer/subscribe-incident/v1}. */
+    public static final String SUBSCRIBE_INCIDENT_URI = SUBSCRIBE_INCIDENT.uri();
+
     /** Notification-T template for the service-recovery scenario. */
     public static final TemplateUri SERVICE_RECOVERY =
             TemplateUri.of(NOTIFICATION_EXTENSION_NAME, NETWORK_LAYER_SEGMENT, "service-recovery");
+
+    /** Raw template URI of {@link #SERVICE_RECOVERY}: {@code Notification-T/network-layer/service-recovery/v1}. */
+    public static final String SERVICE_RECOVERY_URI = SERVICE_RECOVERY.uri();
 
     /** Authorization-T template for the authorization-policy-management scenario. */
     public static final TemplateUri AUTHORIZATION_POLICY_MANAGEMENT =
             TemplateUri.of(AUTHORIZATION_EXTENSION_NAME, "authorization-policy-management");
 
+    /**
+     * Raw template URI of {@link #AUTHORIZATION_POLICY_MANAGEMENT}:
+     * {@code Authorization-T/authorization-policy-management/v1}.
+     */
+    public static final String AUTHORIZATION_POLICY_MANAGEMENT_URI = AUTHORIZATION_POLICY_MANAGEMENT.uri();
+
     /** Negotiation-T propose template for information negotiation. */
     public static final TemplateUri INFORMATION_NEGOTIATION_PROPOSE =
             TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "information-negotiation", "propose");
+
+    /**
+     * Raw template URI of {@link #INFORMATION_NEGOTIATION_PROPOSE}:
+     * {@code Negotiation-T/information-negotiation/propose/v1}.
+     */
+    public static final String INFORMATION_NEGOTIATION_PROPOSE_URI = INFORMATION_NEGOTIATION_PROPOSE.uri();
 
     /** Negotiation-T accept-reject template for information negotiation. */
     public static final TemplateUri INFORMATION_NEGOTIATION_ACCEPT_REJECT =
             TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "information-negotiation", "accept-reject");
 
+    /**
+     * Raw template URI of {@link #INFORMATION_NEGOTIATION_ACCEPT_REJECT}:
+     * {@code Negotiation-T/information-negotiation/accept-reject/v1}.
+     */
+    public static final String INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI =
+            INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri();
+
     /** Negotiation-T propose template for target negotiation. */
     public static final TemplateUri TARGET_NEGOTIATION_PROPOSE =
             TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "target-negotiation", "propose");
+
+    /** Raw template URI of {@link #TARGET_NEGOTIATION_PROPOSE}: {@code Negotiation-T/target-negotiation/propose/v1}. */
+    public static final String TARGET_NEGOTIATION_PROPOSE_URI = TARGET_NEGOTIATION_PROPOSE.uri();
 
     /** Negotiation-T accept-reject template for target negotiation. */
     public static final TemplateUri TARGET_NEGOTIATION_ACCEPT_REJECT =
             TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "target-negotiation", "accept-reject");
 
+    /**
+     * Raw template URI of {@link #TARGET_NEGOTIATION_ACCEPT_REJECT}:
+     * {@code Negotiation-T/target-negotiation/accept-reject/v1}.
+     */
+    public static final String TARGET_NEGOTIATION_ACCEPT_REJECT_URI = TARGET_NEGOTIATION_ACCEPT_REJECT.uri();
+
     /** Negotiation-T propose template for feasibility negotiation. */
     public static final TemplateUri FEASIBILITY_NEGOTIATION_PROPOSE =
             TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "feasibility-negotiation", "propose");
+
+    /**
+     * Raw template URI of {@link #FEASIBILITY_NEGOTIATION_PROPOSE}:
+     * {@code Negotiation-T/feasibility-negotiation/propose/v1}.
+     */
+    public static final String FEASIBILITY_NEGOTIATION_PROPOSE_URI = FEASIBILITY_NEGOTIATION_PROPOSE.uri();
 
     /** Negotiation-T accept-reject template for feasibility negotiation. */
     public static final TemplateUri FEASIBILITY_NEGOTIATION_ACCEPT_REJECT =
             TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "feasibility-negotiation", "accept-reject");
 
+    /**
+     * Raw template URI of {@link #FEASIBILITY_NEGOTIATION_ACCEPT_REJECT}:
+     * {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}.
+     */
+    public static final String FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI =
+            FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri();
+
     /** Negotiation-T common abort template. */
     public static final TemplateUri NEGOTIATION_ABORT =
             TemplateUri.of(NEGOTIATION_EXTENSION_NAME, "common", "abort");
 
+    /** Raw template URI of {@link #NEGOTIATION_ABORT}: {@code Negotiation-T/common/abort/v1}. */
+    public static final String NEGOTIATION_ABORT_URI = NEGOTIATION_ABORT.uri();
+
     /** All built-in Task-T templates. */
     public static final List<TemplateUri> TASK = List.of(ENERGY_SAVING, PRIVATE_LINE_COMPLAINT);
+
+    /** Raw template URIs of all built-in Task-T templates. */
+    public static final List<String> TASK_URIS = List.of(ENERGY_SAVING_URI, PRIVATE_LINE_COMPLAINT_URI);
 
     /** All built-in Notification-T templates. */
     public static final List<TemplateUri> NOTIFICATION = List.of(SUBSCRIBE_INCIDENT, SERVICE_RECOVERY);
 
+    /** Raw template URIs of all built-in Notification-T templates. */
+    public static final List<String> NOTIFICATION_URIS = List.of(SUBSCRIBE_INCIDENT_URI, SERVICE_RECOVERY_URI);
+
     /** All built-in Authorization-T templates. */
     public static final List<TemplateUri> AUTHORIZATION = List.of(AUTHORIZATION_POLICY_MANAGEMENT);
+
+    /** Raw template URIs of all built-in Authorization-T templates. */
+    public static final List<String> AUTHORIZATION_URIS = List.of(AUTHORIZATION_POLICY_MANAGEMENT_URI);
 
     /** All built-in Negotiation-T templates. */
     public static final List<TemplateUri> NEGOTIATION = List.of(
@@ -105,4 +173,14 @@ public final class StandardTemplates {
             FEASIBILITY_NEGOTIATION_PROPOSE,
             FEASIBILITY_NEGOTIATION_ACCEPT_REJECT,
             NEGOTIATION_ABORT);
+
+    /** Raw template URIs of all built-in Negotiation-T templates. */
+    public static final List<String> NEGOTIATION_URIS = List.of(
+            INFORMATION_NEGOTIATION_PROPOSE_URI,
+            INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI,
+            TARGET_NEGOTIATION_PROPOSE_URI,
+            TARGET_NEGOTIATION_ACCEPT_REJECT_URI,
+            FEASIBILITY_NEGOTIATION_PROPOSE_URI,
+            FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI,
+            NEGOTIATION_ABORT_URI);
 }

--- a/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/ContentValidator.java
+++ b/a2a-t-core/src/main/java/net/openan/a2at/sdk/core/validation/ContentValidator.java
@@ -23,7 +23,7 @@ public interface ContentValidator {
      * @param templateUri URI of the template the content is validated against, such as
      *     {@code Task-T/network-layer/ran-energy-saving/v1}
      * @return filled parameter data carrying the merged parameters
-     * @throws ContentValidationException with {@code validation_invalid_input} if the template URI is null or
+     * @throws ContentValidationException with {@code negotiation.invalid_input} if the template URI is null or
      *     malformed, the prompt is null or blank, or the schema is null
      * @throws ContentValidationException if the validation fails at any stage
      */

--- a/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/StandardTemplatesStringConstantsTest.java
+++ b/a2a-t-core/src/test/java/net/openan/a2at/sdk/core/model/StandardTemplatesStringConstantsTest.java
@@ -1,0 +1,78 @@
+package net.openan.a2at.sdk.core.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the parallel string constant set of {@link StandardTemplates}.
+ *
+ * <p>Pins the typed {@link TemplateUri} constants and their raw {@code _URI} string twins in lockstep so the two
+ * spellings of the same template cannot drift apart, and mirrors the family aggregates the same way.
+ *
+ * @since 2026-08
+ */
+class StandardTemplatesStringConstantsTest {
+
+    @Test
+    void should_keepTypedAndStringConstantsInLockstep() {
+        assertEquals(StandardTemplates.ENERGY_SAVING.uri(), StandardTemplates.ENERGY_SAVING_URI);
+        assertEquals(StandardTemplates.PRIVATE_LINE_COMPLAINT.uri(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
+        assertEquals(StandardTemplates.SUBSCRIBE_INCIDENT.uri(), StandardTemplates.SUBSCRIBE_INCIDENT_URI);
+        assertEquals(StandardTemplates.SERVICE_RECOVERY.uri(), StandardTemplates.SERVICE_RECOVERY_URI);
+        assertEquals(
+                StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT.uri(),
+                StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
+        assertEquals(
+                StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE.uri(),
+                StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI);
+        assertEquals(
+                StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT.uri(),
+                StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
+        assertEquals(StandardTemplates.TARGET_NEGOTIATION_PROPOSE.uri(), StandardTemplates.TARGET_NEGOTIATION_PROPOSE_URI);
+        assertEquals(
+                StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT.uri(),
+                StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT_URI);
+        assertEquals(
+                StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE.uri(),
+                StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE_URI);
+        assertEquals(
+                StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT.uri(),
+                StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI);
+        assertEquals(StandardTemplates.NEGOTIATION_ABORT.uri(), StandardTemplates.NEGOTIATION_ABORT_URI);
+    }
+
+    @Test
+    void should_keepFamilyAggregatesInLockstep() {
+        assertEquals(uriList(StandardTemplates.TASK), StandardTemplates.TASK_URIS);
+        assertEquals(uriList(StandardTemplates.NOTIFICATION), StandardTemplates.NOTIFICATION_URIS);
+        assertEquals(uriList(StandardTemplates.AUTHORIZATION), StandardTemplates.AUTHORIZATION_URIS);
+        assertEquals(uriList(StandardTemplates.NEGOTIATION), StandardTemplates.NEGOTIATION_URIS);
+    }
+
+    @Test
+    void should_exposeOneStringConstantPerTypedConstant() {
+        List<String> typed = Arrays.stream(StandardTemplates.class.getDeclaredFields())
+                .filter(field -> field.getType() == TemplateUri.class)
+                .map(Field::getName)
+                .sorted()
+                .toList();
+        List<String> strings = Arrays.stream(StandardTemplates.class.getDeclaredFields())
+                .filter(field -> field.getType() == String.class)
+                .map(Field::getName)
+                .filter(name -> name.endsWith("_URI"))
+                .sorted()
+                .toList();
+        // every typed constant ENERGY_SAVING must have exactly one string twin ENERGY_SAVING_URI, and no other
+        // *_URI string constant may exist
+        List<String> expected = typed.stream().map(name -> name + "_URI").sorted().toList();
+        assertEquals(expected, strings);
+    }
+
+    private static List<String> uriList(List<TemplateUri> uris) {
+        return uris.stream().map(TemplateUri::uri).toList();
+    }
+}

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationContentService.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationContentService.java
@@ -72,8 +72,8 @@ public final class NegotiationContentService {
      *     field is blank or empty, or {@code negotiation.invalid_input} when the content combines a non-blank confirm
      *     request with conditional sections (target: the three clarification lists; feasibility: either conditional
      *     list or the alternative action)
-     * @throws NegotiationGenerationException with the code {@code template.not_found} or
-     *     {@code negotiation.field_missing} when loading or rendering the template fails
+     * @throws NegotiationGenerationException with the code {@code template.not_found} when loading the template fails,
+     *     or the code {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateProposeFromData(
             @NonNull NegotiationProposeData data, @NonNull TemplateUri templateUri) {
@@ -91,8 +91,8 @@ public final class NegotiationContentService {
      * @throws NegotiationGenerationException with the code {@code negotiation.conclusion_mismatch} when the content
      *     conclusion is not {@code Accept}, or {@code negotiation.content_invalid} when a required content field is
      *     blank or empty
-     * @throws NegotiationGenerationException with the code {@code template.not_found} or
-     *     {@code negotiation.field_missing} when loading or rendering the template fails
+     * @throws NegotiationGenerationException with the code {@code template.not_found} when loading the template fails,
+     *     or the code {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateAcceptFromData(
             @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
@@ -110,8 +110,8 @@ public final class NegotiationContentService {
      * @throws NegotiationGenerationException with the code {@code negotiation.conclusion_mismatch} when the content
      *     conclusion is not {@code Reject}, or {@code negotiation.content_invalid} when a required content field is
      *     blank or empty
-     * @throws NegotiationGenerationException with the code {@code template.not_found} or
-     *     {@code negotiation.field_missing} when loading or rendering the template fails
+     * @throws NegotiationGenerationException with the code {@code template.not_found} when loading the template fails,
+     *     or the code {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateRejectFromData(
             @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
@@ -128,8 +128,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the template URI does not address the common abort template
      * @throws NegotiationGenerationException with the code {@code negotiation.content_invalid} when the termination
      *     reason is blank
-     * @throws NegotiationGenerationException with the code {@code template.not_found} or
-     *     {@code negotiation.field_missing} when loading or rendering the template fails
+     * @throws NegotiationGenerationException with the code {@code template.not_found} when loading the template fails,
+     *     or the code {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateAbortFromData(@NonNull NegotiationAbortData data, @NonNull TemplateUri templateUri) {
         return orchestrator.generateAbortFromData(data, templateUri);
@@ -147,7 +147,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the template URI contradicts the method
      * @throws NegotiationGenerationException with the code {@code template.not_found},
      *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} or {@code llm.response_invalid}
-     *     when loading or extracting fails, {@code negotiation.field_missing} when the extracted content misses a
+     *     when loading or extracting fails, {@code template.render_failed} when rendering the template fails,
+     *     {@code negotiation.field_missing} when the extracted content misses a
      *     required field, or {@code negotiation.invalid_input} when the text is blank, the extracted content
      *     contradicts the performative or the extracted confirm request is combined with conditional sections or the
      *     wrong feasibility action, or {@code input.text_too_long} when the text exceeds the configured maximum length
@@ -169,7 +170,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the template URI contradicts the method
      * @throws NegotiationGenerationException with the code {@code template.not_found},
      *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} or {@code llm.response_invalid}
-     *     when loading or extracting fails, {@code negotiation.field_missing} when the extracted content misses a
+     *     when loading or extracting fails, {@code template.render_failed} when rendering the template fails,
+     *     {@code negotiation.field_missing} when the extracted content misses a
      *     required field, or {@code negotiation.invalid_input} when the text is blank,
      *     {@code negotiation.conclusion_mismatch} when the extracted conclusion is not {@code Accept}, or
      *     {@code input.text_too_long} when the text exceeds the configured maximum length
@@ -191,7 +193,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the template URI contradicts the method
      * @throws NegotiationGenerationException with the code {@code template.not_found},
      *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} or {@code llm.response_invalid}
-     *     when loading or extracting fails, {@code negotiation.field_missing} when the extracted content misses a
+     *     when loading or extracting fails, {@code template.render_failed} when rendering the template fails,
+     *     {@code negotiation.field_missing} when the extracted content misses a
      *     required field, or {@code negotiation.invalid_input} when the text is blank,
      *     {@code negotiation.conclusion_mismatch} when the extracted conclusion is not {@code Reject}, or
      *     {@code input.text_too_long} when the text exceeds the configured maximum length
@@ -213,7 +216,8 @@ public final class NegotiationContentService {
      * @throws IllegalArgumentException if the template URI does not address the common abort template
      * @throws NegotiationGenerationException with the code {@code template.not_found},
      *     {@code negotiation.content_extract_failed} or {@code llm.invocation_failed} or {@code llm.response_invalid}
-     *     when loading or extracting fails, {@code negotiation.field_missing} when the extracted content misses the
+     *     when loading or extracting fails, {@code template.render_failed} when rendering the template fails,
+     *     {@code negotiation.field_missing} when the extracted content misses the
      *     termination reason, or {@code negotiation.invalid_input} when the text is blank, or
      *     {@code input.text_too_long} when the text exceeds the configured maximum length
      */

--- a/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
+++ b/a2a-t-negotiation/src/main/java/net/openan/a2at/sdk/negotiation/generation/NegotiationGenerationOrchestrator.java
@@ -210,7 +210,8 @@ public final class NegotiationGenerationOrchestrator {
      *     resource exists for the URI and language, {@code negotiation.content_extract_failed} or
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the extraction step fails after exhausting
      *     its retries, {@code negotiation.field_missing} when the extracted content misses a required field, or
-     *     {@code negotiation.invalid_input} when the text is blank or the extracted content contradicts the phase, or
+     *     {@code negotiation.invalid_input} when the text is blank or the extracted content contradicts the phase,
+     *     {@code template.render_failed} when rendering the template fails, or
      *     {@code input.text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateProposeFromText(
@@ -240,8 +241,8 @@ public final class NegotiationGenerationOrchestrator {
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the extraction step fails after exhausting
      *     its retries, {@code negotiation.field_missing} when the extracted content misses a required field, or
      *     {@code negotiation.invalid_input} when the text is blank, {@code negotiation.conclusion_mismatch} when the
-     *     extracted conclusion is not {@code Accept}, or {@code input.text_too_long} when the text exceeds the
-     *     configured maximum length
+     *     extracted conclusion is not {@code Accept}, {@code template.render_failed} when rendering the template
+     *     fails, or {@code input.text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateAcceptFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -270,8 +271,8 @@ public final class NegotiationGenerationOrchestrator {
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the extraction step fails after exhausting
      *     its retries, {@code negotiation.field_missing} when the extracted content misses a required field, or
      *     {@code negotiation.invalid_input} when the text is blank, {@code negotiation.conclusion_mismatch} when the
-     *     extracted conclusion is not {@code Reject}, or {@code input.text_too_long} when the text exceeds the
-     *     configured maximum length
+     *     extracted conclusion is not {@code Reject}, {@code template.render_failed} when rendering the template
+     *     fails, or {@code input.text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateRejectFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {
@@ -299,8 +300,8 @@ public final class NegotiationGenerationOrchestrator {
      *     resource exists for the URI and language, {@code negotiation.content_extract_failed} or
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the extraction step fails after exhausting
      *     its retries, {@code negotiation.field_missing} when the extracted content misses the termination reason, or
-     *     {@code negotiation.invalid_input} when the text is blank, or {@code input.text_too_long} when the text
-     *     exceeds the configured maximum length
+     *     {@code negotiation.invalid_input} when the text is blank, {@code template.render_failed} when rendering the
+     *     template fails, or {@code input.text_too_long} when the text exceeds the configured maximum length
      */
     public MetadataContent generateAbortFromText(
             String text, @NonNull NegotiationContext context, @NonNull TemplateUri templateUri) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/authz_policy/AuthzPromptValidator.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/authz_policy/AuthzPromptValidator.java
@@ -2,7 +2,6 @@ package net.openan.a2at.sample.authz_policy;
 
 import java.util.Map;
 import net.openan.a2at.sdk.core.model.FilledParamData;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
 /**
  * Functional interface for validating an authorization prompt and extracting filled slot data.
@@ -12,5 +11,5 @@ import net.openan.a2at.sdk.core.model.TemplateUri;
 @FunctionalInterface
 public interface AuthzPromptValidator {
 
-    FilledParamData validate(String prompt, Map<String, Object> schema, TemplateUri templateUri);
+    FilledParamData validate(String prompt, Map<String, Object> schema, String templateUri);
 }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/authz_policy/AuthzSampleMain.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/authz_policy/AuthzSampleMain.java
@@ -100,7 +100,7 @@ public final class AuthzSampleMain {
         Map<String, Object> paramSchema = loadParamSchema();
 
         List<AuthzScenario> scenarios = AuthzScenarioLoader.load(SCENARIOS_RESOURCE);
-        TemplateUri templateUri = StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT;
+        String templateUri = StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI;
 
         AuthzPromptGenerator generator = buildGenerator(envPath, templateUri, capture);
         AuthzPromptValidator validator = buildValidator(envPath, capture);
@@ -194,7 +194,7 @@ public final class AuthzSampleMain {
         }
     }
 
-    static AuthzPromptGenerator buildGenerator(Path envPath, TemplateUri templateUri, AuthzReasoningCapture capture) {
+    static AuthzPromptGenerator buildGenerator(Path envPath, String templateUri, AuthzReasoningCapture capture) {
         if (capture == null) {
             A2ATClient client = new A2ATClient(envPath);
             return scenario -> {
@@ -219,16 +219,17 @@ public final class AuthzSampleMain {
                 .config(config)
                 .llmClient(decorated);
         ClientPromptGenerationOrchestrator orchestrator = builder.buildPromptGenerationOrchestrator();
+        TemplateUri parsedTemplateUri = parseTemplateUri(templateUri);
         return scenario -> {
             if (AuthzScenario.FROM_TEXT.equals(scenario.entry())) {
                 String text = (String) scenario.input().get("text");
-                return orchestrator.generateAuthPromptFromText(text, templateUri);
+                return orchestrator.generateAuthPromptFromText(text, parsedTemplateUri);
             }
             @SuppressWarnings("unchecked")
             Map<String, Object> data = (Map<String, Object>) scenario.input().get("data");
             @SuppressWarnings("unchecked")
             Map<String, Object> schema = (Map<String, Object>) scenario.input().get("schema");
-            return orchestrator.generateAuthPromptFromDataWithSchema(data, schema, templateUri);
+            return orchestrator.generateAuthPromptFromDataWithSchema(data, schema, parsedTemplateUri);
         };
     }
 
@@ -245,7 +246,13 @@ public final class AuthzSampleMain {
                 .config(config)
                 .llmClient(decorated);
         ContentValidator contentValidator = builder.buildAuthContentValidator();
-        return contentValidator::validate;
+        return (prompt, schema, templateUri) -> contentValidator.validate(prompt, schema, parseTemplateUri(templateUri));
+    }
+
+    /** Parses a template URI string for the typed orchestrator/content-validator seams. */
+    private static TemplateUri parseTemplateUri(String templateUri) {
+        return TemplateUri.parse(templateUri)
+                .orElseThrow(() -> new IllegalArgumentException("Unparseable template URI: " + templateUri));
     }
 
     static void printScenarioReport(AuthzScenario scenario, ScenarioOutcome outcome) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/authz_policy/AuthzScenarioExecutor.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/authz_policy/AuthzScenarioExecutor.java
@@ -14,7 +14,6 @@ import net.openan.a2at.sample.authz_policy.AuthzScenarioRunner.ScenarioResult;
 import net.openan.a2at.sdk.core.exception.A2ATError;
 import net.openan.a2at.sdk.core.exception.ErrorCatalog;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
 /**
  * Concurrent scenario executor that runs multiple {@link AuthzScenario} instances in parallel using a fixed thread
@@ -73,7 +72,7 @@ public final class AuthzScenarioExecutor {
     public List<ScenarioOutcome> executeAll(
             List<AuthzScenario> scenarios,
             Map<String, Object> paramSchema,
-            TemplateUri templateUri,
+            String templateUri,
             int workers,
             ProgressListener onCompleted) {
         return executeAll(scenarios, paramSchema, templateUri, workers, onCompleted, null);
@@ -97,7 +96,7 @@ public final class AuthzScenarioExecutor {
     public List<ScenarioOutcome> executeAll(
             List<AuthzScenario> scenarios,
             Map<String, Object> paramSchema,
-            TemplateUri templateUri,
+            String templateUri,
             int workers,
             ProgressListener onCompleted,
             AuthzReasoningCapture capture) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/authz_policy/AuthzScenarioRunner.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/authz_policy/AuthzScenarioRunner.java
@@ -13,7 +13,6 @@ import net.openan.a2at.sdk.core.exception.PromptGenerationException;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 
 /**
@@ -41,7 +40,7 @@ public final class AuthzScenarioRunner {
         this.validator = validator;
     }
 
-    public ScenarioOutcome run(AuthzScenario scenario, Map<String, Object> paramSchema, TemplateUri templateUri) {
+    public ScenarioOutcome run(AuthzScenario scenario, Map<String, Object> paramSchema, String templateUri) {
         MetadataContent metadata;
         try {
             metadata = generator.generate(scenario);

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/client/NegotiationClient.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/client/NegotiationClient.java
@@ -146,7 +146,7 @@ public final class NegotiationClient {
         Map<String, Object> mergedMetadata = new LinkedHashMap<>();
         mergedMetadata.put(DemoConstants.TASK_T_URI, taskFilled.promptText());
         mergedMetadata.put(DemoConstants.NEGOTIATION_T_URI, acceptPrompt.promptText());
-        mergedMetadata.put(DemoConstants.TEMPLATE_URI_KEY, DemoConstants.TASK_TEMPLATE.uri());
+        mergedMetadata.put(DemoConstants.TEMPLATE_URI_KEY, DemoConstants.TASK_TEMPLATE);
         mergedMetadata.put(DemoConstants.NEGOTIATION_CONTEXT_KEY, NegotiationMessage.toJson(negotiationContext));
 
         EventKind reply2 = sendRaw(agentCard, mergedMetadata, taskFilled.promptText(), negotiationContext);
@@ -166,8 +166,8 @@ public final class NegotiationClient {
     /** Sends one extension's prompt as an A2A message and returns the raw reply event. */
     private EventKind send(
             AgentCard agentCard, String extensionUri, MetadataContent content, Map<String, Object> contextMap) {
-        Map<String, Object> metadata = NegotiationMessage.buildMetadata(
-                extensionUri, content.promptText(), parseTemplateUri(content.templateUri()), contextMap);
+        Map<String, Object> metadata =
+                NegotiationMessage.buildMetadata(extensionUri, content.promptText(), content.templateUri(), contextMap);
         return sendRaw(agentCard, metadata, content.promptText(), contextMap);
     }
 
@@ -287,12 +287,6 @@ public final class NegotiationClient {
             }
             throw new IllegalStateException("a2a-java reply carried neither a task nor an agent message");
         }
-    }
-
-    /** Parses a rendered template URI string back into a {@code TemplateUri} for metadata building. */
-    private static net.openan.a2at.sdk.core.model.TemplateUri parseTemplateUri(String templateUri) {
-        return net.openan.a2at.sdk.core.model.TemplateUri.parse(templateUri)
-                .orElseThrow(() -> new IllegalArgumentException("Unparseable template URI: " + templateUri));
     }
 
     private static Message extractReplyMessage(EventKind reply) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationEvalApp.java
@@ -24,7 +24,6 @@ import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.core.model.NegotiationPerformative;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.negotiation.content.InformationEndingContent;
 import net.openan.a2at.sdk.negotiation.content.InformationProposeContent;
@@ -193,7 +192,7 @@ public final class NegotiationEvalApp {
         String inputText = String.valueOf(testCase.get("input_text"));
         Map<String, Object> inputData = asMap(testCase.get("input_data"));
 
-        TemplateUri taskTemplate = parseTemplate(String.valueOf(suite.get("template_uri")));
+        String taskTemplate = String.valueOf(suite.get("template_uri"));
         Map<String, Object> taskSchema = asMap(suite.get("task_schema"));
         Map<String, String> phrasing = stringMap(suite.get("negotiation_phrasing"));
         Map<String, Object> properties = asMap(taskSchema.get("properties"));
@@ -238,7 +237,7 @@ public final class NegotiationEvalApp {
             taskGenerationInput.put("data", inputData);
             taskGenerationInput.put("schema", taskSchema);
         }
-        taskGenerationInput.put("template_uri", taskTemplate.uri());
+        taskGenerationInput.put("template_uri", taskTemplate);
         String taskGenerationApi =
                 fromText ? "A2ATClient.generateTaskPromptFromText" : "A2ATClient.generateTaskPromptFromDataWithSchema";
         String taskPrompt;
@@ -286,7 +285,7 @@ public final class NegotiationEvalApp {
         Map<String, Object> taskValidationInput = Map.of(
                 "prompt", taskPrompt,
                 "schema", taskSchema,
-                "template_uri", taskTemplate.uri());
+                "template_uri", taskTemplate);
         Set<String> actualMissing;
         Map<String, Object> extractedRound1 = new LinkedHashMap<>();
         try {
@@ -359,7 +358,7 @@ public final class NegotiationEvalApp {
             }
             proposeGenerationInput.put("data", proposeData);
         }
-        proposeGenerationInput.put("template_uri", DemoTemplates.NEGOTIATION_PROPOSE.uri());
+        proposeGenerationInput.put("template_uri", DemoTemplates.NEGOTIATION_PROPOSE);
         String proposeGenerationApi = negotiationFromText
                 ? "A2ATServer.generateNegotiationProposePromptFromText"
                 : "A2ATServer.generateNegotiationProposePromptFromData";
@@ -412,7 +411,7 @@ public final class NegotiationEvalApp {
                 "prompt", proposePrompt,
                 "context", contextJson(proposeContext),
                 "schema", negotiationSchema(actualMissing, taskSchema),
-                "template_uri", DemoTemplates.NEGOTIATION_PROPOSE.uri());
+                "template_uri", DemoTemplates.NEGOTIATION_PROPOSE);
         Boolean proposeValid = null;
         try {
             long nanos = System.nanoTime();
@@ -482,7 +481,7 @@ public final class NegotiationEvalApp {
                                     "prompt", proposePrompt,
                                     "context", contextJson(proposeContext),
                                     "schema", negotiationSchema(actualMissing, taskSchema),
-                                    "template_uri", DemoTemplates.NEGOTIATION_PROPOSE.uri())));
+                                    "template_uri", DemoTemplates.NEGOTIATION_PROPOSE)));
             step.put("client_requested_slots", new ArrayList<>(clientRequestedSlots));
             steps.add(step);
             emit("[eval]   [5] client extracted requested slots: " + clientRequestedSlots + " (" + secs(nanos) + "s)");
@@ -505,7 +504,7 @@ public final class NegotiationEvalApp {
                                     "prompt", proposePrompt,
                                     "context", contextJson(proposeContext),
                                     "schema", negotiationSchema(actualMissing, taskSchema),
-                                    "template_uri", DemoTemplates.NEGOTIATION_PROPOSE.uri())));
+                                    "template_uri", DemoTemplates.NEGOTIATION_PROPOSE)));
             step.put("client_requested_slots", List.of());
             steps.add(step);
             emit("[eval]   [5] client propose validation REJECTED: " + error.getCode() + " " + error.getMessage()
@@ -531,7 +530,7 @@ public final class NegotiationEvalApp {
         Map<String, Object> filledGenerationInput = Map.of(
                 "data", filledData,
                 "schema", taskSchema,
-                "template_uri", taskTemplate.uri());
+                "template_uri", taskTemplate);
         try {
             A2ATClient client = new A2ATClient(envPath);
             filledPrompt = client.generateTaskPromptFromDataWithSchema(filledData, taskSchema, taskTemplate)
@@ -578,7 +577,7 @@ public final class NegotiationEvalApp {
                             "conclusion", NegotiationConclusion.ACCEPT.toString(),
                             "items", itemsJson(filledItems(fills))));
         }
-        acceptGenerationInput.put("template_uri", DemoTemplates.NEGOTIATION_ACCEPT.uri());
+        acceptGenerationInput.put("template_uri", DemoTemplates.NEGOTIATION_ACCEPT);
         String acceptGenerationApi = negotiationFromText
                 ? "A2ATClient.generateNegotiationAcceptPromptFromText"
                 : "A2ATClient.generateNegotiationAcceptPromptFromData";
@@ -635,7 +634,7 @@ public final class NegotiationEvalApp {
                 "prompt", acceptPrompt,
                 "context", contextJson(acceptContext),
                 "schema", negotiationSchema(slotsToFill, taskSchema),
-                "template_uri", DemoTemplates.NEGOTIATION_ACCEPT.uri());
+                "template_uri", DemoTemplates.NEGOTIATION_ACCEPT);
         Boolean acceptValid = null;
         Boolean fillValueMatch = null;
         Map<String, Object> extractedAcceptParams = null;
@@ -680,7 +679,7 @@ public final class NegotiationEvalApp {
         Map<String, Object> secondValidationInput = Map.of(
                 "prompt", filledPrompt,
                 "schema", taskSchema,
-                "template_uri", taskTemplate.uri());
+                "template_uri", taskTemplate);
         Boolean fillCompleted = null;
         try {
             long nanos = System.nanoTime();
@@ -1288,19 +1287,12 @@ public final class NegotiationEvalApp {
                 .count();
     }
 
-    private static TemplateUri parseTemplate(String templateUri) {
-        return TemplateUri.parse(templateUri)
-                .orElseThrow(() -> new IllegalArgumentException("Unparseable template URI: " + templateUri));
-    }
-
     /** Negotiation template URIs used by the closed loop; kept local so the evaluator stays self-contained. */
     private static final class DemoTemplates {
 
-        static final TemplateUri NEGOTIATION_PROPOSE =
-                parseTemplate("Negotiation-T/information-negotiation/propose/v1");
+        static final String NEGOTIATION_PROPOSE = "Negotiation-T/information-negotiation/propose/v1";
 
-        static final TemplateUri NEGOTIATION_ACCEPT =
-                parseTemplate("Negotiation-T/information-negotiation/accept-reject/v1");
+        static final String NEGOTIATION_ACCEPT = "Negotiation-T/information-negotiation/accept-reject/v1";
 
         private DemoTemplates() {}
     }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationFromDataApiEvalApp.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/eval/NegotiationFromDataApiEvalApp.java
@@ -26,7 +26,6 @@ import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.core.model.NegotiationPerformative;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.InformationEndingContent;
 import net.openan.a2at.sdk.negotiation.content.InformationProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationConclusion;
@@ -137,7 +136,7 @@ public final class NegotiationFromDataApiEvalApp {
         String relationship = input.containsKey("relationship")
                 ? String.valueOf(input.get("relationship"))
                 : null;
-        TemplateUri template = resolveTemplate(api, input);
+        String template = resolveTemplate(api, input);
 
         NegotiationPerformative performative = "propose".equals(api)
                 ? NegotiationPerformative.PROPOSE
@@ -168,7 +167,7 @@ public final class NegotiationFromDataApiEvalApp {
         if (input.containsKey("relationship")) {
             generateInput.put("relationship", relationship);
         }
-        generateInput.put("template_uri", template.uri());
+        generateInput.put("template_uri", template);
 
         Map<String, Object> record = new LinkedHashMap<>();
         record.put("case", caseId);
@@ -253,7 +252,7 @@ public final class NegotiationFromDataApiEvalApp {
             validateInput.put("prompt", prompt);
             validateInput.put("context", contextJson(context));
             validateInput.put("schema", extractionSchema);
-            validateInput.put("template_uri", template.uri());
+            validateInput.put("template_uri", template);
             Map<String, Object> validateStep = step("2. validate + extract " + api + " (fromData)", validateRole);
             api(validateStep, apiCall(validateMethod, validateInput));
             try {
@@ -377,13 +376,13 @@ public final class NegotiationFromDataApiEvalApp {
         return failure;
     }
 
-    private static TemplateUri resolveTemplate(String api, Map<String, Object> input) {
+    private static String resolveTemplate(String api, Map<String, Object> input) {
         if (input.containsKey("template")) {
-            return parseTemplate(String.valueOf(input.get("template")));
+            return String.valueOf(input.get("template"));
         }
         return "propose".equals(api)
-                ? StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE
-                : StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT;
+                ? StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI
+                : StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI;
     }
 
     private static void check(List<Map<String, Object>> checks, String name, boolean pass) {
@@ -439,11 +438,6 @@ public final class NegotiationFromDataApiEvalApp {
         } catch (IOException exception) {
             throw new UncheckedIOException("Failed to load the eval suite: " + SUITE_RESOURCE, exception);
         }
-    }
-
-    private static TemplateUri parseTemplate(String templateUri) {
-        return TemplateUri.parse(templateUri)
-                .orElseThrow(() -> new IllegalArgumentException("Unparseable template URI: " + templateUri));
     }
 
     private static Map<String, Object> step(String name, String role) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/server/NegotiationAgentExecutor.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/server/NegotiationAgentExecutor.java
@@ -162,7 +162,7 @@ public final class NegotiationAgentExecutor implements AgentExecutor {
                 List.<org.a2aproject.sdk.spec.Part<?>>of(new DataPart(Map.of(DemoConstants.TASK_T_URI, diagnosis))),
                 "faultManagement.Diagnosis",
                 "SPN private-line diagnosis result",
-                Map.of(DemoConstants.TEMPLATE_URI_KEY, DemoConstants.TASK_TEMPLATE.uri()),
+                Map.of(DemoConstants.TEMPLATE_URI_KEY, DemoConstants.TASK_TEMPLATE),
                 false,
                 true);
         emit("[server] diagnosis artifact emitted");
@@ -258,16 +258,10 @@ public final class NegotiationAgentExecutor implements AgentExecutor {
         return value == null || (value instanceof String s && s.isBlank());
     }
 
-    /** Parses a rendered template URI string back into a {@code TemplateUri} for metadata building. */
-    private static net.openan.a2at.sdk.core.model.TemplateUri parseTemplateUri(String templateUri) {
-        return net.openan.a2at.sdk.core.model.TemplateUri.parse(templateUri)
-                .orElseThrow(() -> new IllegalArgumentException("Unparseable template URI: " + templateUri));
-    }
-
     private static Message buildReplyMessage(
             RequestContext ctx, MetadataContent content, Map<String, Object> contextMap, String extensionUri) {
-        Map<String, Object> replyMetadata = NegotiationMessage.buildMetadata(
-                extensionUri, content.promptText(), parseTemplateUri(content.templateUri()), contextMap);
+        Map<String, Object> replyMetadata =
+                NegotiationMessage.buildMetadata(extensionUri, content.promptText(), content.templateUri(), contextMap);
         return Message.builder()
                 .messageId(UUID.randomUUID().toString())
                 .contextId(ctx.getContextId())

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/DemoConstants.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/DemoConstants.java
@@ -1,7 +1,6 @@
 package net.openan.a2at.sample.negotiation.shared;
 
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
 /**
  * Extension URIs and metadata keys used by the negotiation end-to-end demo.
@@ -24,13 +23,13 @@ public final class DemoConstants {
             "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Negotiation-T/NL/v1";
 
     /** Task-T template URI for the SPN private-line-complaint diagnosis scenario. */
-    public static final TemplateUri TASK_TEMPLATE = StandardTemplates.PRIVATE_LINE_COMPLAINT;
+    public static final String TASK_TEMPLATE = StandardTemplates.PRIVATE_LINE_COMPLAINT_URI;
 
     /** Negotiation-T information propose template (request missing information). */
-    public static final TemplateUri NEGOTIATION_PROPOSE = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
+    public static final String NEGOTIATION_PROPOSE = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI;
 
     /** Negotiation-T information accept-reject template (accept after params filled). */
-    public static final TemplateUri NEGOTIATION_ACCEPT = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT;
+    public static final String NEGOTIATION_ACCEPT = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI;
 
     /** Metadata key carrying the JSON-serialised negotiation context map. */
     public static final String NEGOTIATION_CONTEXT_KEY = "negotiation_context";

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/FromDataStrategy.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/FromDataStrategy.java
@@ -3,7 +3,6 @@ package net.openan.a2at.sample.negotiation.shared;
 import java.util.List;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.negotiation.content.InformationEndingContent;
 import net.openan.a2at.sdk.negotiation.content.InformationProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationConclusion;
@@ -29,7 +28,7 @@ public final class FromDataStrategy implements NegotiationStrategy {
             NegotiationContext ctx,
             List<NegotiationItem> missingItems,
             String relationship,
-            TemplateUri templateUri) {
+            String templateUri) {
         return server.generateNegotiationProposePromptFromData(
                 new NegotiationProposeData(ctx, new InformationProposeContent(missingItems, relationship)),
                 templateUri);
@@ -37,7 +36,7 @@ public final class FromDataStrategy implements NegotiationStrategy {
 
     @Override
     public MetadataContent generateAccept(
-            A2ATClient facade, NegotiationContext ctx, List<NegotiationItem> filledItems, TemplateUri templateUri) {
+            A2ATClient facade, NegotiationContext ctx, List<NegotiationItem> filledItems, String templateUri) {
         return facade.generateNegotiationAcceptPromptFromData(
                 new NegotiationEndingData(ctx, new InformationEndingContent(NegotiationConclusion.ACCEPT, filledItems)),
                 templateUri);
@@ -45,7 +44,7 @@ public final class FromDataStrategy implements NegotiationStrategy {
 
     @Override
     public MetadataContent generateAcceptServer(
-            A2ATServer server, NegotiationContext ctx, List<NegotiationItem> filledItems, TemplateUri templateUri) {
+            A2ATServer server, NegotiationContext ctx, List<NegotiationItem> filledItems, String templateUri) {
         return server.generateNegotiationAcceptPromptFromData(
                 new NegotiationEndingData(ctx, new InformationEndingContent(NegotiationConclusion.ACCEPT, filledItems)),
                 templateUri);

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/FromTextStrategy.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/FromTextStrategy.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.server.A2ATServer;
@@ -27,21 +26,21 @@ public final class FromTextStrategy implements NegotiationStrategy {
             NegotiationContext ctx,
             List<NegotiationItem> missingItems,
             String relationship,
-            TemplateUri templateUri) {
+            String templateUri) {
         String text = itemsToProposeText(missingItems, relationship);
         return server.generateNegotiationProposePromptFromText(text, ctx, templateUri);
     }
 
     @Override
     public MetadataContent generateAccept(
-            A2ATClient facade, NegotiationContext ctx, List<NegotiationItem> filledItems, TemplateUri templateUri) {
+            A2ATClient facade, NegotiationContext ctx, List<NegotiationItem> filledItems, String templateUri) {
         String text = itemsToAcceptText(filledItems);
         return facade.generateNegotiationAcceptPromptFromText(text, ctx, templateUri);
     }
 
     @Override
     public MetadataContent generateAcceptServer(
-            A2ATServer server, NegotiationContext ctx, List<NegotiationItem> filledItems, TemplateUri templateUri) {
+            A2ATServer server, NegotiationContext ctx, List<NegotiationItem> filledItems, String templateUri) {
         String text = itemsToAcceptText(filledItems);
         return server.generateNegotiationAcceptPromptFromText(text, ctx, templateUri);
     }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/NegotiationMessage.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/NegotiationMessage.java
@@ -32,13 +32,10 @@ public final class NegotiationMessage {
      * @return A2A metadata map
      */
     public static Map<String, Object> buildMetadata(
-            String extensionUri,
-            String promptText,
-            net.openan.a2at.sdk.core.model.TemplateUri templateUri,
-            Map<String, Object> contextMap) {
+            String extensionUri, String promptText, String templateUri, Map<String, Object> contextMap) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(extensionUri, promptText);
-        metadata.put(DemoConstants.TEMPLATE_URI_KEY, templateUri.uri());
+        metadata.put(DemoConstants.TEMPLATE_URI_KEY, templateUri);
         if (contextMap != null && !contextMap.isEmpty()) {
             metadata.put(DemoConstants.NEGOTIATION_CONTEXT_KEY, toJson(contextMap));
         }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/NegotiationStrategy.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/negotiation/shared/NegotiationStrategy.java
@@ -3,7 +3,6 @@ package net.openan.a2at.sample.negotiation.shared;
 import java.util.List;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.server.A2ATServer;
@@ -36,7 +35,7 @@ public interface NegotiationStrategy {
             NegotiationContext ctx,
             List<NegotiationItem> missingItems,
             String relationship,
-            TemplateUri templateUri);
+            String templateUri);
 
     /**
      * Generates an accept-phase negotiation message from the filled information items (client facade).
@@ -48,7 +47,7 @@ public interface NegotiationStrategy {
      * @return generated metadata content
      */
     MetadataContent generateAccept(
-            A2ATClient facade, NegotiationContext ctx, List<NegotiationItem> filledItems, TemplateUri templateUri);
+            A2ATClient facade, NegotiationContext ctx, List<NegotiationItem> filledItems, String templateUri);
 
     /**
      * Generates an accept-phase negotiation message from the filled information items (server facade).
@@ -60,5 +59,5 @@ public interface NegotiationStrategy {
      * @return generated metadata content
      */
     MetadataContent generateAcceptServer(
-            A2ATServer server, NegotiationContext ctx, List<NegotiationItem> filledItems, TemplateUri templateUri);
+            A2ATServer server, NegotiationContext ctx, List<NegotiationItem> filledItems, String templateUri);
 }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationAbnormalEvaluationMain.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationAbnormalEvaluationMain.java
@@ -160,7 +160,7 @@ public final class NegotiationAbnormalEvaluationMain {
         long startedAt = System.nanoTime();
         NegotiationPerformative performative = NegotiationPerformative.valueOf(testCase.performative());
         NegotiationContext context = contextFor(testCase.contextMode(), performative);
-        TemplateUri templateUri = templateFor(testCase.template());
+        String templateUri = templateFor(testCase.template());
         Map<String, Object> request = new LinkedHashMap<>();
         if (testCase.api().startsWith("generate_")) {
             request.put("text", testCase.input());
@@ -168,7 +168,7 @@ public final class NegotiationAbnormalEvaluationMain {
             request.put("prompt", testCase.input());
             request.put("schema", schemaFor(testCase.api(), testCase.schemaMode()));
         }
-        request.put("template_uri", templateUri == null ? null : templateUri.uri());
+        request.put("template_uri", templateUri);
         request.put("context", context == null ? null : contextPayload(context));
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("id", testCase.id());
@@ -281,7 +281,7 @@ public final class NegotiationAbnormalEvaluationMain {
                 ? NegotiationPerformative.ACCEPT
                 : testCase.api().contains("reject") ? NegotiationPerformative.REJECT : NegotiationPerformative.PROPOSE;
         NegotiationContext context = new NegotiationContext(UUID.randomUUID().toString(), 1, 3, performative);
-        TemplateUri template = testCase.api().contains("propose")
+        String template = testCase.api().contains("propose")
                 ? NegotiationSampleFlow.PROPOSE_TEMPLATE_URI
                 : NegotiationSampleFlow.ENDING_TEMPLATE_URI;
         ScriptedLlmClient llm = new ScriptedLlmClient(testCase.payload());
@@ -301,7 +301,7 @@ public final class NegotiationAbnormalEvaluationMain {
             request.put("schema", schemaFor(testCase.api(), null));
         }
         request.put("context", contextPayload(context));
-        request.put("template_uri", template.uri());
+        request.put("template_uri", template);
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("id", testCase.id());
         result.put("api", scriptedApiMethod(testCase.api()));
@@ -309,7 +309,7 @@ public final class NegotiationAbnormalEvaluationMain {
         result.put("expected_exception", testCase.expectedException());
         result.put("expected_code", testCase.expectedCode());
         try {
-            Object response = invoke(orchestrator, testCase, context, template);
+            Object response = invoke(orchestrator, testCase, context, parseTemplateUri(template));
             result.put("response", responseSummary(response));
             result.put("outcome", "unexpected_success");
             result.put("passed", false);
@@ -352,7 +352,7 @@ public final class NegotiationAbnormalEvaluationMain {
             A2ATServer server,
             NegotiationAbnormalEvaluationCase testCase,
             NegotiationContext context,
-            TemplateUri templateUri) {
+            String templateUri) {
         return switch (testCase.api()) {
             case "generate_propose" -> client.generateNegotiationProposePromptFromText(
                     testCase.input(), context, templateUri);
@@ -395,17 +395,21 @@ public final class NegotiationAbnormalEvaluationMain {
         return new NegotiationContext(UUID.randomUUID().toString(), 1, 3, performative);
     }
 
-    private static TemplateUri templateFor(String template) {
+    private static String templateFor(String template) {
         return switch (template == null ? "null" : template.toLowerCase(java.util.Locale.ROOT)) {
             case "null" -> null;
             case "propose" -> NegotiationSampleFlow.PROPOSE_TEMPLATE_URI;
             case "ending" -> NegotiationSampleFlow.ENDING_TEMPLATE_URI;
-            case "unknown_propose" -> TemplateUri.of(
-                    "Negotiation-T", List.of("information-negotiation", "propose"), "v999");
-            case "unknown_ending" -> TemplateUri.of(
-                    "Negotiation-T", List.of("information-negotiation", "accept-reject"), "v999");
+            case "unknown_propose" -> "Negotiation-T/information-negotiation/propose/v999";
+            case "unknown_ending" -> "Negotiation-T/information-negotiation/accept-reject/v999";
             default -> throw new IllegalArgumentException("Unknown abnormal evaluation template: " + template);
         };
+    }
+
+    /** Parses a template URI string for the typed {@code NegotiationGenerationOrchestrator} seam. */
+    private static TemplateUri parseTemplateUri(String templateUri) {
+        return TemplateUri.parse(templateUri)
+                .orElseThrow(() -> new IllegalArgumentException("Unparseable template URI: " + templateUri));
     }
 
     private static String apiMethod(String api) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationBusinessAbnormalEvaluationMain.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationBusinessAbnormalEvaluationMain.java
@@ -168,8 +168,8 @@ public final class NegotiationBusinessAbnormalEvaluationMain {
         }
         request.put("context", contextPayload(context));
         request.put("template_uri", testCase.api().contains("propose")
-                ? NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri()
-                : NegotiationSampleFlow.ENDING_TEMPLATE_URI.uri());
+                ? NegotiationSampleFlow.PROPOSE_TEMPLATE_URI
+                : NegotiationSampleFlow.ENDING_TEMPLATE_URI);
         return request;
     }
 

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationQwenEvaluationMain.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/evaluation/NegotiationQwenEvaluationMain.java
@@ -208,8 +208,8 @@ public final class NegotiationQwenEvaluationMain {
         NegotiationEvaluationCase proposeCase = testCase.proposeCase();
         boolean fromData = "fromData".equals(channel);
         Map<String, Object> request = fromData
-                ? Map.of("data", proposeCase.data(), "template_uri", NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri())
-                : Map.of("text", proposeCase.text(), "template_uri", NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri());
+                ? Map.of("data", proposeCase.data(), "template_uri", NegotiationSampleFlow.PROPOSE_TEMPLATE_URI)
+                : Map.of("text", proposeCase.text(), "template_uri", NegotiationSampleFlow.PROPOSE_TEMPLATE_URI);
         try {
             MetadataContent content = fromData
                     ? server.generateNegotiationProposePromptFromData(
@@ -247,13 +247,13 @@ public final class NegotiationQwenEvaluationMain {
             writeStage(processLogger, apiTrace, stageEvent(runId, testCase, "validate_propose_and_fill", "propose", channel, null, Map.of(
                     "prompt", prompt,
                     "schema", schema,
-                    "template_uri", NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri()), Map.of("filled_data", filled.data()), startedAt, null));
+                    "template_uri", NegotiationSampleFlow.PROPOSE_TEMPLATE_URI), Map.of("filled_data", filled.data()), startedAt, null));
             return filled;
         } catch (RuntimeException exception) {
             writeStage(processLogger, apiTrace, stageEvent(runId, testCase, "validate_propose_and_fill", "propose", channel, null, Map.of(
                     "prompt", prompt,
                     "schema", schema,
-                    "template_uri", NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri()), null, startedAt, exception));
+                    "template_uri", NegotiationSampleFlow.PROPOSE_TEMPLATE_URI), null, startedAt, exception));
             throw exception;
         }
     }
@@ -283,9 +283,9 @@ public final class NegotiationQwenEvaluationMain {
                 ? Map.of("data", Map.of(
                         "items", itemsJson(endingItems),
                         "conclusion", accept ? NegotiationConclusion.ACCEPT.toString() : NegotiationConclusion.REJECT.toString()),
-                        "template_uri", NegotiationSampleFlow.ENDING_TEMPLATE_URI.uri())
+                        "template_uri", NegotiationSampleFlow.ENDING_TEMPLATE_URI)
                 : Map.of("text", endingInputText,
-                        "template_uri", NegotiationSampleFlow.ENDING_TEMPLATE_URI.uri());
+                        "template_uri", NegotiationSampleFlow.ENDING_TEMPLATE_URI);
         try {
             MetadataContent content = fromData
                     ? accept
@@ -334,13 +334,13 @@ public final class NegotiationQwenEvaluationMain {
                             prompt, context, schema, NegotiationSampleFlow.ENDING_TEMPLATE_URI);
             writeStage(processLogger, apiTrace, stageEvent(runId, testCase, "validate_" + testCase.decision() + "_and_fill",
                     testCase.decision(), channel, null, Map.of("prompt", prompt, "schema", schema,
-                            "template_uri", NegotiationSampleFlow.ENDING_TEMPLATE_URI.uri()),
+                            "template_uri", NegotiationSampleFlow.ENDING_TEMPLATE_URI),
                     Map.of("filled_data", filled.data()), startedAt, null));
             return filled;
         } catch (RuntimeException exception) {
             writeStage(processLogger, apiTrace, stageEvent(runId, testCase, "validate_" + testCase.decision() + "_and_fill",
                     testCase.decision(), channel, null, Map.of("prompt", prompt, "schema", schema,
-                            "template_uri", NegotiationSampleFlow.ENDING_TEMPLATE_URI.uri()), null, startedAt, exception));
+                            "template_uri", NegotiationSampleFlow.ENDING_TEMPLATE_URI), null, startedAt, exception));
             throw exception;
         }
     }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/shared/NegotiationMetadataReader.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/shared/NegotiationMetadataReader.java
@@ -5,7 +5,6 @@ import net.openan.a2at.sdk.core.model.ExtensionUriConstants;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.core.model.NegotiationPerformative;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
 /** Reads and validates Negotiation-T metadata received over A2A. */
 public final class NegotiationMetadataReader {
@@ -13,14 +12,14 @@ public final class NegotiationMetadataReader {
     private NegotiationMetadataReader() {
     }
 
-    public static String readPrompt(Map<String, ?> metadata, TemplateUri expectedTemplateUri) {
+    public static String readPrompt(Map<String, ?> metadata, String expectedTemplateUri) {
         if (metadata == null) {
             throw new IllegalArgumentException("Negotiation metadata is required");
         }
         String templateUri = stringValue(metadata.get(MetadataContent.TEMPLATE_URI_METADATA_KEY));
-        if (!expectedTemplateUri.uri().equals(templateUri)) {
+        if (!expectedTemplateUri.equals(templateUri)) {
             throw new IllegalArgumentException(
-                    "Unexpected negotiation template URI: expected=" + expectedTemplateUri.uri() + ", actual=" + templateUri);
+                    "Unexpected negotiation template URI: expected=" + expectedTemplateUri + ", actual=" + templateUri);
         }
         String prompt = stringValue(metadata.get(ExtensionUriConstants.NEGOTIATION_T_EXTENSION_URI));
         if (prompt.isBlank()) {

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/shared/NegotiationSampleFlow.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/private_line_complaint/negotiation/shared/NegotiationSampleFlow.java
@@ -6,7 +6,6 @@ import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.core.model.NegotiationPerformative;
 import net.openan.a2at.sdk.server.A2ATServer;
@@ -15,9 +14,9 @@ import net.openan.a2at.sample.negotiation.shared.InformationNegotiationSchemas;
 /** Runs the six Negotiation-T APIs used by the private-line complaint sample. */
 public final class NegotiationSampleFlow {
 
-    public static final TemplateUri PROPOSE_TEMPLATE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
+    public static final String PROPOSE_TEMPLATE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI;
 
-    public static final TemplateUri ENDING_TEMPLATE_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT;
+    public static final String ENDING_TEMPLATE_URI = StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI;
 
     private NegotiationSampleFlow() {
     }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/service_recovery/FromTextProbe.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/service_recovery/FromTextProbe.java
@@ -4,7 +4,6 @@ import java.nio.file.Path;
 import java.util.Map;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
 /**
  * One-shot diagnostic entry: runs {@code generateNotificationPromptFromText} alone with the
@@ -58,8 +57,7 @@ public final class FromTextProbe {
         System.out.println();
 
         A2ATClient client = new A2ATClient(envPath);
-        TemplateUri templateUri = TemplateUri.parse(ServiceRecoverySampleInputs.TEMPLATE_URI)
-                .orElseThrow(() -> new IllegalArgumentException("Malformed template URI"));
+        String templateUri = ServiceRecoverySampleInputs.TEMPLATE_URI;
 
         System.out.println("=== [probe] calling generateNotificationPromptFromText ===");
         long start = System.currentTimeMillis();

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/service_recovery/client/prompt/A2ATNotificationPromptClient.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/service_recovery/client/prompt/A2ATNotificationPromptClient.java
@@ -3,7 +3,6 @@ package net.openan.a2at.sample.service_recovery.client.prompt;
 import java.util.Map;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
 /**
  * {@link SamplePromptClient} adapter delegating to the real {@link A2ATClient} facade.
@@ -28,17 +27,12 @@ public final class A2ATNotificationPromptClient implements SamplePromptClient {
 
     @Override
     public MetadataContent generateNotificationPromptFromText(String text, String templateUri) {
-        return delegate.generateNotificationPromptFromText(text, parse(templateUri));
+        return delegate.generateNotificationPromptFromText(text, templateUri);
     }
 
     @Override
     public MetadataContent generateNotificationPromptFromDataWithSchema(
             Map<String, Object> data, Map<String, Object> schema, String templateUri) {
-        return delegate.generateNotificationPromptFromDataWithSchema(data, schema, parse(templateUri));
-    }
-
-    private static TemplateUri parse(String templateUri) {
-        return TemplateUri.parse(templateUri)
-                .orElseThrow(() -> new IllegalArgumentException("Malformed template URI: " + templateUri));
+        return delegate.generateNotificationPromptFromDataWithSchema(data, schema, templateUri);
     }
 }

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/service_recovery/server/runtime/DefaultSampleServerRuntime.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/service_recovery/server/runtime/DefaultSampleServerRuntime.java
@@ -20,7 +20,6 @@ import net.openan.a2at.sample.service_recovery.server.registry.ServerRegistryCli
 import net.openan.a2at.sample.service_recovery.shared.env.SampleEnvironmentPathResolver;
 import net.openan.a2at.sample.service_recovery.shared.error.ValueErrorException;
 import net.openan.a2at.sample.service_recovery.shared.registry.RegistryAgentCardMapper;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.server.A2ATServer;
 import org.a2aproject.sdk.server.agentexecution.AgentExecutor;
 import org.a2aproject.sdk.server.events.InMemoryQueueManager;
@@ -96,9 +95,7 @@ public final class DefaultSampleServerRuntime implements SampleServerRuntime, A2
     @Override
     public NotificationPromptValidator buildNotificationValidator(Path envPath) {
         A2ATServer server = new A2ATServer(envPath);
-        TemplateUri templateUri = TemplateUri.parse(ServiceRecoverySampleInputs.TEMPLATE_URI)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Malformed template URI: " + ServiceRecoverySampleInputs.TEMPLATE_URI));
+        String templateUri = ServiceRecoverySampleInputs.TEMPLATE_URI;
         return promptText -> server.validateNotificationPromptAndDataFilling(
                 promptText,
                 ServiceRecoverySampleInputs.validationParamSchema(),

--- a/a2a-t-sample/src/main/java/net/openan/a2at/sample/task_t/TaskTDemoMain.java
+++ b/a2a-t-sample/src/main/java/net/openan/a2at/sample/task_t/TaskTDemoMain.java
@@ -80,7 +80,7 @@ public final class TaskTDemoMain {
         Path envPath = resolveEnvPath(args);
         String caseSelection = resolveCaseSelection(args);
         println("Task-T 准确率验证样例，env: " + envPath.toAbsolutePath() + (Files.exists(envPath) ? "" : "  (不存在，请先配置)"));
-        println("模板: " + StandardTemplates.PRIVATE_LINE_COMPLAINT.uri());
+        println("模板: " + StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
         println("用例: " + caseLabel(caseSelection));
         println();
 
@@ -146,7 +146,7 @@ public final class TaskTDemoMain {
             println();
             try {
                 MetadataContent metadata =
-                        client.generateTaskPromptFromText(sample.text(), StandardTemplates.PRIVATE_LINE_COMPLAINT);
+                        client.generateTaskPromptFromText(sample.text(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
                 printGeneratedMetadata(metadata);
                 TaskTAccuracyEvaluator.SampleScore score = validateAndScore(server, sample, metadata, "用例一");
                 scores.add(score);
@@ -174,7 +174,7 @@ public final class TaskTDemoMain {
             println();
             try {
                 MetadataContent metadata = client.generateTaskPromptFromDataWithSchema(
-                        sample.data(), sample.semanticsSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT);
+                        sample.data(), sample.semanticsSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
                 printGeneratedMetadata(metadata);
                 TaskTAccuracyEvaluator.SampleScore score = validateAndScore(server, sample, metadata, "用例二");
                 scores.add(score);
@@ -217,14 +217,14 @@ public final class TaskTDemoMain {
                     println();
                     println("[生成] generateTaskPromptFromDataWithSchema:");
                     metadata = client.generateTaskPromptFromDataWithSchema(
-                            sample.data(), sample.semanticsSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT);
+                            sample.data(), sample.semanticsSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
                 } else {
                     println("[输入] 自然语言文本 (缺少关键槽位):");
                     println(sample.text());
                     println();
                     println("[生成] generateTaskPromptFromText:");
                     metadata =
-                            client.generateTaskPromptFromText(sample.text(), StandardTemplates.PRIVATE_LINE_COMPLAINT);
+                            client.generateTaskPromptFromText(sample.text(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
                 }
                 System.out.println("  templateUri : " + metadata.templateUri());
                 System.out.println("  promptText : " + metadata.promptText());
@@ -233,7 +233,7 @@ public final class TaskTDemoMain {
                 Map<String, Object> extracted = server.validateTaskPromptAndDataFilling(
                                 metadata.promptText(),
                                 sample.validationSchema(),
-                                StandardTemplates.PRIVATE_LINE_COMPLAINT)
+                                StandardTemplates.PRIVATE_LINE_COMPLAINT_URI)
                         .data();
                 unexpectedlyPassed++;
                 println("[意外通过] 应被拒绝却校验通过，提取参数:");
@@ -266,7 +266,7 @@ public final class TaskTDemoMain {
             A2ATServer server, TaskTSample sample, MetadataContent metadata, String caseLabel) {
         try {
             Map<String, Object> extracted = server.validateTaskPromptAndDataFilling(
-                            metadata.promptText(), sample.validationSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT)
+                            metadata.promptText(), sample.validationSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI)
                     .data();
             println("[服务端] " + caseLabel + " validateTaskPromptAndDataFilling 通过，提取参数:");
             println(pretty(extracted));

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/api/NegotiationFacadeOutputSymmetryTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/api/NegotiationFacadeOutputSymmetryTest.java
@@ -17,7 +17,6 @@ import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.core.model.NegotiationPerformative;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMClientConfig;
 import net.openan.a2at.sdk.llm.LLMClientFactory;
@@ -103,7 +102,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 assertNotNull(clientResult.promptText());
                 assertEquals(clientResult, serverResult, "case " + symmetryCase.label() + " [" + language + "]");
                 assertEquals(clientResult.buildMetadataContent(), serverResult.buildMetadataContent());
-                assertEquals(symmetryCase.templateUri().uri(), clientResult.templateUri());
+                assertEquals(symmetryCase.templateUri(), clientResult.templateUri());
                 assertEquals(
                         symmetryCase.performative(),
                         clientResult.negotiationContext().performative(),
@@ -158,7 +157,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "information_propose",
                         NegotiationPerformative.PROPOSE,
-                        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE,
+                        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI,
                         new NegotiationProposeData(
                                 new NegotiationContext(
                                         "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5, NegotiationPerformative.PROPOSE),
@@ -171,7 +170,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "target_propose",
                         NegotiationPerformative.PROPOSE,
-                        StandardTemplates.TARGET_NEGOTIATION_PROPOSE,
+                        StandardTemplates.TARGET_NEGOTIATION_PROPOSE_URI,
                         new NegotiationProposeData(
                                 new NegotiationContext(
                                         "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 1, 5, NegotiationPerformative.PROPOSE),
@@ -184,7 +183,7 @@ class NegotiationFacadeOutputSymmetryTest {
                 new SymmetryCase(
                         "feasibility_propose",
                         NegotiationPerformative.PROPOSE,
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE,
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE_URI,
                         new NegotiationProposeData(
                                 new NegotiationContext(
                                         "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", 2, 5, NegotiationPerformative.PROPOSE),
@@ -197,43 +196,43 @@ class NegotiationFacadeOutputSymmetryTest {
                 endingCase(
                         "information_accept",
                         NegotiationPerformative.ACCEPT,
-                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT,
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI,
                         new InformationEndingContent(
                                 NegotiationConclusion.ACCEPT,
                                 List.of(new NegotiationItem("area information", "Songshan Lake")))),
                 endingCase(
                         "target_accept",
                         NegotiationPerformative.ACCEPT,
-                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT,
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT_URI,
                         new TargetEndingContent(NegotiationConclusion.ACCEPT, "The confirmed intent.", null)),
                 endingCase(
                         "feasibility_accept",
                         NegotiationPerformative.ACCEPT,
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT,
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI,
                         new FeasibilityEndingContent(NegotiationConclusion.ACCEPT, "The target is achievable.")),
                 endingCase(
                         "information_reject",
                         NegotiationPerformative.REJECT,
-                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT,
+                        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI,
                         new InformationEndingContent(
                                 NegotiationConclusion.REJECT,
                                 List.of(new NegotiationItem("area information", "not available")))),
                 endingCase(
                         "target_reject",
                         NegotiationPerformative.REJECT,
-                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT,
+                        StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT_URI,
                         new TargetEndingContent(NegotiationConclusion.REJECT, null, "The intent is unclear.")),
                 endingCase(
                         "feasibility_reject",
                         NegotiationPerformative.REJECT,
-                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT,
+                        StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI,
                         new FeasibilityEndingContent(NegotiationConclusion.REJECT, "The target is not achievable.")));
     }
 
     private static SymmetryCase endingCase(
             String label,
             NegotiationPerformative performative,
-            TemplateUri templateUri,
+            String templateUri,
             NegotiationEndingContent content) {
         return new SymmetryCase(
                 label,
@@ -245,7 +244,7 @@ class NegotiationFacadeOutputSymmetryTest {
 
     /** One symmetry case: a fixed input addressed to one of the three from-data generation methods. */
     private record SymmetryCase(
-            String label, NegotiationPerformative performative, TemplateUri templateUri, Object data) {
+            String label, NegotiationPerformative performative, String templateUri, Object data) {
 
         MetadataContent generate(ProposeGenerator propose, EndingGenerator accept, EndingGenerator reject) {
             return switch (performative) {
@@ -260,13 +259,13 @@ class NegotiationFacadeOutputSymmetryTest {
     @FunctionalInterface
     private interface ProposeGenerator {
 
-        MetadataContent generate(NegotiationProposeData data, TemplateUri templateUri);
+        MetadataContent generate(NegotiationProposeData data, String templateUri);
     }
 
     @FunctionalInterface
     private interface EndingGenerator {
 
-        MetadataContent generate(NegotiationEndingData data, TemplateUri templateUri);
+        MetadataContent generate(NegotiationEndingData data, String templateUri);
     }
 
     public static final class RecordingClient implements LLMClient {

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/authz_policy/AuthzSampleMainConcurrencyTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/authz_policy/AuthzSampleMainConcurrencyTest.java
@@ -22,7 +22,6 @@ import net.openan.a2at.sample.authz_policy.AuthzScenarioRunner.ScenarioResult;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMResponse;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ class AuthzSampleMainConcurrencyTest {
     private static final String CONTENT_VALIDATION_SYSTEM =
             "/prompt_resources/prompts/content_validation/zh-CN/system.md";
 
-    private static final TemplateUri TEMPLATE_URI = StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT;
+    private static final String TEMPLATE_URI = StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI;
 
     private static final String ENV_CONTENT =
             "A2AT_LLM_PROVIDER=openai\nA2AT_LLM_MODEL=gpt-4\nA2AT_LLM_API_KEY=sk-test\n"

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/authz_policy/AuthzScenarioExecutorTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/authz_policy/AuthzScenarioExecutorTest.java
@@ -19,13 +19,12 @@ import net.openan.a2at.sample.authz_policy.AuthzScenarioRunner.ScenarioOutcome;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class AuthzScenarioExecutorTest {
 
-    private static final TemplateUri TEMPLATE_URI = StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT;
+    private static final String TEMPLATE_URI = StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI;
     private static final Map<String, Object> PARAM_SCHEMA = Map.of("properties", Map.of(), "required", Map.of());
     private static final AuthzExpected SUCCESS = new AuthzExpected(
             new ClientExpected(null, "generated prompt", null), new ServerExpected("success", null, null));
@@ -52,7 +51,7 @@ class AuthzScenarioExecutorTest {
             } else {
                 gate.countDown();
             }
-            return new MetadataContent(TEMPLATE_URI.uri(), scenario.label(), "Authorization-T/v1");
+            return new MetadataContent(TEMPLATE_URI, scenario.label(), "Authorization-T/v1");
         };
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
@@ -76,7 +75,7 @@ class AuthzScenarioExecutorTest {
                 case "boom-assert":
                     throw new AssertionError("assertion failure");
                 default:
-                    return new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                    return new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
             }
         };
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
@@ -102,7 +101,7 @@ class AuthzScenarioExecutorTest {
     @Test
     void should_deliverProgressCallbacks_WithDistinctCompletionIndices() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenarioExecutor executor = new AuthzScenarioExecutor(runner);
@@ -123,7 +122,7 @@ class AuthzScenarioExecutorTest {
     @Test
     void should_runAllScenariosSerially_WhenSingleWorker() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenarioExecutor executor = new AuthzScenarioExecutor(runner);
@@ -154,7 +153,7 @@ class AuthzScenarioExecutorTest {
     @Test
     void should_notThrow_WhenProgressListenerIsNull() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenarioExecutor executor = new AuthzScenarioExecutor(runner);

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/authz_policy/AuthzScenarioRunnerTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/authz_policy/AuthzScenarioRunnerTest.java
@@ -21,13 +21,12 @@ import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.SlotValidationError;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import org.junit.jupiter.api.Test;
 
 class AuthzScenarioRunnerTest {
 
-    private static final TemplateUri TEMPLATE_URI = StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT;
+    private static final String TEMPLATE_URI = StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI;
     private static final Map<String, Object> PARAM_SCHEMA = Map.of("properties", Map.of(), "required", Map.of());
     private static final AuthzExpected SUCCESS = new AuthzExpected(
             new ClientExpected(null, "generated prompt", null), new ServerExpected("success", null, null));
@@ -42,7 +41,7 @@ class AuthzScenarioRunnerTest {
         AtomicReference<String> calledEntry = new AtomicReference<>();
         AuthzPromptGenerator generator = scenario -> {
             calledEntry.set(scenario.entry());
-            return new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+            return new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         };
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
@@ -58,7 +57,7 @@ class AuthzScenarioRunnerTest {
         AtomicReference<String> calledEntry = new AtomicReference<>();
         AuthzPromptGenerator generator = scenario -> {
             calledEntry.set(scenario.entry());
-            return new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+            return new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         };
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
@@ -73,7 +72,7 @@ class AuthzScenarioRunnerTest {
     @Test
     void should_match_WhenExpectedSuccessAndValidationPasses() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of("k", "v"));
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), SUCCESS);
@@ -89,7 +88,7 @@ class AuthzScenarioRunnerTest {
     @Test
     void should_match_WhenExpectedSemanticRejectedAndSemanticRejected() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> {
             throw new ContentValidationException(
                     ErrorCatalog.NEGOTIATION_SEMANTIC_REJECTED.getCode(), "semantic rejected");
@@ -109,7 +108,7 @@ class AuthzScenarioRunnerTest {
     @Test
     void should_notMatch_WhenExpectedSuccessAndValidationRejected() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> {
             throw new ContentValidationException(
                     ErrorCatalog.NEGOTIATION_SEMANTIC_REJECTED.getCode(), "semantic rejected");
@@ -128,7 +127,7 @@ class AuthzScenarioRunnerTest {
     @Test
     void should_notMatch_WhenExpectedSemanticRejectedAndValidationPasses() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of("k", "v"));
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario =
@@ -145,7 +144,7 @@ class AuthzScenarioRunnerTest {
     @Test
     void should_match_WhenPromptTextDiffersFromExpectation() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "different prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "different prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), SUCCESS);
@@ -164,7 +163,7 @@ class AuthzScenarioRunnerTest {
                 new ClientExpected(null, "expected prompt", null),
                 new ServerExpected("success", null, Map.of("操作类型", "新增授权策略")));
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "drifted prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "drifted prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of("操作类型", "新增授权策略"));
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), expected);
@@ -181,7 +180,7 @@ class AuthzScenarioRunnerTest {
         AuthzExpected expected = new AuthzExpected(
                 new ClientExpected(null, "generated prompt  \n", null), new ServerExpected("success", null, null));
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "  generated prompt\n", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "  generated prompt\n", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), expected);
@@ -249,7 +248,7 @@ class AuthzScenarioRunnerTest {
     @Test
     void should_notMatch_WhenExpectedSuccessAndValidatorThrowsInfrastructureError() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> {
             throw new ContentValidationException(ErrorCatalog.LLM_INVOCATION_FAILED.getCode(), "infrastructure error");
         };
@@ -268,7 +267,7 @@ class AuthzScenarioRunnerTest {
     @Test
     void should_notMatch_WhenExpectedSuccessAndValidatorThrowsResourceNotFound() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> {
             throw new ContentValidationException(ErrorCatalog.TEMPLATE_NOT_FOUND.getCode(), "resource not found");
         };
@@ -287,7 +286,7 @@ class AuthzScenarioRunnerTest {
     @Test
     void should_notMatch_WhenExpectedSuccessAndValidatorThrowsUnknownCode() {
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> {
             throw new ContentValidationException("unknown_code", "unknown error");
         };
@@ -380,7 +379,7 @@ class AuthzScenarioRunnerTest {
                 new ClientExpected(null, "generated prompt", null),
                 new ServerExpected("success", null, Map.of("操作类型", "新增授权策略", "策略列表", List.of(Map.of("业务场景", "校园专网")))));
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         Map<String, Object> actualEntry = new java.util.LinkedHashMap<>();
         actualEntry.put("策略标识", null);
         actualEntry.put("业务场景", "校园专网");
@@ -402,7 +401,7 @@ class AuthzScenarioRunnerTest {
                 new ClientExpected(null, "generated prompt", null),
                 new ServerExpected("success", null, Map.of("策略列表", List.of(Map.of("业务场景", "校园专网")))));
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator =
                 (prompt, schema, templateUri) -> new FilledParamData(Map.of("策略列表", List.of(Map.of("业务场景", "医疗专线"))));
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
@@ -420,7 +419,7 @@ class AuthzScenarioRunnerTest {
                 new ClientExpected(null, "generated prompt", null),
                 new ServerExpected("success", null, Map.of("策略列表", List.of(Map.of("业务场景", "校园专网")))));
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) ->
                 new FilledParamData(Map.of("策略列表", List.of(Map.of("业务场景", "校园专网"), Map.of("业务场景", "医疗专线"))));
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
@@ -454,7 +453,7 @@ class AuthzScenarioRunnerTest {
     void should_warn_WhenMutationAndEmptyPolicyListSection() {
         String promptText = "## 授权策略的操作类型\n新增授权策略\n\n## 授权策略的操作描述\n描述\n\n## 动网操作的授权策略列表\n\n\n\n## 预期输出\n输出格式";
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), promptText, "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, promptText, "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), SUCCESS);
@@ -469,7 +468,7 @@ class AuthzScenarioRunnerTest {
     void should_warn_WhenModifyAndEmptyPolicyListSection() {
         String promptText = "## 授权策略的操作类型\n修改授权策略\n\n## 授权策略的操作描述\n描述\n\n## 动网操作的授权策略列表\n\n## 预期输出\n输出格式";
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), promptText, "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, promptText, "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), SUCCESS);
@@ -484,7 +483,7 @@ class AuthzScenarioRunnerTest {
     void should_notWarn_WhenQueryAndEmptyPolicyListSection() {
         String promptText = "## 授权策略的操作类型\n查询授权策略\n\n## 授权策略的操作描述\n描述\n\n## 动网操作的授权策略列表\n\n## 预期输出\n输出格式";
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), promptText, "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, promptText, "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), SUCCESS);
@@ -499,7 +498,7 @@ class AuthzScenarioRunnerTest {
     void should_notWarn_WhenMutationAndNonEmptyPolicyListSection() {
         String promptText = "## 授权策略的操作类型\n新增授权策略\n\n## 授权策略的操作描述\n描述\n\n## 动网操作的授权策略列表\n校园专网，紧急扩容\n\n## 预期输出\n输出格式";
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), promptText, "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, promptText, "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), SUCCESS);
@@ -514,7 +513,7 @@ class AuthzScenarioRunnerTest {
     void should_notWarn_WhenPromptTextHasUnknownSectionOrder() {
         String promptText = "## 授权策略的操作描述\n描述\n\n## 授权策略的操作类型\n新增授权策略\n\n## 预期输出\n输出格式\n\n## 动网操作的授权策略列表\n\n";
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), promptText, "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, promptText, "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), SUCCESS);
@@ -529,7 +528,7 @@ class AuthzScenarioRunnerTest {
     void should_notWarn_WhenNoOperationTypeSection() {
         String promptText = "## 授权策略的操作描述\n描述\n\n## 动网操作的授权策略列表\n\n## 预期输出\n输出格式";
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), promptText, "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, promptText, "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> new FilledParamData(Map.of());
         AuthzScenarioRunner runner = new AuthzScenarioRunner(generator, validator);
         AuthzScenario scenario = new AuthzScenario("test", "from_text", Map.of("text", "hello"), SUCCESS);
@@ -545,7 +544,7 @@ class AuthzScenarioRunnerTest {
         Map<String, Object> scenarioSchema = Map.of("处置规则", "应为短语");
         AtomicReference<Map<String, Object>> receivedSchema = new AtomicReference<>();
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> {
             receivedSchema.set(schema);
             return new FilledParamData(Map.of());
@@ -563,7 +562,7 @@ class AuthzScenarioRunnerTest {
     void should_useDefaultSchema_WhenValidateSchemaAbsent() {
         AtomicReference<Map<String, Object>> receivedSchema = new AtomicReference<>();
         AuthzPromptGenerator generator =
-                scenario -> new MetadataContent(TEMPLATE_URI.uri(), "generated prompt", "Authorization-T/v1");
+                scenario -> new MetadataContent(TEMPLATE_URI, "generated prompt", "Authorization-T/v1");
         AuthzPromptValidator validator = (prompt, schema, templateUri) -> {
             receivedSchema.set(schema);
             return new FilledParamData(Map.of());

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/private_line_complaint/negotiation/NegotiationMetadataReaderTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/private_line_complaint/negotiation/NegotiationMetadataReaderTest.java
@@ -20,7 +20,7 @@ class NegotiationMetadataReaderTest {
                 ExtensionUriConstants.NEGOTIATION_T_EXTENSION_URI,
                 "prompt",
                 MetadataContent.TEMPLATE_URI_METADATA_KEY,
-                NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri());
+                NegotiationSampleFlow.PROPOSE_TEMPLATE_URI);
 
         assertEquals(
                 "prompt",
@@ -33,7 +33,7 @@ class NegotiationMetadataReaderTest {
                 ExtensionUriConstants.NEGOTIATION_T_EXTENSION_URI,
                 "prompt",
                 MetadataContent.TEMPLATE_URI_METADATA_KEY,
-                NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri(),
+                NegotiationSampleFlow.PROPOSE_TEMPLATE_URI,
                 MetadataContent.NEGOTIATION_CONTEXT_METADATA_KEY,
                 Map.of("id", "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3", "round", 1, "maxRounds", 5, "performative", "PROPOSE"));
 
@@ -91,7 +91,7 @@ class NegotiationMetadataReaderTest {
                 () -> NegotiationMetadataReader.readPrompt(
                         Map.of(
                                 MetadataContent.TEMPLATE_URI_METADATA_KEY,
-                                NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri()),
+                                NegotiationSampleFlow.PROPOSE_TEMPLATE_URI),
                         NegotiationSampleFlow.PROPOSE_TEMPLATE_URI));
         assertThrows(
                 IllegalArgumentException.class,
@@ -100,7 +100,7 @@ class NegotiationMetadataReaderTest {
                                 ExtensionUriConstants.NEGOTIATION_T_EXTENSION_URI,
                                 "prompt",
                                 MetadataContent.TEMPLATE_URI_METADATA_KEY,
-                                NegotiationSampleFlow.ENDING_TEMPLATE_URI.uri()),
+                                NegotiationSampleFlow.ENDING_TEMPLATE_URI),
                         NegotiationSampleFlow.PROPOSE_TEMPLATE_URI));
         assertThrows(IllegalArgumentException.class, () -> NegotiationMetadataReader.requireExtension("Task-T/v1"));
     }

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/private_line_complaint/negotiation/NegotiationSampleFlowTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/private_line_complaint/negotiation/NegotiationSampleFlowTest.java
@@ -35,8 +35,8 @@ class NegotiationSampleFlowTest {
         NegotiationSampleFlow.NegotiationFlowResult result = run(NegotiationDecision.ACCEPT);
 
         assertEquals(NegotiationDecision.ACCEPT, result.decision());
-        assertEquals(NegotiationSampleFlow.PROPOSE_TEMPLATE_URI.uri(), result.propose().templateUri());
-        assertEquals(NegotiationSampleFlow.ENDING_TEMPLATE_URI.uri(), result.ending().templateUri());
+        assertEquals(NegotiationSampleFlow.PROPOSE_TEMPLATE_URI, result.propose().templateUri());
+        assertEquals(NegotiationSampleFlow.ENDING_TEMPLATE_URI, result.ending().templateUri());
         assertEquals(ExtensionUriConstants.NEGOTIATION_T_EXTENSION_URI, result.propose().extensionUri());
         assertContextIsShared(result);
         assertEquals(

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/service_recovery/accuracy/NotificationTAccuracyTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/service_recovery/accuracy/NotificationTAccuracyTest.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.server.A2ATServer;
 import org.junit.jupiter.api.AfterAll;
@@ -41,7 +40,7 @@ class NotificationTAccuracyTest {
 
     private static A2ATClient client;
     private static A2ATServer server;
-    private static TemplateUri templateUri;
+    private static String templateUri;
     private static Map<String, Object> dataSchema;
     private static Map<String, Object> validationSchema;
     private static boolean apiKeyConfigured;
@@ -53,8 +52,7 @@ class NotificationTAccuracyTest {
 
     @BeforeAll
     static void setup() throws Exception {
-        templateUri = TemplateUri.parse(TEMPLATE_URI_STR)
-                .orElseThrow(() -> new IllegalStateException("Invalid template URI: " + TEMPLATE_URI_STR));
+        templateUri = TEMPLATE_URI_STR;
 
         dataSchema = loadJsonResource(DATA_SCHEMA_RESOURCE);
         validationSchema = loadJsonResource(VALIDATION_SCHEMA_RESOURCE);

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sample/task_t/TaskTSingleSampleTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sample/task_t/TaskTSingleSampleTest.java
@@ -295,7 +295,7 @@ class TaskTSingleSampleTest {
         System.out.println();
 
         MetadataContent metadata = client.generateTaskPromptFromText(
-                sample.text(), StandardTemplates.PRIVATE_LINE_COMPLAINT);
+                sample.text(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
         printMetadata(metadata);
 
         Map<String, Object> extracted = validate(server, sample, metadata);
@@ -322,7 +322,7 @@ class TaskTSingleSampleTest {
         System.out.println();
 
         MetadataContent metadata = client.generateTaskPromptFromDataWithSchema(
-                sample.data(), sample.semanticsSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT);
+                sample.data(), sample.semanticsSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
         printMetadata(metadata);
 
         Map<String, Object> extracted = validate(server, sample, metadata);
@@ -359,10 +359,10 @@ class TaskTSingleSampleTest {
         try {
             if (isData) {
                 metadata = client.generateTaskPromptFromDataWithSchema(
-                        sample.data(), sample.semanticsSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT);
+                        sample.data(), sample.semanticsSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
             } else {
                 metadata = client.generateTaskPromptFromText(
-                        sample.text(), StandardTemplates.PRIVATE_LINE_COMPLAINT);
+                        sample.text(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
             }
         } catch (PromptGenerationException e) {
             // 客户端前置校验拒绝：缺少必填槽位，在调用 LLM 之前就被拦截
@@ -373,7 +373,7 @@ class TaskTSingleSampleTest {
 
         try {
             Map<String, Object> extracted = server.validateTaskPromptAndDataFilling(
-                            metadata.promptText(), sample.validationSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT)
+                            metadata.promptText(), sample.validationSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI)
                     .data();
             System.out.println("[意外通过] 应被拒绝却校验通过，提取参数: " + extracted);
             // 拒绝样本应被拒绝，意外通过视为失败
@@ -394,7 +394,7 @@ class TaskTSingleSampleTest {
 
     private static Map<String, Object> validate(A2ATServer server, TaskTSample sample, MetadataContent metadata) {
         return server.validateTaskPromptAndDataFilling(
-                        metadata.promptText(), sample.validationSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT)
+                        metadata.promptText(), sample.validationSchema(), StandardTemplates.PRIVATE_LINE_COMPLAINT_URI)
                 .data();
     }
 

--- a/a2a-t-sample/src/test/java/net/openan/a2at/sdk/sample/api/NegotiationV3ApiSurfaceTest.java
+++ b/a2a-t-sample/src/test/java/net/openan/a2at/sdk/sample/api/NegotiationV3ApiSurfaceTest.java
@@ -16,7 +16,6 @@ import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.FilledParamData;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.server.A2ATServer;
 import org.junit.jupiter.api.Test;
 
@@ -96,21 +95,25 @@ class NegotiationV3ApiSurfaceTest {
     }
 
     @Test
-    void sixTargetApisUseStructuredTemplateUri() {
-        Set<String> targetMethods = Set.of(
-                "generateNegotiationProposePromptFromText",
-                "generateNegotiationAcceptPromptFromText",
-                "generateNegotiationRejectPromptFromText",
-                "validateProposePromptAndDataFilling",
-                "validateAcceptPromptAndDataFilling",
-                "validateRejectPromptAndDataFilling");
+    void allFacadeTemplateUriParamsAreStrings() {
         for (Class<?> facade : List.of(A2ATClient.class, A2ATServer.class)) {
-            Arrays.stream(facade.getMethods())
-                    .filter(method -> targetMethods.contains(method.getName()))
-                    .forEach(method -> assertEquals(
-                            TemplateUri.class,
-                            method.getParameterTypes()[method.getParameterCount() - 1],
-                            "last parameter of " + facade.getSimpleName() + "." + method.getName()));
+            List<Method> methodsWithTemplateUri = Arrays.stream(facade.getDeclaredMethods())
+                    .filter(method -> java.lang.reflect.Modifier.isPublic(method.getModifiers())
+                            && !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+                    .filter(method -> Arrays.stream(method.getParameters())
+                            .anyMatch(parameter -> "templateUri".equals(parameter.getName())))
+                    .toList();
+            assertFalse(methodsWithTemplateUri.isEmpty(), facade.getSimpleName() + " must declare templateUri methods");
+            for (Method method : methodsWithTemplateUri) {
+                for (java.lang.reflect.Parameter parameter : method.getParameters()) {
+                    if ("templateUri".equals(parameter.getName())) {
+                        assertEquals(
+                                String.class,
+                                parameter.getType(),
+                                "templateUri parameter of " + facade.getSimpleName() + "." + method.getName());
+                    }
+                }
+            }
         }
     }
 

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
@@ -126,14 +126,16 @@ public final class A2ATServer {
      *
      * @param data typed propose input carrying the negotiation context and the typed content
      * @param templateUri raw template URI string such as {@code Negotiation-T/information-negotiation/propose/v1};
-     *     its phase segment must be {@code propose}
+     *     its performative segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
      *     method or the content type
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
-     *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
-     *     {@code negotiation.field_missing} when rendering the template fails
+     *     {@code template.not_found} when no template exists for the URI in any resource root, the code
+     *     {@code negotiation.content_invalid} when a required content field is blank or empty, the code
+     *     {@code negotiation.invalid_input} when the content combines a non-blank confirm request with conditional
+     *     sections, or the code {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateNegotiationProposePromptFromData(
             @NonNull NegotiationProposeData data, @NonNull String templateUri) {
@@ -148,14 +150,16 @@ public final class A2ATServer {
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
      * @param templateUri raw template URI string such as {@code Negotiation-T/information-negotiation/accept-reject/v1};
-     *     its phase segment must be {@code accept-reject}
+     *     its performative segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
-     * @throws IllegalArgumentException if the template URI is blank or malformed, its phase or type contradicts the
-     *     method or the content, or the content conclusion is not {@code Accept}
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
+     *     method or the content
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
-     *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
-     *     {@code negotiation.field_missing} when rendering the template fails
+     *     {@code template.not_found} when no template exists for the URI in any resource root, the code
+     *     {@code negotiation.conclusion_mismatch} when the content conclusion is not {@code Accept}, the code
+     *     {@code negotiation.content_invalid} when a required content field is blank or empty, or the code
+     *     {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateNegotiationAcceptPromptFromData(
             @NonNull NegotiationEndingData data, @NonNull String templateUri) {
@@ -170,14 +174,16 @@ public final class A2ATServer {
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
      * @param templateUri raw template URI string such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1};
-     *     its phase segment must be {@code accept-reject}
+     *     its performative segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
-     * @throws IllegalArgumentException if the template URI is blank or malformed, its phase or type contradicts the
-     *     method or the content, or the content conclusion is not {@code Reject}
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
+     *     method or the content
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
-     *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
-     *     {@code negotiation.field_missing} when rendering the template fails
+     *     {@code template.not_found} when no template exists for the URI in any resource root, the code
+     *     {@code negotiation.conclusion_mismatch} when the content conclusion is not {@code Reject}, the code
+     *     {@code negotiation.content_invalid} when a required content field is blank or empty, or the code
+     *     {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateNegotiationRejectPromptFromData(
             @NonNull NegotiationEndingData data, @NonNull String templateUri) {
@@ -195,10 +201,11 @@ public final class A2ATServer {
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank, malformed or does not address the common abort
-     *     template, or the termination reason is blank
+     *     template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
-     *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
-     *     {@code negotiation.field_missing} when rendering the template fails
+     *     {@code template.not_found} when no template exists for the URI in any resource root, the code
+     *     {@code negotiation.content_invalid} when the termination reason is blank, or the code
+     *     {@code template.render_failed} when rendering the template fails
      */
     public MetadataContent generateNegotiationAbortPromptFromData(
             @NonNull NegotiationAbortData data, @NonNull String templateUri) {
@@ -216,8 +223,8 @@ public final class A2ATServer {
      * @param text free-text input describing the message content
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri raw template URI string such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase
-     *     segment must be {@code propose}
+     * @param templateUri raw template URI string such as {@code Negotiation-T/target-negotiation/propose/v1}; its
+     *     performative segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
@@ -231,7 +238,7 @@ public final class A2ATServer {
      */
     public MetadataContent generateNegotiationProposePromptFromText(
             @NonNull String text,
-            net.openan.a2at.sdk.core.model.NegotiationContext context,
+            net.openan.a2at.sdk.core.model.@NonNull NegotiationContext context,
             @NonNull String templateUri) {
         return negotiationContentService.generateProposeFromText(text, context, parseTemplateUri(templateUri));
     }
@@ -247,7 +254,7 @@ public final class A2ATServer {
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
      * @param templateUri raw template URI string such as {@code Negotiation-T/information-negotiation/accept-reject/v1};
-     *     its phase segment must be {@code accept-reject}
+     *     its performative segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
@@ -255,13 +262,14 @@ public final class A2ATServer {
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid}
      *     when the extraction step fails after exhausting its retries, {@code negotiation.field_missing} when the
-     *     extracted content misses a required field, {@code negotiation.invalid_input} when the text is blank or the
-     *     extracted conclusion is not {@code Accept}, or {@code input.text_too_long} when the text exceeds the
-     *     configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
+     *     extracted content misses a required field, {@code negotiation.invalid_input} when the text is blank,
+     *     {@code negotiation.conclusion_mismatch} when the extracted conclusion is not {@code Accept}, or
+     *     {@code input.text_too_long} when the text exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public MetadataContent generateNegotiationAcceptPromptFromText(
             @NonNull String text,
-            net.openan.a2at.sdk.core.model.NegotiationContext context,
+            net.openan.a2at.sdk.core.model.@NonNull NegotiationContext context,
             @NonNull String templateUri) {
         return negotiationContentService.generateAcceptFromText(text, context, parseTemplateUri(templateUri));
     }
@@ -277,7 +285,7 @@ public final class A2ATServer {
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
      * @param templateUri raw template URI string such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1};
-     *     its phase segment must be {@code accept-reject}
+     *     its performative segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
      * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
@@ -285,13 +293,14 @@ public final class A2ATServer {
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid}
      *     when the extraction step fails after exhausting its retries, {@code negotiation.field_missing} when the
-     *     extracted content misses a required field, {@code negotiation.invalid_input} when the text is blank or the
-     *     extracted conclusion is not {@code Reject}, or {@code input.text_too_long} when the text exceeds the
-     *     configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
+     *     extracted content misses a required field, {@code negotiation.invalid_input} when the text is blank,
+     *     {@code negotiation.conclusion_mismatch} when the extracted conclusion is not {@code Reject}, or
+     *     {@code input.text_too_long} when the text exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public MetadataContent generateNegotiationRejectPromptFromText(
             @NonNull String text,
-            net.openan.a2at.sdk.core.model.NegotiationContext context,
+            net.openan.a2at.sdk.core.model.@NonNull NegotiationContext context,
             @NonNull String templateUri) {
         return negotiationContentService.generateRejectFromText(text, context, parseTemplateUri(templateUri));
     }
@@ -320,7 +329,7 @@ public final class A2ATServer {
      */
     public MetadataContent generateNegotiationAbortPromptFromText(
             @NonNull String text,
-            net.openan.a2at.sdk.core.model.NegotiationContext context,
+            net.openan.a2at.sdk.core.model.@NonNull NegotiationContext context,
             @NonNull String templateUri) {
         return negotiationContentService.generateAbortFromText(text, context, parseTemplateUri(templateUri));
     }
@@ -366,16 +375,16 @@ public final class A2ATServer {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its phase segment
+     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its performative segment
      *     must be {@code propose}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or its phase
-     *     contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
-     *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
-     *     {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded} when the negotiation context
-     *     violates a rule, one of the closed {@code negotiation.*} code set (for example
+     *     {@code negotiation.invalid_input} when the prompt is null or blank or is not a negotiation message,
+     *     {@code negotiation.rule_violation} when the negotiation context violates a rule (nested slot error codes
+     *     such as {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded}), one of the closed
+     *     {@code negotiation.*} code set (for example
      *     {@code negotiation.conclusion_content_mismatch}) when a rule or semantic check rejects the message,
      *     {@code negotiation.semantic_rejected} when the semantic validation rejects the message,
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
@@ -403,16 +412,16 @@ public final class A2ATServer {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its phase segment
+     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its performative segment
      *     must be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or its phase
-     *     contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
-     *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
-     *     {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded} when the negotiation context
-     *     violates a rule, one of the closed {@code negotiation.*} code set (for example
+     *     {@code negotiation.invalid_input} when the prompt is null or blank or is not a negotiation message,
+     *     {@code negotiation.rule_violation} when the negotiation context violates a rule (nested slot error codes
+     *     such as {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded}), one of the closed
+     *     {@code negotiation.*} code set (for example
      *     {@code negotiation.conclusion_content_mismatch}) when a rule or semantic check rejects the message,
      *     {@code negotiation.semantic_rejected} when the semantic validation rejects the message,
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
@@ -440,16 +449,16 @@ public final class A2ATServer {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its phase segment
+     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its performative segment
      *     must be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or its phase
-     *     contradicts the method
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
-     *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
-     *     {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded} when the negotiation context
-     *     violates a rule, one of the closed {@code negotiation.*} code set (for example
+     *     {@code negotiation.invalid_input} when the prompt is null or blank or is not a negotiation message,
+     *     {@code negotiation.rule_violation} when the negotiation context violates a rule (nested slot error codes
+     *     such as {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded}), one of the closed
+     *     {@code negotiation.*} code set (for example
      *     {@code negotiation.conclusion_content_mismatch}) when a rule or semantic check rejects the message,
      *     {@code negotiation.semantic_rejected} when the semantic validation rejects the message,
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
@@ -479,13 +488,14 @@ public final class A2ATServer {
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
      * @param templateUri raw template URI string of the common abort template {@code Negotiation-T/common/abort/v1}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank, malformed or does not address
-     *     the common abort template
+     * @throws NullPointerException if the schema or the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank, malformed or does not address the common abort
+     *     template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
-     *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
-     *     {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded} when the negotiation context
-     *     violates a rule, one of the closed {@code negotiation.*} code set (for example
+     *     {@code negotiation.invalid_input} when the prompt is null or blank or is not a negotiation message,
+     *     {@code negotiation.rule_violation} when the negotiation context violates a rule (nested slot error codes
+     *     such as {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded}), one of the closed
+     *     {@code negotiation.*} code set (for example
      *     {@code negotiation.conclusion_content_mismatch}) when a rule or semantic check rejects the message,
      *     {@code negotiation.semantic_rejected} when the semantic validation rejects the message,
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
@@ -510,14 +520,16 @@ public final class A2ATServer {
      * @param templateUri raw template URI string declaring the expected task template; its prefix segment must be
      *     {@code Task-T}
      * @return filled parameter data carrying the merged parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is blank or malformed
+     * @throws NullPointerException if the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
-     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content,
+     *     {@code negotiation.invalid_input} when the prompt is null or blank, the schema is null, or the template URI
+     *     addresses another extension or carries an unsupported version, the code
+     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content, the code
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
-     *     its retries, or {@code template.not_found} when the validation prompt resources are missing, or
-     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
-     *     default 16384)
+     *     its retries, the code {@code template.not_found} when the template or the validation prompt resources are
+     *     missing, or the code {@code input.text_too_long} when the prompt exceeds the configured maximum length
+     *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateTaskPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull String templateUri) {
@@ -532,14 +544,16 @@ public final class A2ATServer {
      * @param templateUri raw template URI string declaring the expected notification template; its prefix segment must
      *     be {@code Notification-T}
      * @return filled parameter data carrying the merged parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is blank or malformed
+     * @throws NullPointerException if the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
-     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content,
+     *     {@code negotiation.invalid_input} when the prompt is null or blank, the schema is null, or the template URI
+     *     addresses another extension or carries an unsupported version, the code
+     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content, the code
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
-     *     its retries, or {@code template.not_found} when the validation prompt resources are missing, or
-     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
-     *     default 16384)
+     *     its retries, the code {@code template.not_found} when the template or the validation prompt resources are
+     *     missing, or the code {@code input.text_too_long} when the prompt exceeds the configured maximum length
+     *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateNotificationPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull String templateUri) {
@@ -554,14 +568,16 @@ public final class A2ATServer {
      * @param templateUri raw template URI string declaring the expected authorization template; its prefix segment
      *     must be {@code Authorization-T}
      * @return filled parameter data carrying the merged parameters
-     * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank, or the template URI is blank or malformed
+     * @throws NullPointerException if the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
-     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content,
+     *     {@code negotiation.invalid_input} when the prompt is null or blank, the schema is null, or the template URI
+     *     addresses another extension or carries an unsupported version, the code
+     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content, the code
      *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
-     *     its retries, or {@code template.not_found} when the validation prompt resources are missing, or
-     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
-     *     default 16384)
+     *     its retries, the code {@code template.not_found} when the template or the validation prompt resources are
+     *     missing, or the code {@code input.text_too_long} when the prompt exceeds the configured maximum length
+     *     (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
      */
     public FilledParamData validateAuthPromptAndDataFilling(
             @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull String templateUri) {

--- a/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
+++ b/a2a-t-server/src/main/java/net/openan/a2at/sdk/server/A2ATServer.java
@@ -3,6 +3,7 @@ package net.openan.a2at.sdk.server;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import net.openan.a2at.sdk.core.model.A2ATConfig;
 import net.openan.a2at.sdk.core.model.FilledParamData;
@@ -124,18 +125,19 @@ public final class A2ATServer {
      * generator of the negotiation type addressed by the template URI and rendered from that template.
      *
      * @param data typed propose input carrying the negotiation context and the typed content
-     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/propose/v1}; its phase
-     *     segment must be {@code propose}
+     * @param templateUri raw template URI string such as {@code Negotiation-T/information-negotiation/propose/v1};
+     *     its phase segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
-     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content type
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase or type contradicts the
+     *     method or the content type
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation.field_missing} when rendering the template fails
      */
     public MetadataContent generateNegotiationProposePromptFromData(
-            @NonNull NegotiationProposeData data, @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateProposeFromData(data, templateUri);
+            @NonNull NegotiationProposeData data, @NonNull String templateUri) {
+        return negotiationContentService.generateProposeFromData(data, parseTemplateUri(templateUri));
     }
 
     /**
@@ -145,19 +147,19 @@ public final class A2ATServer {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri raw template URI string such as {@code Negotiation-T/information-negotiation/accept-reject/v1};
+     *     its phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
-     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
-     *     content conclusion is not {@code Accept}
+     * @throws IllegalArgumentException if the template URI is blank or malformed, its phase or type contradicts the
+     *     method or the content, or the content conclusion is not {@code Accept}
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation.field_missing} when rendering the template fails
      */
     public MetadataContent generateNegotiationAcceptPromptFromData(
-            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateAcceptFromData(data, templateUri);
+            @NonNull NegotiationEndingData data, @NonNull String templateUri) {
+        return negotiationContentService.generateAcceptFromData(data, parseTemplateUri(templateUri));
     }
 
     /**
@@ -167,19 +169,19 @@ public final class A2ATServer {
      * mismatched conclusion is a content error.
      *
      * @param data typed terminal input carrying the negotiation context and the typed ending content
-     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri raw template URI string such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1};
+     *     its phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
-     * @throws IllegalArgumentException if the template URI phase or type contradicts the method or the content, or the
-     *     content conclusion is not {@code Reject}
+     * @throws IllegalArgumentException if the template URI is blank or malformed, its phase or type contradicts the
+     *     method or the content, or the content conclusion is not {@code Reject}
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation.field_missing} when rendering the template fails
      */
     public MetadataContent generateNegotiationRejectPromptFromData(
-            @NonNull NegotiationEndingData data, @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateRejectFromData(data, templateUri);
+            @NonNull NegotiationEndingData data, @NonNull String templateUri) {
+        return negotiationContentService.generateRejectFromData(data, parseTemplateUri(templateUri));
     }
 
     /**
@@ -189,18 +191,18 @@ public final class A2ATServer {
      * template must be the common abort template and the content carries only the termination reason.
      *
      * @param data typed abort input carrying the negotiation context and the termination reason
-     * @param templateUri template URI of the common abort template {@code Negotiation-T/common/abort/v1}
+     * @param templateUri raw template URI string of the common abort template {@code Negotiation-T/common/abort/v1}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the data, its context or the template URI is null
-     * @throws IllegalArgumentException if the template URI does not address the common abort template or the
-     *     termination reason is blank
+     * @throws IllegalArgumentException if the template URI is blank, malformed or does not address the common abort
+     *     template, or the termination reason is blank
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template exists for the URI in any resource root, or the code
      *     {@code negotiation.field_missing} when rendering the template fails
      */
     public MetadataContent generateNegotiationAbortPromptFromData(
-            @NonNull NegotiationAbortData data, @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateAbortFromData(data, templateUri);
+            @NonNull NegotiationAbortData data, @NonNull String templateUri) {
+        return negotiationContentService.generateAbortFromData(data, parseTemplateUri(templateUri));
     }
 
     /**
@@ -214,11 +216,11 @@ public final class A2ATServer {
      * @param text free-text input describing the message content
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase segment
-     *     must be {@code propose}
+     * @param templateUri raw template URI string such as {@code Negotiation-T/target-negotiation/propose/v1}; its phase
+     *     segment must be {@code propose}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
-     * @throws IllegalArgumentException if the template URI phase contradicts the method
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid}
@@ -230,8 +232,8 @@ public final class A2ATServer {
     public MetadataContent generateNegotiationProposePromptFromText(
             @NonNull String text,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateProposeFromText(text, context, templateUri);
+            @NonNull String templateUri) {
+        return negotiationContentService.generateProposeFromText(text, context, parseTemplateUri(templateUri));
     }
 
     /**
@@ -244,11 +246,11 @@ public final class A2ATServer {
      * @param text free-text input describing the message content
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/information-negotiation/accept-reject/v1}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri raw template URI string such as {@code Negotiation-T/information-negotiation/accept-reject/v1};
+     *     its phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
-     * @throws IllegalArgumentException if the template URI phase contradicts the method
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid}
@@ -260,8 +262,8 @@ public final class A2ATServer {
     public MetadataContent generateNegotiationAcceptPromptFromText(
             @NonNull String text,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateAcceptFromText(text, context, templateUri);
+            @NonNull String templateUri) {
+        return negotiationContentService.generateAcceptFromText(text, context, parseTemplateUri(templateUri));
     }
 
     /**
@@ -274,11 +276,11 @@ public final class A2ATServer {
      * @param text free-text input describing the message content
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1}; its phase
-     *     segment must be {@code accept-reject}
+     * @param templateUri raw template URI string such as {@code Negotiation-T/feasibility-negotiation/accept-reject/v1};
+     *     its phase segment must be {@code accept-reject}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
-     * @throws IllegalArgumentException if the template URI phase contradicts the method
+     * @throws IllegalArgumentException if the template URI is blank or malformed, or its phase contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid}
@@ -290,8 +292,8 @@ public final class A2ATServer {
     public MetadataContent generateNegotiationRejectPromptFromText(
             @NonNull String text,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateRejectFromText(text, context, templateUri);
+            @NonNull String templateUri) {
+        return negotiationContentService.generateRejectFromText(text, context, parseTemplateUri(templateUri));
     }
 
     /**
@@ -303,10 +305,11 @@ public final class A2ATServer {
      * @param text free-text input stating the termination reason
      * @param context negotiation context carried in the {@code negotiationContext} metadata entry of the generated
      *     message without any LLM involvement
-     * @param templateUri template URI of the common abort template {@code Negotiation-T/common/abort/v1}
+     * @param templateUri raw template URI string of the common abort template {@code Negotiation-T/common/abort/v1}
      * @return generated message carrying the template URI, the rendered message text and the negotiation extension URI
      * @throws NullPointerException if the context or the template URI is null
-     * @throws IllegalArgumentException if the template URI does not address the common abort template
+     * @throws IllegalArgumentException if the template URI is blank, malformed or does not address the common abort
+     *     template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationGenerationException with the code
      *     {@code template.not_found} when no template or prompt resource exists for the URI and language,
      *     {@code negotiation.content_extract_failed}, {@code llm.invocation_failed} or {@code llm.response_invalid}
@@ -318,8 +321,8 @@ public final class A2ATServer {
     public MetadataContent generateNegotiationAbortPromptFromText(
             @NonNull String text,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.generateAbortFromText(text, context, templateUri);
+            @NonNull String templateUri) {
+        return negotiationContentService.generateAbortFromText(text, context, parseTemplateUri(templateUri));
     }
 
     /**
@@ -339,15 +342,17 @@ public final class A2ATServer {
     /**
      * Loads one template by its URI, regardless of the extension.
      *
-     * <p>This query never throws: a template that exists nowhere for the configured language returns an empty result
-     * and logs an actionable warning.
+     * <p>This query never throws for a well-formed template URI: a template that exists nowhere for the configured
+     * language returns an empty result and logs an actionable warning.
      *
-     * @param templateUri template URI such as {@code Negotiation-T/target-negotiation/propose/v1} or
+     * @param templateUri raw template URI string such as {@code Negotiation-T/target-negotiation/propose/v1} or
      *     {@code Task-T/network-layer/ran-energy-saving/v1}
      * @return the addressed template, or an empty result when the template does not exist for the configured language
+     * @throws NullPointerException if the template URI is null
+     * @throws IllegalArgumentException if the template URI is blank or malformed
      */
-    public Optional<PromptTemplate> getPrompt(@NonNull TemplateUri templateUri) {
-        return templateQueryService.getPrompt(templateUri);
+    public Optional<PromptTemplate> getPrompt(@NonNull String templateUri) {
+        return templateQueryService.getPrompt(parseTemplateUri(templateUri));
     }
 
     /**
@@ -361,11 +366,12 @@ public final class A2ATServer {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
-     *     {@code propose}
+     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its phase segment
+     *     must be {@code propose}
      * @return filled parameter data carrying the context parameters and the extracted parameters
      * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank or the template URI phase contradicts the method
+     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or its phase
+     *     contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded} when the negotiation context
@@ -381,8 +387,9 @@ public final class A2ATServer {
             @NonNull String prompt,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
             @NonNull Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.validateProposePromptAndDataFilling(prompt, context, schema, templateUri);
+            @NonNull String templateUri) {
+        return negotiationContentService.validateProposePromptAndDataFilling(
+                prompt, context, schema, parseTemplateUri(templateUri));
     }
 
     /**
@@ -396,11 +403,12 @@ public final class A2ATServer {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
-     *     {@code accept-reject}
+     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its phase segment
+     *     must be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
      * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank or the template URI phase contradicts the method
+     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or its phase
+     *     contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded} when the negotiation context
@@ -416,8 +424,9 @@ public final class A2ATServer {
             @NonNull String prompt,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
             @NonNull Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.validateAcceptPromptAndDataFilling(prompt, context, schema, templateUri);
+            @NonNull String templateUri) {
+        return negotiationContentService.validateAcceptPromptAndDataFilling(
+                prompt, context, schema, parseTemplateUri(templateUri));
     }
 
     /**
@@ -431,11 +440,12 @@ public final class A2ATServer {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected negotiation type and phase; its phase segment must be
-     *     {@code accept-reject}
+     * @param templateUri raw template URI string declaring the expected negotiation type and phase; its phase segment
+     *     must be {@code accept-reject}
      * @return filled parameter data carrying the context parameters and the extracted parameters
      * @throws NullPointerException if the prompt, schema or template URI is null
-     * @throws IllegalArgumentException if the prompt is blank or the template URI phase contradicts the method
+     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank or malformed, or its phase
+     *     contradicts the method
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded} when the negotiation context
@@ -451,8 +461,9 @@ public final class A2ATServer {
             @NonNull String prompt,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
             @NonNull Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.validateRejectPromptAndDataFilling(prompt, context, schema, templateUri);
+            @NonNull String templateUri) {
+        return negotiationContentService.validateRejectPromptAndDataFilling(
+                prompt, context, schema, parseTemplateUri(templateUri));
     }
 
     /**
@@ -466,10 +477,11 @@ public final class A2ATServer {
      * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
      *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI of the common abort template {@code Negotiation-T/common/abort/v1}
+     * @param templateUri raw template URI string of the common abort template {@code Negotiation-T/common/abort/v1}
      * @return filled parameter data carrying the context parameters and the extracted parameters
-     * @throws IllegalArgumentException if the prompt is blank or the template URI does not address the common abort
-     *     template
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, the template URI is blank, malformed or does not address
+     *     the common abort template
      * @throws net.openan.a2at.sdk.negotiation.content.NegotiationParamExtractionException with the code
      *     {@code negotiation.invalid_input} when the prompt is not a negotiation message,
      *     {@code negotiation.invalid_context_id} or {@code negotiation.round_exceeded} when the negotiation context
@@ -485,78 +497,80 @@ public final class A2ATServer {
             @NonNull String prompt,
             net.openan.a2at.sdk.core.model.NegotiationContext context,
             @NonNull Map<String, Object> schema,
-            @NonNull TemplateUri templateUri) {
-        return negotiationContentService.validateAbortPromptAndDataFilling(prompt, context, schema, templateUri);
+            @NonNull String templateUri) {
+        return negotiationContentService.validateAbortPromptAndDataFilling(
+                prompt, context, schema, parseTemplateUri(templateUri));
     }
 
     /**
      * Validates a task prompt and extracts its parameters.
      *
      * @param prompt rendered task prompt text to validate
-     * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
-     *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected task template; its prefix segment must be {@code Task-T}
+     * @param templateUri raw template URI string declaring the expected task template; its prefix segment must be
+     *     {@code Task-T}
      * @return filled parameter data carrying the merged parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
-     *     {@code negotiation.invalid_input} when the template URI is null, {@code negotiation.semantic_rejected} when
-     *     the semantic validation rejects the content, {@code llm.invocation_failed} or {@code llm.response_invalid}
-     *     when the semantic step fails after exhausting its retries, or {@code template.not_found} when the validation
-     *     prompt resources are missing, or {@code input.text_too_long} when the prompt exceeds the configured maximum
-     *     length (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
+     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content,
+     *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
+     *     its retries, or {@code template.not_found} when the validation prompt resources are missing, or
+     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public FilledParamData validateTaskPromptAndDataFilling(
-            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
-        return taskContentValidator.validate(prompt, schema, templateUri);
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull String templateUri) {
+        return taskContentValidator.validate(prompt, schema, parseTemplateUri(templateUri));
     }
 
     /**
      * Validates a notification prompt and extracts its parameters.
      *
      * @param prompt rendered notification prompt text to validate
-     * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
-     *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected notification template; its prefix segment must be
-     *     {@code Notification-T}
+     * @param templateUri raw template URI string declaring the expected notification template; its prefix segment must
+     *     be {@code Notification-T}
      * @return filled parameter data carrying the merged parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
-     *     {@code negotiation.invalid_input} when the template URI is null, {@code negotiation.semantic_rejected} when
-     *     the semantic validation rejects the content, {@code llm.invocation_failed} or {@code llm.response_invalid}
-     *     when the semantic step fails after exhausting its retries, or {@code template.not_found} when the validation
-     *     prompt resources are missing, or {@code input.text_too_long} when the prompt exceeds the configured maximum
-     *     length (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
+     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content,
+     *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
+     *     its retries, or {@code template.not_found} when the validation prompt resources are missing, or
+     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public FilledParamData validateNotificationPromptAndDataFilling(
-            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
-        return notificationContentValidator.validate(prompt, schema, templateUri);
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull String templateUri) {
+        return notificationContentValidator.validate(prompt, schema, parseTemplateUri(templateUri));
     }
 
     /**
      * Validates an authorization prompt and extracts its parameters.
      *
      * @param prompt rendered authorization prompt text to validate
-     * @param context negotiation context carried alongside the message in the A2A-T metadata; {@code null} is reported
-     *     as not being a negotiation message
      * @param schema caller-provided parameter JSON schema describing the parameters to extract
-     * @param templateUri template URI declaring the expected authorization template; its prefix segment must be
-     *     {@code Authorization-T}
+     * @param templateUri raw template URI string declaring the expected authorization template; its prefix segment
+     *     must be {@code Authorization-T}
      * @return filled parameter data carrying the merged parameters
-     * @throws NullPointerException if the prompt or schema is null
-     * @throws IllegalArgumentException if the prompt is blank
+     * @throws NullPointerException if the prompt, schema or template URI is null
+     * @throws IllegalArgumentException if the prompt is blank, or the template URI is blank or malformed
      * @throws net.openan.a2at.sdk.core.validation.ContentValidationException with the code
-     *     {@code negotiation.invalid_input} when the template URI is null, {@code negotiation.semantic_rejected} when
-     *     the semantic validation rejects the content, {@code llm.invocation_failed} or {@code llm.response_invalid}
-     *     when the semantic step fails after exhausting its retries, or {@code template.not_found} when the validation
-     *     prompt resources are missing, or {@code input.text_too_long} when the prompt exceeds the configured maximum
-     *     length (A2AT_INPUT_TEXT_MAX_CHARS, default 16384)
+     *     {@code negotiation.semantic_rejected} when the semantic validation rejects the content,
+     *     {@code llm.invocation_failed} or {@code llm.response_invalid} when the semantic step fails after exhausting
+     *     its retries, or {@code template.not_found} when the validation prompt resources are missing, or
+     *     {@code input.text_too_long} when the prompt exceeds the configured maximum length (A2AT_INPUT_TEXT_MAX_CHARS,
+     *     default 16384)
      */
     public FilledParamData validateAuthPromptAndDataFilling(
-            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull TemplateUri templateUri) {
-        return authContentValidator.validate(prompt, schema, templateUri);
+            @NonNull String prompt, @NonNull Map<String, Object> schema, @NonNull String templateUri) {
+        return authContentValidator.validate(prompt, schema, parseTemplateUri(templateUri));
+    }
+
+    private static TemplateUri parseTemplateUri(String templateUri) {
+        Objects.requireNonNull(templateUri, "templateUri");
+        return TemplateUri.parse(templateUri)
+                .orElseThrow(() -> new IllegalArgumentException("Unparseable template URI: " + templateUri));
     }
 }

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/A2ATServerContentValidationApiTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/A2ATServerContentValidationApiTest.java
@@ -1,17 +1,15 @@
 package net.openan.a2at.sdk.server.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import net.openan.a2at.sdk.core.exception.A2ATErrorCodes;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.core.model.NegotiationPerformative;
-import net.openan.a2at.sdk.core.validation.ContentValidationException;
 import net.openan.a2at.sdk.negotiation.content.InformationProposeContent;
 import net.openan.a2at.sdk.negotiation.content.NegotiationItem;
 import net.openan.a2at.sdk.negotiation.content.NegotiationProposeData;
@@ -23,36 +21,30 @@ class A2ATServerContentValidationApiTest {
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
     @Test
-    void validateTaskPromptRejectsNullTemplateUriWithValidationInvalidInput() throws IOException {
+    void validateTaskPromptRejectsNullTemplateUriWithNullPointerException() throws IOException {
         A2ATServer server = new A2ATServer(writeEnv());
 
-        ContentValidationException error = assertThrows(
-                ContentValidationException.class,
+        assertThrows(
+                NullPointerException.class,
                 () -> server.validateTaskPromptAndDataFilling("test prompt", Map.of(), null));
-
-        assertEquals(A2ATErrorCodes.VALIDATION_INVALID_INPUT, error.getCode());
     }
 
     @Test
-    void validateNotificationPromptRejectsNullTemplateUriWithValidationInvalidInput() throws IOException {
+    void validateNotificationPromptRejectsNullTemplateUriWithNullPointerException() throws IOException {
         A2ATServer server = new A2ATServer(writeEnv());
 
-        ContentValidationException error = assertThrows(
-                ContentValidationException.class,
+        assertThrows(
+                NullPointerException.class,
                 () -> server.validateNotificationPromptAndDataFilling("test prompt", Map.of(), null));
-
-        assertEquals(A2ATErrorCodes.VALIDATION_INVALID_INPUT, error.getCode());
     }
 
     @Test
-    void validateAuthPromptRejectsNullTemplateUriWithValidationInvalidInput() throws IOException {
+    void validateAuthPromptRejectsNullTemplateUriWithNullPointerException() throws IOException {
         A2ATServer server = new A2ATServer(writeEnv());
 
-        ContentValidationException error = assertThrows(
-                ContentValidationException.class,
+        assertThrows(
+                NullPointerException.class,
                 () -> server.validateAuthPromptAndDataFilling("test prompt", Map.of(), null));
-
-        assertEquals(A2ATErrorCodes.VALIDATION_INVALID_INPUT, error.getCode());
     }
 
     @Test
@@ -73,6 +65,62 @@ class A2ATServerContentValidationApiTest {
         A2ATServer server = new A2ATServer(writeEnv());
 
         assertThrows(NullPointerException.class, () -> server.getPrompt(null));
+    }
+
+    @Test
+    void generateNegotiationProposePromptFromDataRejectsMalformedTemplateUri() throws IOException {
+        A2ATServer server = new A2ATServer(writeEnv());
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> server.generateNegotiationProposePromptFromData(
+                        new NegotiationProposeData(
+                                new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
+                                new InformationProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
+                        "not-a-template-uri"));
+
+        assertTrue(error.getMessage().contains("Unparseable template URI"));
+    }
+
+    @Test
+    void validateProposePromptAndDataFillingRejectsMalformedTemplateUri() throws IOException {
+        A2ATServer server = new A2ATServer(writeEnv());
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> server.validateProposePromptAndDataFilling("test prompt", null, Map.of(), "not-a-template-uri"));
+
+        assertTrue(error.getMessage().contains("Unparseable template URI"));
+    }
+
+    @Test
+    void validateTaskPromptAndDataFillingRejectsMalformedTemplateUri() throws IOException {
+        A2ATServer server = new A2ATServer(writeEnv());
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> server.validateTaskPromptAndDataFilling("test prompt", Map.of(), "Task-T/network-layer"));
+
+        assertTrue(error.getMessage().contains("Unparseable template URI"));
+    }
+
+    @Test
+    void getPromptRejectsMalformedTemplateUri() throws IOException {
+        A2ATServer server = new A2ATServer(writeEnv());
+
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> server.getPrompt("not-a-template-uri"));
+
+        assertTrue(error.getMessage().contains("Unparseable template URI"));
+    }
+
+    @Test
+    void getPromptRejectsBlankTemplateUri() throws IOException {
+        A2ATServer server = new A2ATServer(writeEnv());
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () -> server.getPrompt("   "));
+
+        assertTrue(error.getMessage().contains("Unparseable template URI"));
     }
 
     private static Path writeEnv() throws IOException {

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/A2ATServerNegotiationApiTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/A2ATServerNegotiationApiTest.java
@@ -39,7 +39,7 @@ class A2ATServerNegotiationApiTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
                         new InformationProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE);
+                INFORMATION_PROPOSE_URI);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -59,7 +59,7 @@ class A2ATServerNegotiationApiTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
                         new InformationProposeContent(List.of(new NegotiationItem("Region", "Songshan Lake")), null)),
-                INFORMATION_PROPOSE);
+                INFORMATION_PROPOSE_URI);
 
         assertEquals(INFORMATION_PROPOSE_URI, result.templateUri());
         assertFalse(result.promptText().isBlank());
@@ -81,7 +81,7 @@ class A2ATServerNegotiationApiTest {
                 new NegotiationAbortData(
                         new NegotiationContext(UUID, 5, 5, NegotiationPerformative.ABORT),
                         new NegotiationAbortContent("达到协商轮次上限，本次协商确认结束。")),
-                StandardTemplates.NEGOTIATION_ABORT);
+                StandardTemplates.NEGOTIATION_ABORT_URI);
 
         assertEquals(StandardTemplates.NEGOTIATION_ABORT.uri(), result.templateUri());
         assertTrue(result.promptText().contains("## 协商结果\nAbort"));
@@ -94,7 +94,7 @@ class A2ATServerNegotiationApiTest {
         A2ATServer server = new A2ATServer(writeEnv("zh-CN"));
 
         PromptTemplate template =
-                server.getPrompt(StandardTemplates.NEGOTIATION_ABORT).orElseThrow();
+                server.getPrompt(StandardTemplates.NEGOTIATION_ABORT_URI).orElseThrow();
         assertEquals(StandardTemplates.NEGOTIATION_ABORT, template.templateUri());
         assertFalse(template.content().isBlank());
     }
@@ -103,13 +103,13 @@ class A2ATServerNegotiationApiTest {
     void queriesSingleNegotiationTemplateWithoutThrowing() throws IOException {
         A2ATServer server = new A2ATServer(writeEnv("zh-CN"));
 
-        assertTrue(server.getPrompt(INFORMATION_PROPOSE).isPresent());
-        assertTrue(server.getPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT)
+        assertTrue(server.getPrompt(INFORMATION_PROPOSE_URI).isPresent());
+        assertTrue(server.getPrompt(StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI)
                 .isPresent());
         assertFalse(server.getPrompt(
-                        TemplateUri.of(StandardTemplates.NEGOTIATION_EXTENSION_NAME, "unknown-negotiation", "propose"))
+                        StandardTemplates.NEGOTIATION_EXTENSION_NAME + "/unknown-negotiation/propose/v1")
                 .isPresent());
-        PromptTemplate template = server.getPrompt(INFORMATION_PROPOSE).orElseThrow();
+        PromptTemplate template = server.getPrompt(INFORMATION_PROPOSE_URI).orElseThrow();
         assertEquals(INFORMATION_PROPOSE, template.templateUri());
         assertFalse(template.content().isBlank());
     }

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/InputTextLengthLimitTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/InputTextLengthLimitTest.java
@@ -80,15 +80,15 @@ class InputTextLengthLimitTest {
         ContentValidationException taskError = assertThrows(
                 ContentValidationException.class,
                 () -> server.validateTaskPromptAndDataFilling(
-                        oversizedPrompt, schema, StandardTemplates.ENERGY_SAVING));
+                        oversizedPrompt, schema, StandardTemplates.ENERGY_SAVING_URI));
         ContentValidationException notificationError = assertThrows(
                 ContentValidationException.class,
                 () -> server.validateNotificationPromptAndDataFilling(
-                        oversizedPrompt, schema, StandardTemplates.SUBSCRIBE_INCIDENT));
+                        oversizedPrompt, schema, StandardTemplates.SUBSCRIBE_INCIDENT_URI));
         ContentValidationException authError = assertThrows(
                 ContentValidationException.class,
                 () -> server.validateAuthPromptAndDataFilling(
-                        oversizedPrompt, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT));
+                        oversizedPrompt, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI));
 
         assertEquals(ErrorCatalog.INPUT_TEXT_TOO_LONG.getCode(), taskError.getCode());
         assertEquals(ErrorCatalog.INPUT_TEXT_TOO_LONG.getCode(), notificationError.getCode());

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/TaskPromptNegotiationCoexistenceTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/api/TaskPromptNegotiationCoexistenceTest.java
@@ -13,7 +13,6 @@ import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.NegotiationContext;
 import net.openan.a2at.sdk.core.model.NegotiationPerformative;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 import net.openan.a2at.sdk.llm.LLMClient;
 import net.openan.a2at.sdk.llm.LLMClientConfig;
 import net.openan.a2at.sdk.llm.LLMClientFactory;
@@ -48,9 +47,7 @@ class TaskPromptNegotiationCoexistenceTest {
 
     private static final String UUID = "3dbc13b5-bd57-4c2b-b503-24e381b6c8d3";
 
-    private static final TemplateUri INFORMATION_PROPOSE_TEMPLATE = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE;
-
-    private static final String INFORMATION_PROPOSE_URI = INFORMATION_PROPOSE_TEMPLATE.uri();
+    private static final String INFORMATION_PROPOSE_URI = StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI;
 
     private static final String TASK_T_MESSAGE = "## 任务类型(Task Type)\n"
             + "无线能效优化\n\n"
@@ -78,7 +75,7 @@ class TaskPromptNegotiationCoexistenceTest {
                         TASK_T_MESSAGE,
                         null,
                         Map.of("type", "object", "properties", Map.of("region", Map.of("type", "string"))),
-                        INFORMATION_PROPOSE_TEMPLATE));
+                        INFORMATION_PROPOSE_URI));
 
         assertEquals("negotiation.invalid_input", negotiationFailure.getCode());
         assertEquals("输入的协商内容无效:缺少协商上下文(该报文不是协商报文)", negotiationFailure.getMessage());
@@ -87,7 +84,7 @@ class TaskPromptNegotiationCoexistenceTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 1, 5, NegotiationPerformative.PROPOSE),
                         new InformationProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE_TEMPLATE);
+                INFORMATION_PROPOSE_URI);
         assertEquals(INFORMATION_PROPOSE_URI, negotiationMessage.templateUri());
         assertEquals(UUID, negotiationMessage.negotiationContext().id());
     }
@@ -107,7 +104,7 @@ class TaskPromptNegotiationCoexistenceTest {
                 new NegotiationProposeData(
                         new NegotiationContext(UUID, 2, 5, NegotiationPerformative.PROPOSE),
                         new InformationProposeContent(List.of(new NegotiationItem("节能区域", "松山湖")), null)),
-                INFORMATION_PROPOSE_TEMPLATE);
+                INFORMATION_PROPOSE_URI);
         assertEquals(2, negotiationMessage.negotiationContext().round());
 
         Map<String, Object> startedAgain = server.startNegotiation(NegotiationType.TARGET, "请澄清目标。", Map.of());

--- a/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/validation/AuthorizationContentValidatorTest.java
+++ b/a2a-t-server/src/test/java/net/openan/a2at/sdk/server/validation/AuthorizationContentValidatorTest.java
@@ -43,7 +43,7 @@ class AuthorizationContentValidatorTest {
         String prompt = "新增两条动网操作授权策略：业务投诉诊断/业务抢通/隧道调优/限期生效";
 
         FilledParamData result = assertDoesNotThrow(() -> server.validateAuthPromptAndDataFilling(
-                prompt, schemaMap, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT));
+                prompt, schemaMap, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI));
 
         assertNotNull(result);
         assertEquals(Map.of("授权策略的操作类型", "新增授权策略"), result.data());

--- a/docs/en/API_Reference.md
+++ b/docs/en/API_Reference.md
@@ -44,22 +44,24 @@ The A2A-T SDK exposes exactly two public entry points: the client entry `A2ATCli
 | message | String | Human-readable error description, rendered by the SDK from the message template of the error code and following `A2AT_LANGUAGE` |
 | facts | Map&lt;String, String&gt; | Structured fact values behind the rendered message (e.g. `section_label`, `index`, `field_label`), may be null |
 
-- **TemplateUri:** the template URI value type. Prefer building it with the `net.openan.a2at.sdk.core.model.StandardTemplates` constants; for strings coming from outside the code, parse them with `TemplateUri.parse(String)`, which returns an `Optional<TemplateUri>` and never throws. The currently supported TemplateUri constants are listed below:
+- **Template URI:** the `A2ATClient` and `A2ATServer` facades declare the template selection of every template-specific method as a plain `String templateUri` (e.g. `Task-T/network-layer/private-line-complaint/v1`). Prefer passing the `net.openan.a2at.sdk.core.model.StandardTemplates` String constants (constant name suffixed `_URI`, each with a typed `TemplateUri` twin named without the suffix); strings coming from outside the code are passed directly. The typed value type `TemplateUri` is still used by the lower-level service layer (e.g. `NegotiationContentService`), where it can be obtained with `TemplateUri.parse(String)`, which returns an `Optional<TemplateUri>` and never throws. The currently supported template URI constants (String form) are listed below:
 
 | Constant | Description | TemplateUri |
 | ---- | ---- | ---- |
-| StandardTemplates.ENERGY_SAVING | Task-T energy-saving task template | Task-T/network-layer/ran-energy-saving/v1 |
-| StandardTemplates.PRIVATE_LINE_COMPLAINT | Task-T private-line complaint task template | Task-T/network-layer/private-line-complaint/v1 |
-| StandardTemplates.SUBSCRIBE_INCIDENT | Notification-T incident subscription notification template | Notification-T/network-layer/subscribe-incident/v1 |
-| StandardTemplates.SERVICE_RECOVERY | Notification-T service recovery notification template | Notification-T/network-layer/service-recovery/v1 |
-| StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT | Authorization-T authorization policy management template | Authorization-T/authorization-policy-management/v1 |
-| StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE | Negotiation-T information negotiation propose template | Negotiation-T/information-negotiation/propose/v1 |
-| StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT | Negotiation-T information negotiation accept/reject template | Negotiation-T/information-negotiation/accept-reject/v1 |
-| StandardTemplates.TARGET_NEGOTIATION_PROPOSE | Negotiation-T target negotiation propose template | Negotiation-T/target-negotiation/propose/v1 |
-| StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT | Negotiation-T target negotiation accept/reject template | Negotiation-T/target-negotiation/accept-reject/v1 |
-| StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE | Negotiation-T feasibility negotiation propose template | Negotiation-T/feasibility-negotiation/propose/v1 |
-| StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT | Negotiation-T feasibility negotiation accept/reject template | Negotiation-T/feasibility-negotiation/accept-reject/v1 |
-| StandardTemplates.NEGOTIATION_ABORT | Negotiation-T common negotiation abort template | Negotiation-T/common/abort/v1 |
+| StandardTemplates.ENERGY_SAVING_URI | Task-T energy-saving task template | Task-T/network-layer/ran-energy-saving/v1 |
+| StandardTemplates.PRIVATE_LINE_COMPLAINT_URI | Task-T private-line complaint task template | Task-T/network-layer/private-line-complaint/v1 |
+| StandardTemplates.SUBSCRIBE_INCIDENT_URI | Notification-T incident subscription notification template | Notification-T/network-layer/subscribe-incident/v1 |
+| StandardTemplates.SERVICE_RECOVERY_URI | Notification-T service recovery notification template | Notification-T/network-layer/service-recovery/v1 |
+| StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI | Authorization-T authorization policy management template | Authorization-T/authorization-policy-management/v1 |
+| StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI | Negotiation-T information negotiation propose template | Negotiation-T/information-negotiation/propose/v1 |
+| StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI | Negotiation-T information negotiation accept/reject template | Negotiation-T/information-negotiation/accept-reject/v1 |
+| StandardTemplates.TARGET_NEGOTIATION_PROPOSE_URI | Negotiation-T target negotiation propose template | Negotiation-T/target-negotiation/propose/v1 |
+| StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT_URI | Negotiation-T target negotiation accept/reject template | Negotiation-T/target-negotiation/accept-reject/v1 |
+| StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE_URI | Negotiation-T feasibility negotiation propose template | Negotiation-T/feasibility-negotiation/propose/v1 |
+| StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI | Negotiation-T feasibility negotiation accept/reject template | Negotiation-T/feasibility-negotiation/accept-reject/v1 |
+| StandardTemplates.NEGOTIATION_ABORT_URI | Negotiation-T common negotiation abort template | Negotiation-T/common/abort/v1 |
+
+- **Facade template URI failure policy (both `A2ATClient` and `A2ATServer`):** every facade method that takes a `templateUri` parameter (including `getPrompt`) accepts a raw URI string. A null template URI throws `NullPointerException`; a blank or malformed URI (fewer than three segments, or a segment that is not simple) throws `IllegalArgumentException` with the message `Unparseable template URI: <input>`. This replaces the previous behavior where a null typed template URI on the server task/notification/authorization validate trio threw `ContentValidationException` with the code `negotiation.invalid_input` — such programming errors are now plain JDK exceptions, not part of the `A2ATError` tree.
 
 
 
@@ -76,7 +78,7 @@ The A2A-T SDK exposes exactly two public entry points: the client entry `A2ATCli
 
 ```java
 public MetadataContent generateNegotiationProposePromptFromText(
-        String text, NegotiationContext context, TemplateUri templateUri)
+        String text, NegotiationContext context, String templateUri)
 ```
 
 **Typical scenarios**: after receiving a Task-T task message with missing parameters, the server agent uses natural language to send a "supplement the missing information" negotiation request to the client agent; also applicable when the client agent initiates a target-clarification or feasibility-evaluation request to the server.
@@ -89,7 +91,7 @@ public MetadataContent generateNegotiationProposePromptFromText(
 | ---- | ---- | ---- | ---- |
 | text | String | Yes | Natural-language text describing the negotiation proposal (e.g. the list of missing information items to request); the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
 | context | NegotiationContext | Yes | Negotiation session context, injected directly into the `negotiationContext` metadata of the generated message without going through the LLM |
-| templateUri | TemplateUri | Yes | Propose template, e.g. `StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE` |
+| templateUri | String | Yes | Propose template, e.g. `StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI` |
 
 **Request Example**
 
@@ -110,7 +112,7 @@ MetadataContent propose = client.generateNegotiationProposePromptFromText(
         "Please provide the following missing information: complaint category: private line interruption or poor private line quality. "
                 + "Both parameters are required; diagnosis cannot start without them.",
         ctx,
-        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI);
 
 // The generated metadata travels with the A2A message
 Map<String, Object> metadata = propose.buildMetadataContent();
@@ -150,7 +152,7 @@ Error codes:
 
 - `negotiation.field_missing` (a required field is missing)
 
-A null argument throws `NullPointerException`; a templateUri whose phase segment is not `propose` throws `IllegalArgumentException`.
+A null argument throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1) or a templateUri whose phase segment is not `propose` throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -171,7 +173,7 @@ Please supplement the relevant content based on <Required Information Items>.
 
 ```java
 public MetadataContent generateNegotiationAcceptPromptFromText(
-        String text, NegotiationContext context, TemplateUri templateUri)
+        String text, NegotiationContext context, String templateUri)
 ```
 
 **Typical scenarios**: after receiving the peer's information-negotiation request, the negotiation responder (usually the client agent) supplements/delivers the requested information in natural language and generates an accept message to return, e.g. confirming that diagnosis can start after supplementing the access port name and complaint category.
@@ -184,7 +186,7 @@ public MetadataContent generateNegotiationAcceptPromptFromText(
 | ---- | ---- | ---- | ---- |
 | text | String | Yes | Natural-language text describing the acceptance (e.g. the list of supplemented/delivered information items); the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
 | context | NegotiationContext | Yes | Negotiation session context |
-| templateUri | TemplateUri | Yes | Accept-reject template, e.g. `StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT` |
+| templateUri | String | Yes | Accept-reject template, e.g. `StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI` |
 
 **Request Example**
 
@@ -194,7 +196,7 @@ MetadataContent accept = client.generateNegotiationAcceptPromptFromText(
                 + "2. Complaint category: dedicated-line quality degradation. "
                 + "The information is complete and diagnosis can start.",
         ctx,
-        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **Output**
@@ -235,7 +237,7 @@ Accept
 
 ```java
 public MetadataContent generateNegotiationRejectPromptFromText(
-        String text, NegotiationContext context, TemplateUri templateUri)
+        String text, NegotiationContext context, String templateUri)
 ```
 
 **Typical scenarios**: when the negotiation responder (usually the client agent) cannot satisfy the peer's negotiation request, it generates a reject message in natural language to return and end the current negotiation round, e.g. the access port name cannot be provided because the site inventory is unavailable.
@@ -250,7 +252,7 @@ public MetadataContent generateNegotiationRejectPromptFromText(
 MetadataContent reject = client.generateNegotiationRejectPromptFromText(
         "I refuse to supplement the information: the access port name cannot be provided because the site inventory is unavailable. This negotiation is over.",
         ctx,
-        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **Output**
@@ -290,7 +292,7 @@ Reject
 
 ```java
 public MetadataContent generateNegotiationProposePromptFromData(
-        NegotiationProposeData data, TemplateUri templateUri)
+        NegotiationProposeData data, String templateUri)
 ```
 
 **Typical scenarios**: the same initiation scenarios as the fromText variant, but the input is structured data constructed by the business system (e.g. the server agent automatically generates the negotiation-request items from the missing-slot list detected by `validateTaskPromptAndDataFilling`), suitable for scenarios that require deterministic message content and want to avoid the nondeterminism of LLM extraction.
@@ -302,7 +304,7 @@ public MetadataContent generateNegotiationProposePromptFromData(
 | Parameter | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | data | `NegotiationProposeData(context, content)` | Yes | Negotiation context plus typed propose content; the content type depends on the negotiation type |
-| templateUri | TemplateUri | Yes | Propose template |
+| templateUri | String | Yes | Propose template |
 
 Propose content of the three negotiation types:
 
@@ -334,7 +336,7 @@ MetadataContent propose = client.generateNegotiationProposePromptFromData(
                                 new NegotiationItem("Complaint Category", "e.g. dedicated-line quality degradation"),
                                 new NegotiationItem("Private Line Service Identifier", null)),
                         "OR")),
-        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI);
 ```
 
 **Output**
@@ -347,9 +349,9 @@ On failure, throws `NegotiationGenerationException` (structure same as 1.3.1). E
 
 - `negotiation.content_invalid` (a typed content field is invalid, e.g. blank required items or a blank required description)
 
-- `negotiation.field_missing` (a required field is missing during rendering)
+- `template.render_failed` (template rendering failure)
 
-There are also two categories of programming errors (outside the `A2ATError` tree, standard JDK exceptions): a null argument or a null context within it throws `NullPointerException`; a content type that does not match the template's negotiation type, or a phase segment that is not `propose`, throws `IllegalArgumentException`.
+There are also two categories of programming errors (outside the `A2ATError` tree, standard JDK exceptions): a null argument or a null context within it throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1), a content type that does not match the template's negotiation type, or a phase segment that is not `propose`, throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -373,7 +375,7 @@ Relationship between missing items: OR
 
 ```java
 public MetadataContent generateNegotiationAcceptPromptFromData(
-        NegotiationEndingData data, TemplateUri templateUri)
+        NegotiationEndingData data, String templateUri)
 ```
 
 **Typical scenarios**: the negotiation responder (usually the client agent) programmatically fills in the parameters per the peer's requested slot list and generates an accept message from structured items to return.
@@ -385,7 +387,7 @@ public MetadataContent generateNegotiationAcceptPromptFromData(
 | Parameter | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | data | `NegotiationEndingData(context, content)` | Yes | Negotiation context plus typed accept content (conclusion is `ACCEPT`) |
-| templateUri | TemplateUri | Yes | Accept-reject template |
+| templateUri | String | Yes | Accept-reject template |
 
 Accept content of the three negotiation types: `InformationEndingContent(ACCEPT, items)` (list of delivered information items), `TargetEndingContent(ACCEPT, confirmedIntent, null)` (finally confirmed intent), `FeasibilityEndingContent(ACCEPT, feasibilitySummary)` (feasibility assessment conclusion summary).
 
@@ -404,7 +406,7 @@ MetadataContent accept = client.generateNegotiationAcceptPromptFromData(
                         List.of(
                                 new NegotiationItem("Access Port Name", "P533-Zhujiang Old Town-PTN3900-23-TPA1EG24-1"),
                                 new NegotiationItem("Complaint Category", "dedicated-line quality degradation")))),
-        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **Output**
@@ -417,9 +419,9 @@ On failure, throws `NegotiationGenerationException` (structure same as 1.3.1). E
 
 - `negotiation.content_invalid` (a typed content field is invalid, e.g. blank required items or a blank required description)
 
-- `negotiation.field_missing` (a required field is missing during rendering)
+- `template.render_failed` (template rendering failure)
 
-Programming errors: a null argument or a null context within it throws `NullPointerException`; a mismatched content type or a phase segment that is not `accept-reject` throws `IllegalArgumentException`. A `conclusion` that is not `ACCEPT` is rejected with the `negotiation.conclusion_mismatch` business error.
+Programming errors: a null argument or a null context within it throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1), a mismatched content type or a phase segment that is not `accept-reject` throws `IllegalArgumentException`; a `conclusion` that is not `ACCEPT` is rejected with the `negotiation.conclusion_mismatch` business error.
 
 **Response Example**
 
@@ -441,7 +443,7 @@ Accept
 
 ```java
 public MetadataContent generateNegotiationRejectPromptFromData(
-        NegotiationEndingData data, TemplateUri templateUri)
+        NegotiationEndingData data, String templateUri)
 ```
 
 **Typical scenarios**: the negotiation responder, after programmatically determining that the peer's request cannot be satisfied, generates a reject message from structured items (the items that cannot be provided and the reasons) to return.
@@ -459,7 +461,7 @@ MetadataContent reject = client.generateNegotiationRejectPromptFromData(
                 new InformationEndingContent(
                         NegotiationConclusion.REJECT,
                         List.of(new NegotiationItem("Access Port Name", "cannot be provided because the port inventory is temporarily unavailable on the workbench side")))),
-        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **Output**
@@ -472,9 +474,9 @@ On failure, throws `NegotiationGenerationException` (structure same as 1.3.1). E
 
 - `negotiation.content_invalid` (a typed content field is invalid, e.g. blank required items or a blank required description)
 
-- `negotiation.field_missing` (a required field is missing during rendering)
+- `template.render_failed` (template rendering failure)
 
-Programming errors: a null argument or a null context within it throws `NullPointerException`; a mismatched content type or a phase segment that is not `accept-reject` throws `IllegalArgumentException`. A `conclusion` that is not `REJECT` is rejected with the `negotiation.conclusion_mismatch` business error.
+Programming errors: a null argument or a null context within it throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1), a mismatched content type or a phase segment that is not `accept-reject` throws `IllegalArgumentException`; a `conclusion` that is not `REJECT` is rejected with the `negotiation.conclusion_mismatch` business error.
 
 **Response Example**
 
@@ -495,7 +497,7 @@ Reject
 
 ```java
 public FilledParamData validateProposePromptAndDataFilling(
-        String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, NegotiationContext context, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: an outbound self-check by the initiator (server agent) before sending a negotiation request; or the receiver (client agent) validating an inbound negotiation request and extracting the list of slots to supplement, driving the subsequent parameter filling.
@@ -509,7 +511,7 @@ public FilledParamData validateProposePromptAndDataFilling(
 | prompt | String | Yes | Negotiation propose message text to validate (`MetadataContent.promptText()`); the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
 | context | NegotiationContext | Yes | Negotiation context traveling with the message; a null value is reported as `negotiation.invalid_input` |
 | schema | Map&lt;String, Object&gt; | Yes | Caller-provided parameter JSON Schema declaring the parameters to extract |
-| templateUri | TemplateUri | Yes | Propose template |
+| templateUri | String | Yes | Propose template |
 
 **Request Example**
 
@@ -532,7 +534,7 @@ Map<String, Object> schema = Map.of(
 
 // proposePrompt is the negotiation propose message text sent by the peer
 FilledParamData requested = client.validateProposePromptAndDataFilling(
-        proposePrompt, ctx, schema, StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+        proposePrompt, ctx, schema, StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI);
 
 // After filtering out the context parameters (id/round/maxRounds), the remaining keys
 // are the slots to supplement
@@ -559,9 +561,7 @@ Error codes:
 
 - `negotiation.invalid_input` (the message is not a negotiation message, or the context is null)
 
-- `negotiation.invalid_context_id` (the context id is not a valid UUID)
-
-- `negotiation.round_exceeded` (the context round exceeds the configured maximum)
+- `negotiation.rule_violation` (the negotiation context violates a rule; the nested slot error codes in `getErrors()` identify the concrete rule, e.g. `negotiation.invalid_context_id`, `negotiation.round_exceeded`)
 
 - `negotiation.semantic_rejected` (semantic validation rejected the message; the per-slot details in `getErrors()` use the closed `negotiation.*` code set, e.g. `negotiation.conclusion_content_mismatch`, `negotiation.missing_result_content`, `negotiation.field_inconsistency`)
 
@@ -569,7 +569,7 @@ Error codes:
 
 - `template.not_found` (validation prompt resources missing)
 
-Programming errors: a null prompt or schema throws `NullPointerException`; a blank prompt or a mismatched phase segment throws `IllegalArgumentException`.
+Programming errors: a null prompt, schema or templateUri throws `NullPointerException`; a blank prompt, a blank or malformed templateUri (see the facade failure policy in 1.1), or a mismatched phase segment throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -590,7 +590,7 @@ requested.data() =
 
 ```java
 public FilledParamData validateAcceptPromptAndDataFilling(
-        String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, NegotiationContext context, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: the initiator (server agent) validates the accept message returned by the peer, extracts the delivered parameter values, and cross-checks them against the expected fill values before continuing task execution.
@@ -609,7 +609,7 @@ A2ATServer server = new A2ATServer(Path.of("server.env"));
 // acceptPrompt is the accept message text returned by the client;
 // acceptContext is its negotiation context
 FilledParamData acceptParams = server.validateAcceptPromptAndDataFilling(
-        acceptPrompt, acceptContext, schema, StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        acceptPrompt, acceptContext, schema, StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **Output**
@@ -620,7 +620,7 @@ On failure, throws `NegotiationParamExtractionException` (structure same as 1.3.
 
 - `negotiation.invalid_input` (the message is not an accept negotiation message, or the context is null)
 
-- `negotiation.invalid_context_id` / `negotiation.round_exceeded` (the negotiation context violates a structural rule)
+- `negotiation.rule_violation` (the negotiation context violates a rule; the nested slot error codes in `getErrors()` identify the concrete rule, e.g. `negotiation.invalid_context_id`, `negotiation.round_exceeded`)
 
 - `negotiation.semantic_rejected` (the conclusion is not Accept, or the content does not satisfy the accept-phase constraints)
 
@@ -628,7 +628,7 @@ On failure, throws `NegotiationParamExtractionException` (structure same as 1.3.
 
 - `template.not_found` (validation prompt resources missing)
 
-Programming errors: a null prompt or schema throws `NullPointerException`; a blank prompt or a phase segment that is not `accept-reject` throws `IllegalArgumentException`.
+Programming errors: a null prompt, schema or templateUri throws `NullPointerException`; a blank prompt, a blank or malformed templateUri (see the facade failure policy in 1.1), or a phase segment that is not `accept-reject` throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -649,7 +649,7 @@ acceptParams.data() =
 
 ```java
 public FilledParamData validateRejectPromptAndDataFilling(
-        String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, NegotiationContext context, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: the initiator (server agent) validates the reject message returned by the peer, extracts the rejection reason, and terminates the task or escalates to manual handling accordingly.
@@ -662,7 +662,7 @@ public FilledParamData validateRejectPromptAndDataFilling(
 
 ```java
 FilledParamData rejectParams = server.validateRejectPromptAndDataFilling(
-        rejectPrompt, ctx, schema, StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        rejectPrompt, ctx, schema, StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **Output**
@@ -673,7 +673,7 @@ On failure, throws `NegotiationParamExtractionException` (structure same as 1.3.
 
 - `negotiation.invalid_input` (the message is not a reject negotiation message, or the context is null)
 
-- `negotiation.invalid_context_id` / `negotiation.round_exceeded` (the negotiation context violates a structural rule)
+- `negotiation.rule_violation` (the negotiation context violates a rule; the nested slot error codes in `getErrors()` identify the concrete rule, e.g. `negotiation.invalid_context_id`, `negotiation.round_exceeded`)
 
 - `negotiation.semantic_rejected` (the conclusion is not Reject, or the content does not satisfy the reject-phase constraints)
 
@@ -681,7 +681,7 @@ On failure, throws `NegotiationParamExtractionException` (structure same as 1.3.
 
 - `template.not_found` (validation prompt resources missing)
 
-Programming errors: a null prompt or schema throws `NullPointerException`; a blank prompt or a phase segment that is not `accept-reject` throws `IllegalArgumentException`.
+Programming errors: a null prompt, schema or templateUri throws `NullPointerException`; a blank prompt, a blank or malformed templateUri (see the facade failure policy in 1.1), or a phase segment that is not `accept-reject` throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -700,7 +700,7 @@ rejectParams.data() =
 **API Definition**
 
 ```java
-public MetadataContent generateTaskPromptFromText(String text, TemplateUri templateUri)
+public MetadataContent generateTaskPromptFromText(String text, String templateUri)
 ```
 
 **Typical scenarios**: the client agent converts the user's natural-language task description (e.g. a private-line complaint diagnosis request) into a Task-T protocol message for a specified scenario; suitable when the target template is already known and scenario recognition should be skipped.
@@ -712,7 +712,7 @@ public MetadataContent generateTaskPromptFromText(String text, TemplateUri templ
 | Parameter | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | text | String | Yes | Natural-language task description; the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
-| templateUri | TemplateUri | Yes | Task-T template, e.g. `StandardTemplates.PRIVATE_LINE_COMPLAINT` (`Task-T/network-layer/private-line-complaint/v1`) |
+| templateUri | String | Yes | Task-T template, e.g. `StandardTemplates.PRIVATE_LINE_COMPLAINT_URI` (`Task-T/network-layer/private-line-complaint/v1`) |
 
 **Request Example**
 
@@ -729,7 +729,7 @@ MetadataContent metadata = client.generateTaskPromptFromText(
                 + "the customer reports poor private line quality. Starting from 8:30 AM on May 11, 2026, accessing the core "
                 + "systems in Guangzhou from Shenzhen has been extremely slow, latency jumped from 12ms to 320ms, the counter "
                 + "and mobile banking keep reporting connection timeouts, and the OSS sequence number is event-id-20260511-09013.",
-        StandardTemplates.PRIVATE_LINE_COMPLAINT);
+        StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
 ```
 
 **Output**
@@ -772,7 +772,7 @@ Error codes:
 
 - `input.text_too_long` (input longer than `A2AT_INPUT_TEXT_MAX_CHARS`)
 
-Programming errors: a null text or templateUri throws `NullPointerException`.
+Programming errors: a null text or templateUri throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1) throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -812,7 +812,7 @@ Requirement: The complaint diagnosis task result should include the following in
 
 ```java
 public MetadataContent generateTaskPromptFromDataWithSchema(
-        Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+        Map<String, Object> data, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: the client agent converts structured task parameters from an upstream system (field names may differ from the template slots; the schema describes the field semantics) into a Task-T protocol message; suitable when the task parameters are already available in structured form.
@@ -825,7 +825,7 @@ public MetadataContent generateTaskPromptFromDataWithSchema(
 | ---- | ---- | ---- | ---- |
 | data | Map&lt;String, Object&gt; | Yes | Structured business-field input; keys are business field names and values are field values |
 | schema | Map&lt;String, Object&gt; | Yes (non-empty) | Field-semantics JSON Schema describing the meaning and constraints of each field |
-| templateUri | TemplateUri | Yes | Task-T template |
+| templateUri | String | Yes | Task-T template |
 
 **Request Example**
 
@@ -855,14 +855,14 @@ Map<String, Object> semanticsSchema = Map.of(
         "required", List.of("portName", "complaintScenario"));
 
 MetadataContent metadata = client.generateTaskPromptFromDataWithSchema(
-        data, semanticsSchema, StandardTemplates.PRIVATE_LINE_COMPLAINT);
+        data, semanticsSchema, StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
 ```
 
 **Output**
 
 On success, returns `MetadataContent` (structure same as [1.3.10](#1310-generatetaskpromptfromtext)).
 
-On failure, throws `PromptGenerationException` (structure same as 1.3.10). Programming errors: a null argument throws `NullPointerException`; an empty schema map throws `IllegalArgumentException`.
+On failure, throws `PromptGenerationException` (structure same as 1.3.10). Programming errors: a null argument throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1) or an empty schema map throws `IllegalArgumentException`.
 
 **Response Example** (same template as 1.3.10; slot values come from the structured input, and `faultDetail` is a truncated sample value)
 
@@ -902,7 +902,7 @@ Requirement: The complaint diagnosis task result should include the following in
 
 ```java
 public FilledParamData validateTaskPromptAndDataFilling(
-        String prompt, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: the parameter validation and extraction entry point for the server agent after receiving a Task-T message and before business execution; also the decision point for "missing-slot detection" in the negotiation flow — when a required parameter is missing, the caller decides whether to initiate a negotiation to supplement it.
@@ -915,7 +915,7 @@ public FilledParamData validateTaskPromptAndDataFilling(
 | ---- | ---- | ---- | ---- |
 | prompt | String | Yes (non-blank) | Task prompt message text to validate (`MetadataContent.promptText()`); the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
 | schema | Map&lt;String, Object&gt; | Yes | Caller-provided parameter JSON Schema declaring the parameters to extract/validate and the required constraints |
-| templateUri | TemplateUri | Yes | Task-T template (the prefix segment must be `Task-T`) |
+| templateUri | String | Yes | Task-T template (the prefix segment must be `Task-T`) |
 
 **Request Example**
 
@@ -943,7 +943,7 @@ Map<String, Object> validationSchema = Map.of(
 
 Map<String, Object> extracted = server
         .validateTaskPromptAndDataFilling(
-                metadata.promptText(), validationSchema, StandardTemplates.PRIVATE_LINE_COMPLAINT)
+                metadata.promptText(), validationSchema, StandardTemplates.PRIVATE_LINE_COMPLAINT_URI)
         .data();
 ```
 
@@ -974,7 +974,7 @@ Error codes:
 
 - `input.text_too_long` (prompt longer than `A2AT_INPUT_TEXT_MAX_CHARS`)
 
-Programming errors: a null prompt / schema / templateUri throws `NullPointerException`; a blank prompt throws `IllegalArgumentException`.
+Programming errors: a null prompt / schema / templateUri throws `NullPointerException`; a blank prompt or a blank or malformed templateUri (see the facade failure policy in 1.1) throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -1001,7 +1001,7 @@ ContentValidationException: [negotiation.semantic_rejected] ...
 **API Definition**
 
 ```java
-public MetadataContent generateNotificationPromptFromText(String text, TemplateUri templateUri)
+public MetadataContent generateNotificationPromptFromText(String text, String templateUri)
 ```
 
 **Typical scenarios**: the client agent converts a natural-language subscription requirement (e.g. a service recovery event subscription) into a Notification-T subscription message for a specified scenario.
@@ -1013,7 +1013,7 @@ public MetadataContent generateNotificationPromptFromText(String text, TemplateU
 | Parameter | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | text | String | Yes | Natural-language subscription description (notification topic, subscribe condition, notification data format, etc.); the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
-| templateUri | TemplateUri | Yes | Notification-T template, e.g. `StandardTemplates.SUBSCRIBE_INCIDENT`, `StandardTemplates.SERVICE_RECOVERY` |
+| templateUri | String | Yes | Notification-T template, e.g. `StandardTemplates.SUBSCRIBE_INCIDENT_URI`, `StandardTemplates.SERVICE_RECOVERY_URI` |
 
 **Request Example**
 
@@ -1022,10 +1022,9 @@ import java.nio.file.Path;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
 A2ATClient client = new A2ATClient(Path.of("client.env"));
-TemplateUri templateUri = TemplateUri.parse("Notification-T/network-layer/service-recovery/v1").orElseThrow();
+String templateUri = StandardTemplates.SERVICE_RECOVERY_URI;
 
 MetadataContent result = client.generateNotificationPromptFromText(
         "I want to subscribe to service recovery events. The notification data format is as follows: "
@@ -1040,7 +1039,7 @@ MetadataContent result = client.generateNotificationPromptFromText(
 
 On success, returns `MetadataContent` (structure same as [1.3.10](#1310-generatetaskpromptfromtext); `extensionUri` is `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1`).
 
-On failure, throws `PromptGenerationException` (structure same as 1.3.10). Programming errors: a null text or templateUri throws `NullPointerException`.
+On failure, throws `PromptGenerationException` (structure same as 1.3.10). Programming errors: a null text or templateUri throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1) throws `IllegalArgumentException`.
 
 **Response Example** (rendered per the template; the actual text varies with the LLM slot-extraction result. This example input does not specify a subscribe condition, so that slot is left empty)
 
@@ -1079,7 +1078,7 @@ Service recovery event
 
 ```java
 public MetadataContent generateNotificationPromptFromDataWithSchema(
-        Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+        Map<String, Object> data, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: the client agent converts structured subscription parameters submitted by an upstream system or UI into a Notification-T subscription message; suitable when the subscription parameters are already available in structured form.
@@ -1092,7 +1091,7 @@ public MetadataContent generateNotificationPromptFromDataWithSchema(
 | ---- | ---- | ---- | ---- |
 | data | Map&lt;String, Object&gt; | Yes | Structured subscription input (e.g. the subscribe condition and the notification data format field list) |
 | schema | Map&lt;String, Object&gt; | Yes (non-empty) | Field-semantics JSON Schema |
-| templateUri | TemplateUri | Yes | Notification-T template |
+| templateUri | String | Yes | Notification-T template |
 
 **Request Example**
 
@@ -1133,7 +1132,7 @@ MetadataContent result = client.generateNotificationPromptFromDataWithSchema(
 
 On success, returns `MetadataContent` (structure same as [1.3.10](#1310-generatetaskpromptfromtext); `extensionUri` is `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1`).
 
-On failure, throws `PromptGenerationException` (structure same as 1.3.10). Programming errors: a null argument throws `NullPointerException`; an empty schema map throws `IllegalArgumentException`.
+On failure, throws `PromptGenerationException` (structure same as 1.3.10). Programming errors: a null argument throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1) or an empty schema map throws `IllegalArgumentException`.
 
 **Response Example** (same template as 1.3.13; slot values come from the structured input: `Subscribe Condition` is filled with `condition`, and `Notification Data Format` is rendered per the `reportFormat` list — field layout is illustrative)
 
@@ -1173,7 +1172,7 @@ Subnetwork name: xx subnetwork (optional)
 
 ```java
 public FilledParamData validateNotificationPromptAndDataFilling(
-        String prompt, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: the server agent validates a received Notification-T subscription message, extracts the subscription parameters (topic/condition/report format), and establishes the subscription accordingly.
@@ -1186,7 +1185,7 @@ public FilledParamData validateNotificationPromptAndDataFilling(
 | ---- | ---- | ---- | ---- |
 | prompt | String | Yes (non-blank) | Notification subscription prompt message text to validate; the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
 | schema | Map&lt;String, Object&gt; | Yes | Caller-provided parameter JSON Schema |
-| templateUri | TemplateUri | Yes | Notification-T template (the prefix segment must be `Notification-T`) |
+| templateUri | String | Yes | Notification-T template (the prefix segment must be `Notification-T`) |
 
 **Request Example**
 
@@ -1224,7 +1223,7 @@ On failure, throws `ContentValidationException` (structure same as 1.3.12). Erro
 
 - `input.text_too_long` (prompt longer than `A2AT_INPUT_TEXT_MAX_CHARS`)
 
-Programming errors: a null prompt / schema / templateUri throws `NullPointerException`; a blank prompt throws `IllegalArgumentException`.
+Programming errors: a null prompt / schema / templateUri throws `NullPointerException`; a blank prompt or a blank or malformed templateUri (see the facade failure policy in 1.1) throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -1242,7 +1241,7 @@ result.data() =
 **API Definition**
 
 ```java
-public MetadataContent generateAuthPromptFromText(String text, TemplateUri templateUri)
+public MetadataContent generateAuthPromptFromText(String text, String templateUri)
 ```
 
 **Typical scenarios**: the client agent converts a natural-language authorization request (add/modify/delete/query network operation authorization policies) into an Authorization-T message.
@@ -1254,7 +1253,7 @@ public MetadataContent generateAuthPromptFromText(String text, TemplateUri templ
 | Parameter | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | text | String | Yes | Natural-language authorization description (operation type + network operation authorization policy content); the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
-| templateUri | TemplateUri | Yes | Authorization-T template: `StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT` (`Authorization-T/authorization-policy-management/v1`) |
+| templateUri | String | Yes | Authorization-T template: `StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI` (`Authorization-T/authorization-policy-management/v1`) |
 
 **Request Example**
 
@@ -1268,14 +1267,14 @@ A2ATClient client = new A2ATClient(Path.of("client.env"));
 
 MetadataContent result = client.generateAuthPromptFromText(
         "Add an authorization for the campus private network, use service recovery for handling, do a tunnel optimization, and leave the validity period to be filled in later",
-        StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT);
+        StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
 ```
 
 **Output**
 
 On success, returns `MetadataContent` (structure same as [1.3.10](#1310-generatetaskpromptfromtext); `extensionUri` is `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Authorization-T/v1`).
 
-On failure, throws `PromptGenerationException` (structure same as 1.3.10); for example, an operation type outside the "add/modify/delete/query authorization policy" range is rejected with `slot.constraint_violated`. Programming errors: a null text or templateUri throws `NullPointerException`.
+On failure, throws `PromptGenerationException` (structure same as 1.3.10); for example, an operation type outside the "add/modify/delete/query authorization policy" range is rejected with `slot.constraint_violated`. Programming errors: a null text or templateUri throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1) throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -1304,7 +1303,7 @@ campus private network, service recovery, tunnel optimization
 
 ```java
 public MetadataContent generateAuthPromptFromDataWithSchema(
-        Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+        Map<String, Object> data, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: the client agent converts structured authorization policy data submitted field by field by an authorization management UI or system into an Authorization-T message.
@@ -1317,7 +1316,7 @@ public MetadataContent generateAuthPromptFromDataWithSchema(
 | ---- | ---- | ---- | ---- |
 | data | Map&lt;String, Object&gt; | Yes | Structured authorization input (operation type, policy count, policy detail list, etc.) |
 | schema | Map&lt;String, Object&gt; | Yes (non-empty) | Field-semantics JSON Schema |
-| templateUri | TemplateUri | Yes | Authorization-T template |
+| templateUri | String | Yes | Authorization-T template |
 
 **Request Example**
 
@@ -1353,14 +1352,14 @@ Map<String, Object> schema = Map.of(
                                         "validityPeriod", Map.of("type", "string"))))));
 
 MetadataContent result = client.generateAuthPromptFromDataWithSchema(
-        data, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT);
+        data, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
 ```
 
 **Output**
 
 On success, returns `MetadataContent` (structure same as [1.3.10](#1310-generatetaskpromptfromtext); `extensionUri` is `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Authorization-T/v1`).
 
-On failure, throws `PromptGenerationException` (structure same as 1.3.10). Programming errors: a null argument throws `NullPointerException`; an empty schema map throws `IllegalArgumentException`.
+On failure, throws `PromptGenerationException` (structure same as 1.3.10). Programming errors: a null argument throws `NullPointerException`; a blank or malformed templateUri (see the facade failure policy in 1.1) or an empty schema map throws `IllegalArgumentException`.
 
 **Response Example**
 
@@ -1389,7 +1388,7 @@ campus private network, service recovery, tunnel optimization, permanently valid
 
 ```java
 public FilledParamData validateAuthPromptAndDataFilling(
-        String prompt, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, Map<String, Object> schema, String templateUri)
 ```
 
 **Typical scenarios**: the server agent validates a received Authorization-T message, extracts the operation type and policy list, and performs the authorization policy management action accordingly.
@@ -1402,7 +1401,7 @@ public FilledParamData validateAuthPromptAndDataFilling(
 | ---- | ---- | ---- | ---- |
 | prompt | String | Yes (non-blank) | Authorization prompt message text to validate; the input length is limited by the `A2AT_INPUT_TEXT_MAX_CHARS` configuration item, default 16384 |
 | schema | Map&lt;String, Object&gt; | Yes | Caller-provided parameter JSON Schema (containing `operationType`, `policyList`, etc.) |
-| templateUri | TemplateUri | Yes | Authorization-T template (the prefix segment must be `Authorization-T`) |
+| templateUri | String | Yes | Authorization-T template (the prefix segment must be `Authorization-T`) |
 
 **Request Example**
 
@@ -1417,7 +1416,7 @@ Map<String, Object> paramSchema = MAPPER.readValue(
 // (array whose entries carry policyId/businessScenario/handlingType/operationName/validityPeriod)
 
 FilledParamData result = server.validateAuthPromptAndDataFilling(
-        metadata.promptText(), paramSchema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT);
+        metadata.promptText(), paramSchema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
 ```
 
 **Output**
@@ -1434,7 +1433,7 @@ On failure, throws `ContentValidationException` (structure same as 1.3.12). Erro
 
 - `input.text_too_long` (prompt longer than `A2AT_INPUT_TEXT_MAX_CHARS`)
 
-Programming errors: a null prompt / schema / templateUri throws `NullPointerException`; a blank prompt throws `IllegalArgumentException`.
+Programming errors: a null prompt / schema / templateUri throws `NullPointerException`; a blank prompt or a blank or malformed templateUri (see the facade failure policy in 1.1) throws `IllegalArgumentException`.
 
 **Response Example**
 

--- a/docs/en/developer_guide.md
+++ b/docs/en/developer_guide.md
@@ -1657,16 +1657,16 @@ For example, when the local file is `<local resource root>/templates/Task-T/netw
 
 ```java
 import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
-// Construction: parse the raw URI string
-TemplateUri templateUri = TemplateUri.parse("Task-T/network-layer/site-inspection/v1").orElseThrow();
-
+// The facade takes the raw URI string directly
 MetadataContent metadata = client.generateTaskPromptFromText(
-        "Please perform an on-site inspection of station xx, focusing on alarms and performance metrics", templateUri);
+        "Please perform an on-site inspection of station xx, focusing on alarms and performance metrics",
+        "Task-T/network-layer/site-inspection/v1");
 ```
 
-To override a built-in template (e.g. `StandardTemplates.PRIVATE_LINE_COMPLAINT`), place `template.md` and `slot.json` at the same relative path under the local root directory and keep using the original constant in the code. Note that in `local_file` mode business templates are read only from the local root directory without classpath fallback; when the file for a `templateUri` is missing, the API throws `PromptGenerationException` with the error code `template.not_found`.
+Facade failure policy for `templateUri`: a null template URI throws `NullPointerException`; a blank or malformed URI (fewer than three segments, or a segment that is not simple) throws `IllegalArgumentException` with the message `Unparseable template URI: <input>`.
+
+To override a built-in template (e.g. `StandardTemplates.PRIVATE_LINE_COMPLAINT_URI`), place `template.md` and `slot.json` at the same relative path under the local root directory and keep using the original constant in the code. Note that in `local_file` mode business templates are read only from the local root directory without classpath fallback; when the file for a `templateUri` is missing, the API throws `PromptGenerationException` with the error code `template.not_found`.
 
 #### Step4 Verification and troubleshooting
 

--- a/docs/zh/API参考.md
+++ b/docs/zh/API参考.md
@@ -44,22 +44,24 @@ A2A-T SDK 对外仅提供两个入口：客户端入口 `A2ATClient`（提示词
 | message | String | 人类可读的错误说明，由 SDK 按错误码的消息模板渲染，语言跟随 `A2AT_LANGUAGE`                                                                         |
 | facts | Map&lt;String, String&gt; | 渲染消息所依据的结构化事实值（如 `section_label`、`index`、`field_label`），可为 null                                                          |
 
-- **TemplateUri：** 模板 URI 值类型，推荐用 `net.openan.a2at.sdk.core.model.StandardTemplates` 常量构造；来自外部的字符串用 `TemplateUri.parse(String)` 解析，返回 `Optional<TemplateUri>` 且不抛异常，当前支持的TemplateUri常量如下：
+- **模板 URI：** `A2ATClient` 与 `A2ATServer` 门面上所有指定模板的方法均以 `String templateUri`（如 `Task-T/network-layer/private-line-complaint/v1`）声明模板选择，推荐直接传 `net.openan.a2at.sdk.core.model.StandardTemplates` 的 String 常量（常量名以 `_URI` 结尾，每个都有去掉后缀的同名 `TemplateUri` 类型化孪生常量）；来自外部的字符串直接传入即可。类型 `TemplateUri` 仍用于底层服务层（如 `NegotiationContentService`），可用 `TemplateUri.parse(String)` 解析，返回 `Optional<TemplateUri>` 且不抛异常。当前支持的模板 URI 常量（String 形态）如下：
 
 | 常量名称 | 含义 | TemplateUri |
 | ---- | ---- | ---- |
-| StandardTemplates.ENERGY_SAVING | Task-T 节能任务模板 | Task-T/network-layer/ran-energy-saving/v1 |
-| StandardTemplates.PRIVATE_LINE_COMPLAINT | Task-T 专线投诉任务模板 | Task-T/network-layer/private-line-complaint/v1 |
-| StandardTemplates.SUBSCRIBE_INCIDENT | Notification-T 事件订阅通知模板 | Notification-T/network-layer/subscribe-incident/v1 |
-| StandardTemplates.SERVICE_RECOVERY | Notification-T 业务抢通通知模板 | Notification-T/network-layer/service-recovery/v1 |
-| StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT | Authorization-T 授权策略管理模板 | Authorization-T/authorization-policy-management/v1 |
-| StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE | Negotiation-T 信息协商意图发起模板 | Negotiation-T/information-negotiation/propose/v1 |
-| StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT | Negotiation-T 信息协商接受/拒绝模板 | Negotiation-T/information-negotiation/accept-reject/v1 |
-| StandardTemplates.TARGET_NEGOTIATION_PROPOSE | Negotiation-T 目标协商意图发起模板 | Negotiation-T/target-negotiation/propose/v1 |
-| StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT | Negotiation-T 目标协商接受/拒绝模板 | Negotiation-T/target-negotiation/accept-reject/v1 |
-| StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE | Negotiation-T 可行性协商意图发起模板 | Negotiation-T/feasibility-negotiation/propose/v1 |
-| StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT | Negotiation-T 可行性协商接受/拒绝模板 | Negotiation-T/feasibility-negotiation/accept-reject/v1 |
-| StandardTemplates.NEGOTIATION_ABORT | Negotiation-T 协商中止通用模板 | Negotiation-T/common/abort/v1 |
+| StandardTemplates.ENERGY_SAVING_URI | Task-T 节能任务模板 | Task-T/network-layer/ran-energy-saving/v1 |
+| StandardTemplates.PRIVATE_LINE_COMPLAINT_URI | Task-T 专线投诉任务模板 | Task-T/network-layer/private-line-complaint/v1 |
+| StandardTemplates.SUBSCRIBE_INCIDENT_URI | Notification-T 事件订阅通知模板 | Notification-T/network-layer/subscribe-incident/v1 |
+| StandardTemplates.SERVICE_RECOVERY_URI | Notification-T 业务抢通通知模板 | Notification-T/network-layer/service-recovery/v1 |
+| StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI | Authorization-T 授权策略管理模板 | Authorization-T/authorization-policy-management/v1 |
+| StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI | Negotiation-T 信息协商意图发起模板 | Negotiation-T/information-negotiation/propose/v1 |
+| StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI | Negotiation-T 信息协商接受/拒绝模板 | Negotiation-T/information-negotiation/accept-reject/v1 |
+| StandardTemplates.TARGET_NEGOTIATION_PROPOSE_URI | Negotiation-T 目标协商意图发起模板 | Negotiation-T/target-negotiation/propose/v1 |
+| StandardTemplates.TARGET_NEGOTIATION_ACCEPT_REJECT_URI | Negotiation-T 目标协商接受/拒绝模板 | Negotiation-T/target-negotiation/accept-reject/v1 |
+| StandardTemplates.FEASIBILITY_NEGOTIATION_PROPOSE_URI | Negotiation-T 可行性协商意图发起模板 | Negotiation-T/feasibility-negotiation/propose/v1 |
+| StandardTemplates.FEASIBILITY_NEGOTIATION_ACCEPT_REJECT_URI | Negotiation-T 可行性协商接受/拒绝模板 | Negotiation-T/feasibility-negotiation/accept-reject/v1 |
+| StandardTemplates.NEGOTIATION_ABORT_URI | Negotiation-T 协商中止通用模板 | Negotiation-T/common/abort/v1 |
+
+- **门面模板 URI 失败策略（`A2ATClient` 与 `A2ATServer` 均适用）：** 门面上所有带 `templateUri` 参数的方法（含 `getPrompt`）均接收原始 URI 字符串。templateUri 为 null 抛 `NullPointerException`；为空白或非法 URI（少于三段，或某一段不是简单段）抛 `IllegalArgumentException`，消息为 `Unparseable template URI: <输入>`。此前服务端任务/通知/授权校验三件套传入 null 类型化模板 URI 时抛 `ContentValidationException`（错误码 `negotiation.invalid_input`）；String 化后这类编程错误统一为标准 JDK 异常，不在 `A2ATError` 树内。
 
 
 ## 1.2 约束和限制
@@ -75,7 +77,7 @@ A2A-T SDK 对外仅提供两个入口：客户端入口 `A2ATClient`（提示词
 
 ```java
 public MetadataContent generateNegotiationProposePromptFromText(
-        String text, NegotiationContext context, TemplateUri templateUri)
+        String text, NegotiationContext context, String templateUri)
 ```
 
 **典型场景**：服务端Agent收到参数不全的Task-T任务报文后，用自然语言向客户端Agent发起"补充缺失信息"的协商请求；也适用于客户端Agent向服务端发起目标澄清或可行性评估请求。
@@ -88,7 +90,7 @@ public MetadataContent generateNegotiationProposePromptFromText(
 | ---- | ---- | ---- | ---- |
 | text | String | 是 | 描述协商发起内容的自然语言文本（如请求补充的缺失信息清单）；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
 | context | NegotiationContext | 是 | 协商会话上下文，不经 LLM 直接注入生成消息的 `negotiationContext` metadata |
-| templateUri | TemplateUri | 是 | propose 模板，如 `StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE` |
+| templateUri | String | 是 | propose 模板，如 `StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI` |
 
 **请求样例**
 
@@ -108,7 +110,7 @@ NegotiationContext ctx = new NegotiationContext(
 MetadataContent propose = client.generateNegotiationProposePromptFromText(
         "请提供以下缺失信息：投诉分类：专线中断或专线质差。两个参数均为必选，缺少无法启动诊断。",
         ctx,
-        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI);
 
 // 生成的metadata随A2A消息传输
 Map<String, Object> metadata = propose.buildMetadataContent();
@@ -148,7 +150,7 @@ Map<String, Object> metadata = propose.buildMetadataContent();
 
 - `negotiation.field_missing`（缺少必填字段）
 
-入参为 null 抛 `NullPointerException`，templateUri 的 phase 段不是 `propose` 抛 `IllegalArgumentException`。
+入参为 null 抛 `NullPointerException`，templateUri 为空白或非法（见 1.1 门面失败策略）、或 phase 段不是 `propose` 抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -169,7 +171,7 @@ promptText  :
 
 ```java
 public MetadataContent generateNegotiationAcceptPromptFromText(
-        String text, NegotiationContext context, TemplateUri templateUri)
+        String text, NegotiationContext context, String templateUri)
 ```
 
 **典型场景**：协商响应方（通常是客户端Agent）收到对端的信息协商请求后，用自然语言补充/交付所请求的信息并生成接受报文回传，如补齐接入端口名称与投诉分类后确认启动诊断。
@@ -182,7 +184,7 @@ public MetadataContent generateNegotiationAcceptPromptFromText(
 | ---- | ---- | ---- | ---- |
 | text | String | 是 | 描述接受内容的自然语言文本（如补充交付的信息清单）；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
 | context | NegotiationContext | 是 | 协商会话上下文 |
-| templateUri | TemplateUri | 是 | accept-reject 模板，如 `StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT` |
+| templateUri | String | 是 | accept-reject 模板，如 `StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI` |
 
 **请求样例**
 
@@ -191,7 +193,7 @@ MetadataContent accept = client.generateNegotiationAcceptPromptFromText(
         "同意补充以下信息：1. 接入端口名称：P533-珠江旧城-PTN3900-23-TPA1EG24-1；"
                 + "2. 投诉分类：专线质差。信息已完整，可以启动诊断。",
         ctx,
-        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **输出说明**
@@ -232,7 +234,7 @@ Accept
 
 ```java
 public MetadataContent generateNegotiationRejectPromptFromText(
-        String text, NegotiationContext context, TemplateUri templateUri)
+        String text, NegotiationContext context, String templateUri)
 ```
 
 **典型场景**：协商响应方（通常是客户端Agent）无法满足对端的协商请求时，用自然语言生成拒绝报文回传并结束本轮协商，如因站点清单不可用无法提供接入端口名称。
@@ -247,7 +249,7 @@ public MetadataContent generateNegotiationRejectPromptFromText(
 MetadataContent reject = client.generateNegotiationRejectPromptFromText(
         "拒绝补充信息：接入端口名称因站点清单不可用而无法提供，本次协商结束。",
         ctx,
-        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **输出说明**
@@ -287,7 +289,7 @@ Reject
 
 ```java
 public MetadataContent generateNegotiationProposePromptFromData(
-        NegotiationProposeData data, TemplateUri templateUri)
+        NegotiationProposeData data, String templateUri)
 ```
 
 **典型场景**：与 fromText 相同的发起场景，但输入为业务系统构造的结构化数据（如服务端Agent根据 `validateTaskPromptAndDataFilling` 检出的缺失槽位清单自动生成协商请求条目），适合对报文内容有确定性要求、不希望引入 LLM 抽取不确定性的场景。
@@ -299,7 +301,7 @@ public MetadataContent generateNegotiationProposePromptFromData(
 | 参数 | 类型 | 必填 | 说明 |
 | ---- | ---- | ---- | ---- |
 | data | `NegotiationProposeData(context, content)` | 是 | 协商上下文 + 类型化发起内容；内容类型按协商类型选择 |
-| templateUri | TemplateUri | 是 | propose 模板 |
+| templateUri | String | 是 | propose 模板 |
 
 三种协商类型的发起内容：
 
@@ -331,7 +333,7 @@ MetadataContent propose = client.generateNegotiationProposePromptFromData(
                                 new NegotiationItem("投诉分类", "举例：专线质差"),
                                 new NegotiationItem("专线业务标识", null)),
                         "OR")),
-        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+        StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI);
 ```
 
 **输出说明**
@@ -344,9 +346,9 @@ MetadataContent propose = client.generateNegotiationProposePromptFromData(
 
 - `negotiation.content_invalid`（类型化内容字段无效，如必填 items 为空、必填描述为空白）
 
-- `negotiation.field_missing`（渲染缺少必填字段）
+- `template.render_failed`（模板渲染失败）
 
-另有两类编程错误（`A2ATError` 树外，标准 JDK 异常）：入参或其 context 为 null 抛 `NullPointerException`；内容类型与模板协商类型不符、phase 段不是 `propose` 抛 `IllegalArgumentException`。
+另有两类编程错误（`A2ATError` 树外，标准 JDK 异常）：入参或其 context 为 null 抛 `NullPointerException`；templateUri 为空白或非法（见 1.1 门面失败策略）、内容类型与模板协商类型不符、phase 段不是 `propose` 抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -370,7 +372,7 @@ promptText  :
 
 ```java
 public MetadataContent generateNegotiationAcceptPromptFromData(
-        NegotiationEndingData data, TemplateUri templateUri)
+        NegotiationEndingData data, String templateUri)
 ```
 
 **典型场景**：协商响应方（通常是客户端Agent）按对端请求的槽位清单程序化补参后，以结构化条目生成接受报文回传。
@@ -382,7 +384,7 @@ public MetadataContent generateNegotiationAcceptPromptFromData(
 | 参数 | 类型 | 必填 | 说明 |
 | ---- | ---- | ---- | ---- |
 | data | `NegotiationEndingData(context, content)` | 是 | 协商上下文 + 类型化接受内容（结论为 `ACCEPT`） |
-| templateUri | TemplateUri | 是 | accept-reject 模板 |
+| templateUri | String | 是 | accept-reject 模板 |
 
 三种协商类型的接受内容：`InformationEndingContent(ACCEPT, items)`（交付的信息项清单）、`TargetEndingContent(ACCEPT, confirmedIntent, null)`（最终确认的意图）、`FeasibilityEndingContent(ACCEPT, feasibilitySummary)`（可行性评估结论摘要）。
 
@@ -401,7 +403,7 @@ MetadataContent accept = client.generateNegotiationAcceptPromptFromData(
                         List.of(
                                 new NegotiationItem("接入端口名称", "P533-珠江旧城-PTN3900-23-TPA1EG24-1"),
                                 new NegotiationItem("投诉分类", "专线质差")))),
-        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **输出说明**
@@ -414,9 +416,9 @@ MetadataContent accept = client.generateNegotiationAcceptPromptFromData(
 
 - `negotiation.content_invalid`（类型化内容字段无效，如必填 items 为空、必填描述为空白）
 
-- `negotiation.field_missing`（渲染缺少必填字段）
+- `template.render_failed`（模板渲染失败）
 
-编程错误：入参或其 context 为 null 抛 `NullPointerException`；内容类型不符或 phase 段不是 `accept-reject` 抛 `IllegalArgumentException`。`conclusion` 不是 `ACCEPT` 以 `negotiation.conclusion_mismatch` 业务错误拒绝。
+编程错误：入参或其 context 为 null 抛 `NullPointerException`；templateUri 为空白或非法（见 1.1 门面失败策略）、内容类型不符或 phase 段不是 `accept-reject` 抛 `IllegalArgumentException`；`conclusion` 不是 `ACCEPT` 以 `negotiation.conclusion_mismatch` 业务错误拒绝。
 
 **响应样例**
 
@@ -438,7 +440,7 @@ Accept
 
 ```java
 public MetadataContent generateNegotiationRejectPromptFromData(
-        NegotiationEndingData data, TemplateUri templateUri)
+        NegotiationEndingData data, String templateUri)
 ```
 
 **典型场景**：协商响应方程序化判定无法满足对端请求后，以结构化条目（无法提供的项及原因）生成拒绝报文回传。
@@ -456,7 +458,7 @@ MetadataContent reject = client.generateNegotiationRejectPromptFromData(
                 new InformationEndingContent(
                         NegotiationConclusion.REJECT,
                         List.of(new NegotiationItem("接入端口名称", "无法提供，工作台侧端口资源台账暂不可查")))),
-        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **输出说明**
@@ -469,9 +471,9 @@ MetadataContent reject = client.generateNegotiationRejectPromptFromData(
 
 - `negotiation.content_invalid`（类型化内容字段无效，如必填 items 为空、必填描述为空白）
 
-- `negotiation.field_missing`（渲染缺少必填字段）
+- `template.render_failed`（模板渲染失败）
 
-编程错误：入参或其 context 为 null 抛 `NullPointerException`；内容类型不符或 phase 段不是 `accept-reject` 抛 `IllegalArgumentException`。`conclusion` 不是 `REJECT` 以 `negotiation.conclusion_mismatch` 业务错误拒绝。
+编程错误：入参或其 context 为 null 抛 `NullPointerException`；templateUri 为空白或非法（见 1.1 门面失败策略）、内容类型不符或 phase 段不是 `accept-reject` 抛 `IllegalArgumentException`；`conclusion` 不是 `REJECT` 以 `negotiation.conclusion_mismatch` 业务错误拒绝。
 
 **响应样例**
 
@@ -492,7 +494,7 @@ Reject
 
 ```java
 public FilledParamData validateProposePromptAndDataFilling(
-        String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, NegotiationContext context, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：发起方（服务端Agent）发送协商请求前的出站自检；或接收方（客户端Agent）校验收到的协商请求并提取需补充的槽位清单，驱动后续补参。
@@ -506,7 +508,7 @@ public FilledParamData validateProposePromptAndDataFilling(
 | prompt | String | 是 | 待校验的协商发起报文文本（`MetadataContent.promptText()`）；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
 | context | NegotiationContext | 是 | 随报文传输的协商上下文；为 null 时报 `negotiation.invalid_input` |
 | schema | Map&lt;String, Object&gt; | 是 | 调用方提供的参数 JSON Schema，声明要提取的参数 |
-| templateUri | TemplateUri | 是 | propose 模板 |
+| templateUri | String | 是 | propose 模板 |
 
 **请求样例**
 
@@ -529,7 +531,7 @@ Map<String, Object> schema = Map.of(
 
 // proposePrompt 为对端发来的协商发起报文文本
 FilledParamData requested = client.validateProposePromptAndDataFilling(
-        proposePrompt, ctx, schema, StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE);
+        proposePrompt, ctx, schema, StandardTemplates.INFORMATION_NEGOTIATION_PROPOSE_URI);
 
 // 过滤掉上下文参数（id/round/maxRounds）后即为需补充的槽位清单
 requested.data().keySet().removeAll(List.of("id", "round", "maxRounds"));
@@ -555,9 +557,7 @@ requested.data().keySet().removeAll(List.of("id", "round", "maxRounds"));
 
 - `negotiation.invalid_input`（报文不是协商消息或 context 为 null）
 
-- `negotiation.invalid_context_id`（context 的 id 不是合法 UUID）
-
-- `negotiation.round_exceeded`（context 轮次超过配置上限）
+- `negotiation.rule_violation`（协商上下文违反规则；`getErrors()` 中的嵌套槽位错误码标识具体规则，如 `negotiation.invalid_context_id`、`negotiation.round_exceeded`）
 
 - `negotiation.semantic_rejected`（语义校验拒绝；`getErrors()` 中的逐槽位明细使用封闭的 `negotiation.*` 码集，如 `negotiation.conclusion_content_mismatch`、`negotiation.missing_result_content`、`negotiation.field_inconsistency`）
 
@@ -565,7 +565,7 @@ requested.data().keySet().removeAll(List.of("id", "round", "maxRounds"));
 
 - `template.not_found`（校验提示词资源缺失）
 
-编程错误：prompt 或 schema 为 null 抛 `NullPointerException`，prompt 为空白或 phase 段不匹配抛 `IllegalArgumentException`。
+编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白、templateUri 为空白或非法（见 1.1 门面失败策略）、phase 段不匹配抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -586,7 +586,7 @@ requested.data() =
 
 ```java
 public FilledParamData validateAcceptPromptAndDataFilling(
-        String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, NegotiationContext context, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：发起方（服务端Agent）校验对端回传的接受报文，提取交付的参数值并与期望补齐值核对，确认无误后继续任务执行。
@@ -604,7 +604,7 @@ A2ATServer server = new A2ATServer(Path.of("server.env"));
 
 // acceptPrompt 为客户端回传的接受报文文本，acceptContext 为其协商上下文
 FilledParamData acceptParams = server.validateAcceptPromptAndDataFilling(
-        acceptPrompt, acceptContext, schema, StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        acceptPrompt, acceptContext, schema, StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **输出说明**
@@ -615,7 +615,7 @@ FilledParamData acceptParams = server.validateAcceptPromptAndDataFilling(
 
 - `negotiation.invalid_input`（报文不是 accept 协商消息或 context 为 null）
 
-- `negotiation.invalid_context_id` / `negotiation.round_exceeded`（协商上下文违反结构规则）
+- `negotiation.rule_violation`（协商上下文违反规则；`getErrors()` 中的嵌套槽位错误码标识具体规则，如 `negotiation.invalid_context_id`、`negotiation.round_exceeded`）
 
 - `negotiation.semantic_rejected`（结论不是 Accept 或内容不满足 accept 阶段约束）
 
@@ -623,7 +623,7 @@ FilledParamData acceptParams = server.validateAcceptPromptAndDataFilling(
 
 - `template.not_found`（校验提示词资源缺失）
 
-编程错误：prompt 或 schema 为 null 抛 `NullPointerException`，prompt 为空白或 phase 段不是 `accept-reject` 抛 `IllegalArgumentException`。
+编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白、templateUri 为空白或非法（见 1.1 门面失败策略）、phase 段不是 `accept-reject` 抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -644,7 +644,7 @@ acceptParams.data() =
 
 ```java
 public FilledParamData validateRejectPromptAndDataFilling(
-        String prompt, NegotiationContext context, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, NegotiationContext context, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：发起方（服务端Agent）校验对端回传的拒绝报文，提取拒绝原因，据此终止任务或转入人工处理。
@@ -657,7 +657,7 @@ public FilledParamData validateRejectPromptAndDataFilling(
 
 ```java
 FilledParamData rejectParams = server.validateRejectPromptAndDataFilling(
-        rejectPrompt, ctx, schema, StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT);
+        rejectPrompt, ctx, schema, StandardTemplates.INFORMATION_NEGOTIATION_ACCEPT_REJECT_URI);
 ```
 
 **输出说明**
@@ -668,7 +668,7 @@ FilledParamData rejectParams = server.validateRejectPromptAndDataFilling(
 
 - `negotiation.invalid_input`（报文不是 reject 协商消息或 context 为 null）
 
-- `negotiation.invalid_context_id` / `negotiation.round_exceeded`（协商上下文违反结构规则）
+- `negotiation.rule_violation`（协商上下文违反规则；`getErrors()` 中的嵌套槽位错误码标识具体规则，如 `negotiation.invalid_context_id`、`negotiation.round_exceeded`）
 
 - `negotiation.semantic_rejected`（结论不是 Reject 或内容不满足 reject 阶段约束）
 
@@ -676,7 +676,7 @@ FilledParamData rejectParams = server.validateRejectPromptAndDataFilling(
 
 - `template.not_found`（校验提示词资源缺失）
 
-编程错误：prompt 或 schema 为 null 抛 `NullPointerException`，prompt 为空白或 phase 段不是 `accept-reject` 抛 `IllegalArgumentException`。
+编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白、templateUri 为空白或非法（见 1.1 门面失败策略）、phase 段不是 `accept-reject` 抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -695,7 +695,7 @@ rejectParams.data() =
 **API定义**
 
 ```java
-public MetadataContent generateTaskPromptFromText(String text, TemplateUri templateUri)
+public MetadataContent generateTaskPromptFromText(String text, String templateUri)
 ```
 
 **典型场景**：客户端Agent将用户的自然语言任务描述（如专线投诉诊断诉求）转换为指定场景的Task-T协议报文，适合已确定目标模板、需跳过场景识别的场景。
@@ -707,7 +707,7 @@ public MetadataContent generateTaskPromptFromText(String text, TemplateUri templ
 | 参数 | 类型 | 必填 | 说明 |
 | ---- | ---- | ---- | ---- |
 | text | String | 是 | 自然语言任务描述；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
-| templateUri | TemplateUri | 是 | Task-T 模板，如 `StandardTemplates.PRIVATE_LINE_COMPLAINT`（`Task-T/network-layer/private-line-complaint/v1`） |
+| templateUri | String | 是 | Task-T 模板，如 `StandardTemplates.PRIVATE_LINE_COMPLAINT_URI`（`Task-T/network-layer/private-line-complaint/v1`） |
 
 **请求样例**
 
@@ -723,7 +723,7 @@ MetadataContent metadata = client.generateTaskPromptFromText(
         "帮我创建专线投诉诊断任务，P781-珠江新城-PTN7900-23-TPA1EG24-17 这个端口，"
                 + "客户报的是专线质差，从2026年5月11号早上8点半开始，深圳访问广州的核心系统非常慢，"
                 + "时延从12ms飙到320ms，柜面和手机银行老是报连接超时，OSS流水号是event-id-20260511-09013。",
-        StandardTemplates.PRIVATE_LINE_COMPLAINT);
+        StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
 ```
 
 **输出说明**
@@ -766,7 +766,7 @@ MetadataContent metadata = client.generateTaskPromptFromText(
 
 - `input.text_too_long`（输入超过 `A2AT_INPUT_TEXT_MAX_CHARS`）
 
-编程错误：text 或 templateUri 为 null 抛 `NullPointerException`。
+编程错误：text 或 templateUri 为 null 抛 `NullPointerException`；templateUri 为空白或非法（见 1.1 门面失败策略）抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -806,7 +806,7 @@ promptText  :
 
 ```java
 public MetadataContent generateTaskPromptFromDataWithSchema(
-        Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+        Map<String, Object> data, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：客户端Agent将上游系统的结构化任务参数（字段名可与模板槽位不同，由Schema描述字段语义）转换为Task-T协议报文，适合任务参数已结构化持有的场景。
@@ -819,7 +819,7 @@ public MetadataContent generateTaskPromptFromDataWithSchema(
 | ---- | ---- | ---- | ---- |
 | data | Map&lt;String, Object&gt; | 是 | 结构化业务字段输入，key 为业务字段名，value 为字段值 |
 | schema | Map&lt;String, Object&gt; | 是（非空） | 字段语义 JSON Schema，描述各字段含义与约束 |
-| templateUri | TemplateUri | 是 | Task-T 模板 |
+| templateUri | String | 是 | Task-T 模板 |
 
 **请求样例**
 
@@ -849,14 +849,14 @@ Map<String, Object> semanticsSchema = Map.of(
         "required", List.of("portName", "complaintScenario"));
 
 MetadataContent metadata = client.generateTaskPromptFromDataWithSchema(
-        data, semanticsSchema, StandardTemplates.PRIVATE_LINE_COMPLAINT);
+        data, semanticsSchema, StandardTemplates.PRIVATE_LINE_COMPLAINT_URI);
 ```
 
 **输出说明**
 
 成功时返回 `MetadataContent`（结构同 [1.3.10](#1310-generatetaskpromptfromtext)）。
 
-失败时抛 `PromptGenerationException`（结构同 1.3.10）。编程错误：入参为 null 抛 `NullPointerException`，schema 为空 Map 抛 `IllegalArgumentException`。
+失败时抛 `PromptGenerationException`（结构同 1.3.10）。编程错误：入参为 null 抛 `NullPointerException`，templateUri 为空白或非法（见 1.1 门面失败策略）或 schema 为空 Map 抛 `IllegalArgumentException`。
 
 **响应样例**（与 1.3.10 同模板，槽位值来自结构化输入，`faultDetail` 为示例截断值）
 
@@ -896,7 +896,7 @@ promptText  :
 
 ```java
 public FilledParamData validateTaskPromptAndDataFilling(
-        String prompt, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：服务端Agent收到Task-T报文后、进入业务执行前的参数校验与提取入口；也是协商流程中"缺槽检测"的判定点——required参数缺失时由调用方决定是否发起协商补参。
@@ -909,7 +909,7 @@ public FilledParamData validateTaskPromptAndDataFilling(
 | ---- | ---- | ---- | ---- |
 | prompt | String | 是（非空） | 待校验的任务提示词报文文本（`MetadataContent.promptText()`）；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
 | schema | Map&lt;String, Object&gt; | 是 | 调用方提供的参数 JSON Schema，声明要提取/校验的参数及 required 约束 |
-| templateUri | TemplateUri | 是 | Task-T 模板（前缀段必须为 `Task-T`） |
+| templateUri | String | 是 | Task-T 模板（前缀段必须为 `Task-T`） |
 
 **请求样例**
 
@@ -936,7 +936,7 @@ Map<String, Object> validationSchema = Map.of(
 
 Map<String, Object> extracted = server
         .validateTaskPromptAndDataFilling(
-                metadata.promptText(), validationSchema, StandardTemplates.PRIVATE_LINE_COMPLAINT)
+                metadata.promptText(), validationSchema, StandardTemplates.PRIVATE_LINE_COMPLAINT_URI)
         .data();
 ```
 
@@ -967,7 +967,7 @@ Map<String, Object> extracted = server
 
 - `input.text_too_long`（提示词超过 `A2AT_INPUT_TEXT_MAX_CHARS`）
 
-编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白抛 `IllegalArgumentException`。
+编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白或 templateUri 为空白/非法（见 1.1 门面失败策略）抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -994,7 +994,7 @@ ContentValidationException: [negotiation.semantic_rejected] ...
 **API定义**
 
 ```java
-public MetadataContent generateNotificationPromptFromText(String text, TemplateUri templateUri)
+public MetadataContent generateNotificationPromptFromText(String text, String templateUri)
 ```
 
 **典型场景**：客户端Agent将自然语言订阅需求（如业务抢通事件订阅）转换为指定场景的Notification-T订阅报文。
@@ -1006,7 +1006,7 @@ public MetadataContent generateNotificationPromptFromText(String text, TemplateU
 | 参数 | 类型 | 必填 | 说明 |
 | ---- | ---- | ---- | ---- |
 | text | String | 是 | 自然语言订阅描述（通知主题、订阅条件、上报通知数据格式等）；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
-| templateUri | TemplateUri | 是 | Notification-T 模板，如 `StandardTemplates.SUBSCRIBE_INCIDENT`、`StandardTemplates.SERVICE_RECOVERY` |
+| templateUri | String | 是 | Notification-T 模板，如 `StandardTemplates.SUBSCRIBE_INCIDENT_URI`、`StandardTemplates.SERVICE_RECOVERY_URI` |
 
 **请求样例**
 
@@ -1015,10 +1015,9 @@ import java.nio.file.Path;
 import net.openan.a2at.sdk.client.A2ATClient;
 import net.openan.a2at.sdk.core.model.MetadataContent;
 import net.openan.a2at.sdk.core.model.StandardTemplates;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
 A2ATClient client = new A2ATClient(Path.of("client.env"));
-TemplateUri templateUri = TemplateUri.parse("Notification-T/network-layer/service-recovery/v1").orElseThrow();
+String templateUri = StandardTemplates.SERVICE_RECOVERY_URI;
 
 MetadataContent result = client.generateNotificationPromptFromText(
         "我想订阅一下业务抢通事件。上报通知数据格式如下："
@@ -1032,7 +1031,7 @@ MetadataContent result = client.generateNotificationPromptFromText(
 
 成功时返回 `MetadataContent`（结构同 [1.3.10](#1310-generatetaskpromptfromtext)，`extensionUri` 为 `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1`）。
 
-失败时抛 `PromptGenerationException`（结构同 1.3.10）。编程错误：text 或 templateUri 为 null 抛 `NullPointerException`。
+失败时抛 `PromptGenerationException`（结构同 1.3.10）。编程错误：text 或 templateUri 为 null 抛 `NullPointerException`；templateUri 为空白或非法（见 1.1 门面失败策略）抛 `IllegalArgumentException`。
 
 **响应样例**（按模板渲染，实际文本随 LLM 槽位提取结果变化；本例输入未指定订阅条件，对应槽位留空）
 
@@ -1071,7 +1070,7 @@ promptText  :
 
 ```java
 public MetadataContent generateNotificationPromptFromDataWithSchema(
-        Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+        Map<String, Object> data, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：客户端Agent将上游系统/界面提交的结构化订阅参数转换为Notification-T订阅报文，适合订阅参数已结构化持有的场景。
@@ -1084,7 +1083,7 @@ public MetadataContent generateNotificationPromptFromDataWithSchema(
 | ---- | ---- | ---- | ---- |
 | data | Map&lt;String, Object&gt; | 是 | 结构化订阅输入（如订阅条件、上报数据格式字段列表） |
 | schema | Map&lt;String, Object&gt; | 是（非空） | 字段语义 JSON Schema |
-| templateUri | TemplateUri | 是 | Notification-T 模板 |
+| templateUri | String | 是 | Notification-T 模板 |
 
 **请求样例**
 
@@ -1125,7 +1124,7 @@ MetadataContent result = client.generateNotificationPromptFromDataWithSchema(
 
 成功时返回 `MetadataContent`（结构同 [1.3.10](#1310-generatetaskpromptfromtext)，`extensionUri` 为 `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1`）。
 
-失败时抛 `PromptGenerationException`（结构同 1.3.10）。编程错误：入参为 null 抛 `NullPointerException`，schema 为空 Map 抛 `IllegalArgumentException`。
+失败时抛 `PromptGenerationException`（结构同 1.3.10）。编程错误：入参为 null 抛 `NullPointerException`，templateUri 为空白或非法（见 1.1 门面失败策略）或 schema 为空 Map 抛 `IllegalArgumentException`。
 
 **响应样例**（与 1.3.13 同模板，槽位值来自结构化输入：`订阅条件` 填充 `condition`，`上报通知数据格式` 按 `reportFormat` 列表渲染，字段排列样式示意）
 
@@ -1165,7 +1164,7 @@ promptText  :
 
 ```java
 public FilledParamData validateNotificationPromptAndDataFilling(
-        String prompt, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：服务端Agent收到Notification-T订阅报文后校验合规性并提取订阅参数（主题/条件/上报格式），据此建立订阅关系。
@@ -1178,7 +1177,7 @@ public FilledParamData validateNotificationPromptAndDataFilling(
 | ---- | ---- | ---- | ---- |
 | prompt | String | 是（非空） | 待校验的通知订阅提示词报文文本；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
 | schema | Map&lt;String, Object&gt; | 是 | 调用方提供的参数 JSON Schema |
-| templateUri | TemplateUri | 是 | Notification-T 模板（前缀段必须为 `Notification-T`） |
+| templateUri | String | 是 | Notification-T 模板（前缀段必须为 `Notification-T`） |
 
 **请求样例**
 
@@ -1216,7 +1215,7 @@ FilledParamData result = server.validateNotificationPromptAndDataFilling(
 
 - `input.text_too_long`（提示词超过 `A2AT_INPUT_TEXT_MAX_CHARS`）
 
-编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白抛 `IllegalArgumentException`。
+编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白或 templateUri 为空白/非法（见 1.1 门面失败策略）抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -1234,7 +1233,7 @@ result.data() =
 **API定义**
 
 ```java
-public MetadataContent generateAuthPromptFromText(String text, TemplateUri templateUri)
+public MetadataContent generateAuthPromptFromText(String text, String templateUri)
 ```
 
 **典型场景**：客户端Agent将自然语言授权诉求（新增/修改/删除/查询动网操作授权策略）转换为Authorization-T报文。
@@ -1246,7 +1245,7 @@ public MetadataContent generateAuthPromptFromText(String text, TemplateUri templ
 | 参数 | 类型 | 必填 | 说明 |
 | ---- | ---- | ---- | ---- |
 | text | String | 是 | 自然语言授权描述（操作类型 + 动网操作的授权策略内容）；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
-| templateUri | TemplateUri | 是 | Authorization-T 模板：`StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT`（`Authorization-T/authorization-policy-management/v1`） |
+| templateUri | String | 是 | Authorization-T 模板：`StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI`（`Authorization-T/authorization-policy-management/v1`） |
 
 **请求样例**
 
@@ -1260,14 +1259,14 @@ A2ATClient client = new A2ATClient(Path.of("client.env"));
 
 MetadataContent result = client.generateAuthPromptFromText(
         "加个校园专网的授权，处置用业务抢通，做个隧道调优，有效期先不填后面补",
-        StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT);
+        StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
 ```
 
 **输出说明**
 
 成功时返回 `MetadataContent`（结构同 [1.3.10](#1310-generatetaskpromptfromtext)，`extensionUri` 为 `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Authorization-T/v1`）。
 
-失败时抛 `PromptGenerationException`（结构同 1.3.10），如操作类型不在"新增/修改/删除/查询授权策略"范围内时以 `slot.constraint_violated` 拒绝。编程错误：text 或 templateUri 为 null 抛 `NullPointerException`。
+失败时抛 `PromptGenerationException`（结构同 1.3.10），如操作类型不在"新增/修改/删除/查询授权策略"范围内时以 `slot.constraint_violated` 拒绝。编程错误：text 或 templateUri 为 null 抛 `NullPointerException`；templateUri 为空白或非法（见 1.1 门面失败策略）抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -1296,7 +1295,7 @@ promptText  :
 
 ```java
 public MetadataContent generateAuthPromptFromDataWithSchema(
-        Map<String, Object> data, Map<String, Object> schema, TemplateUri templateUri)
+        Map<String, Object> data, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：客户端Agent将授权管理界面/系统按字段提交的结构化授权策略数据转换为Authorization-T报文。
@@ -1309,7 +1308,7 @@ public MetadataContent generateAuthPromptFromDataWithSchema(
 | ---- | ---- | ---- | ---- |
 | data | Map&lt;String, Object&gt; | 是 | 结构化授权输入（操作类型、策略数量、策略详情列表等） |
 | schema | Map&lt;String, Object&gt; | 是（非空） | 字段语义 JSON Schema |
-| templateUri | TemplateUri | 是 | Authorization-T 模板 |
+| templateUri | String | 是 | Authorization-T 模板 |
 
 **请求样例**
 
@@ -1345,14 +1344,14 @@ Map<String, Object> schema = Map.of(
                                         "有效期", Map.of("type", "string"))))));
 
 MetadataContent result = client.generateAuthPromptFromDataWithSchema(
-        data, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT);
+        data, schema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
 ```
 
 **输出说明**
 
 成功时返回 `MetadataContent`（结构同 [1.3.10](#1310-generatetaskpromptfromtext)，`extensionUri` 为 `https://projects.tmforum.org/a2aproject/telecommunication/extensions/Authorization-T/v1`）。
 
-失败时抛 `PromptGenerationException`（结构同 1.3.10）。编程错误：入参为 null 抛 `NullPointerException`，schema 为空 Map 抛 `IllegalArgumentException`。
+失败时抛 `PromptGenerationException`（结构同 1.3.10）。编程错误：入参为 null 抛 `NullPointerException`，templateUri 为空白或非法（见 1.1 门面失败策略）或 schema 为空 Map 抛 `IllegalArgumentException`。
 
 **响应样例**
 
@@ -1381,7 +1380,7 @@ promptText  :
 
 ```java
 public FilledParamData validateAuthPromptAndDataFilling(
-        String prompt, Map<String, Object> schema, TemplateUri templateUri)
+        String prompt, Map<String, Object> schema, String templateUri)
 ```
 
 **典型场景**：服务端Agent收到Authorization-T报文后校验合规性并提取操作类型与策略列表，据此执行授权策略管理动作。
@@ -1394,7 +1393,7 @@ public FilledParamData validateAuthPromptAndDataFilling(
 | ---- | ---- | ---- | ---- |
 | prompt | String | 是（非空） | 待校验的授权提示词报文文本；输入长度受配置项 `A2AT_INPUT_TEXT_MAX_CHARS` 限制，默认值为 16384 |
 | schema | Map&lt;String, Object&gt; | 是 | 调用方提供的参数 JSON Schema（含 `操作类型`、`策略列表` 等） |
-| templateUri | TemplateUri | 是 | Authorization-T 模板（前缀段必须为 `Authorization-T`） |
+| templateUri | String | 是 | Authorization-T 模板（前缀段必须为 `Authorization-T`） |
 
 **请求样例**
 
@@ -1409,7 +1408,7 @@ Map<String, Object> paramSchema = MAPPER.readValue(
 //（数组，条目含 策略标识/业务场景/处置类型/操作名称/有效期）
 
 FilledParamData result = server.validateAuthPromptAndDataFilling(
-        metadata.promptText(), paramSchema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT);
+        metadata.promptText(), paramSchema, StandardTemplates.AUTHORIZATION_POLICY_MANAGEMENT_URI);
 ```
 
 **输出说明**
@@ -1426,7 +1425,7 @@ FilledParamData result = server.validateAuthPromptAndDataFilling(
 
 - `input.text_too_long`（提示词超过 `A2AT_INPUT_TEXT_MAX_CHARS`）
 
-编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白抛 `IllegalArgumentException`。
+编程错误：prompt / schema / templateUri 为 null 抛 `NullPointerException`，prompt 为空白或 templateUri 为空白/非法（见 1.1 门面失败策略）抛 `IllegalArgumentException`。
 
 **响应样例**
 

--- a/docs/zh/开发指南.md
+++ b/docs/zh/开发指南.md
@@ -1652,15 +1652,14 @@ templateUri：<extensionName>/<pathSegments>/<templateVersion>
 
 ```java
 import net.openan.a2at.sdk.core.model.MetadataContent;
-import net.openan.a2at.sdk.core.model.TemplateUri;
 
-// 构造方式：解析原始 URI 字符串
-TemplateUri templateUri = TemplateUri.parse("Task-T/network-layer/site-inspection/v1").orElseThrow();
-
-MetadataContent metadata = client.generateTaskPromptFromText("请对xx基站开展现场巡检，重点检查告警和性能指标", templateUri);
+// 门面直接接收原始 URI 字符串
+MetadataContent metadata = client.generateTaskPromptFromText("请对xx基站开展现场巡检，重点检查告警和性能指标", "Task-T/network-layer/site-inspection/v1");
 ```
 
-如需覆盖内置模板（如 `StandardTemplates.PRIVATE_LINE_COMPLAINT`），在本地根目录下按相同相对路径放置 `template.md` 与 `slot.json`，代码中继续使用原有常量即可。注意 `local_file` 模式下业务模板只从本地根目录读取、不回退 classpath，`templateUri` 对应的文件缺失时接口抛出 `PromptGenerationException`，错误码为 `template.not_found`。
+门面对 `templateUri` 的失败策略：为 null 抛 `NullPointerException`；为空白或非法 URI（少于三段，或某一段不是简单段）抛 `IllegalArgumentException`，消息为 `Unparseable template URI: <输入>`。
+
+如需覆盖内置模板（如 `StandardTemplates.PRIVATE_LINE_COMPLAINT_URI`），在本地根目录下按相同相对路径放置 `template.md` 与 `slot.json`，代码中继续使用原有常量即可。注意 `local_file` 模式下业务模板只从本地根目录读取、不回退 classpath，`templateUri` 对应的文件缺失时接口抛出 `PromptGenerationException`，错误码为 `template.not_found`。
 
 #### Step4 验证与排障
 


### PR DESCRIPTION
## Description


The public facades `A2ATClient` (19 methods) and `A2ATServer` (16 methods) no longer expose the
`TemplateUri` model as an input parameter: every `templateUri` parameter is now a plain `String`
(e.g. `Task-T/network-layer/ran-energy-saving/v1`). `PromptTemplate` keeps its typed
`TemplateUri` field unchanged, and all internal seams (`NegotiationContentService`,
`NegotiationGenerationOrchestrator`, `ClientPromptGenerationOrchestrator`, `ContentValidator`
SPI, `TemplateQueryService`) deliberately stay typed — the facade parses the string once at the
boundary and delegates the always-valid typed value.

Failure policy (uniform on both facades, including `getPrompt`):
- `null` template URI -> `NullPointerException`
- blank or malformed URI (fewer than three segments or a non-simple segment) ->
  `IllegalArgumentException("Unparseable template URI: <input>")`
- Note: on the server `validateTask/Notification/AuthPromptAndDataFilling` trio, a null URI
  previously threw `ContentValidationException(negotiation.invalid_input)`; it now fails fast
  with a plain NPE at the facade, outside the A2ATError tree (tests re-baselined).

`StandardTemplates` now publishes a parallel `String`-constant set: every typed constant `X` has
an `X_URI` twin (e.g. `ENERGY_SAVING_URI`), plus family list twins `TASK_URIS` /
`NOTIFICATION_URIS` / `AUTHORIZATION_URIS` / `NEGOTIATION_URIS`. A lockstep consistency test
pins the two spellings together.

### Commits

1. `feat(core)` — StandardTemplates string twins + consistency test; fixed the phantom code name
   `validation_invalid_input` -> `negotiation.invalid_input` in `ContentValidator` javadoc.
2. `feat(client)` — all 19 `A2ATClient` methods take `String templateUri`; negative tests for
   null/blank/malformed URIs; call sites migrated to `X_URI` twins.
3. `feat(server)` — all 16 `A2ATServer` methods converted; the three phantom `@param context`
   javadoc entries on `validateTaskPromptAndDataFilling` /
   `validateNotificationPromptAndDataFilling` / `validateAuthPromptAndDataFilling` deleted;
   null-URI expectations re-baselined; negative tests added.
4. `docs(api)` — truth-repair of the facade javadocs (all fixes verified against actual throw
   sites): `field_missing` -> `template.render_failed` on render failures, conclusion mismatch
   documented as `negotiation.conclusion_mismatch` (was wrongly `IllegalArgumentException` /
   `invalid_input`), blank abort reason as `negotiation.content_invalid`, "phase segment" ->
   "performative segment", top-level rule-gate code unified to `negotiation.rule_violation`
   (nested slot codes noted), client facade gained the missing `llm.response_invalid` /
   `input.text_too_long` codes, `@NonNull` added to the fromText context parameters (validate*
   context stays `@Nullable` — null is a supported input).
5. `feat(sample)` — sample mains/tests migrated to string URIs; 8 now-redundant parse helpers
   deleted (2 kept where they feed typed internal seams); the reflection contract test
   `NegotiationV3ApiSurfaceTest` rewritten as `allFacadeTemplateUriParamsAreStrings`, pinning
   `String.class` on every `templateUri` parameter of both facades (~35 methods).
6. `docs` — bilingual API reference + developer guides (en/zh) updated: `String templateUri`
   signatures, `X_URI` examples, and the facade failure policy documented once in the shared
   conventions section.

### Out of scope (deliberate follow-ups)

- `NegotiationContentService` and other internal seams remain typed by design.
- `MetadataContent.templateUri` is already a `@Nullable String` (wire format); no change.
- `NegotiationReference` keeps its intentional typed + String twin entry points.
- `TemplateQueryService` / `PromptTemplateCatalog` / `InputLimitedContentValidator` stay typed
  as internal/advanced seams.
- a2a-t-corpus needed zero changes (verified: it drives internal typed seams only).

### Verification

- `mvn -B clean verify` (full reactor, CI-equivalent): **BUILD SUCCESS**, 11 modules,
  3056 tests, 0 failures, 0 errors, 50 skipped (all `A2AT_LLM_API_KEY` / live-LLM env gates).
- `python tools/template_lint.py --resource-root a2a-t-resources/src/main/resources/prompt_resources`:
  passed.

### Breaking change note

Every public facade method signature on `A2ATClient` / `A2ATServer` changed in this release.
This is intentional while the SDK is pre-release; callers passing typed constants switch to the
`StandardTemplates.X_URI` twins, and callers that parsed strings into `TemplateUri` just to pass
them to a facade now pass the string directly.


## Related Issue(s)

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here. -->
